### PR TITLE
Record buildings-index binary presence in map integrity

### DIFF
--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -36,6 +36,7 @@ import {
   resolveExpectedCustomReleaseManifestAssetName,
   versionedFingerprint,
   withReleaseSizeIfMissing,
+  withBuildingsIndexPresenceIfMissing,
 } from "./downloads-full/integrity-completeness.js";
 import {
   getSecurityFingerprintPart,
@@ -412,9 +413,11 @@ export async function generateDownloadsDataFull(
               : undefined
           );
           const representativeAsset = matchedAsset ?? (zipAssets.length === 1 ? zipAssets[0][1] : undefined);
-          const result = withReleaseSizeIfMissing(
-            cached.result,
-            releaseSizeFromBytes(representativeAsset?.sizeBytes),
+          const result = withBuildingsIndexPresenceIfMissing(
+            withReleaseSizeIfMissing(
+              cached.result,
+              releaseSizeFromBytes(representativeAsset?.sizeBytes),
+            ),
           );
           versionEntries[tag] = result;
           nextListingCacheEntries[tag] = {
@@ -621,7 +624,9 @@ export async function generateDownloadsDataFull(
               )
               : undefined
           );
-          const result = withReleaseSizeIfMissing(cached.result, sizeFromMetadata);
+          const result = withBuildingsIndexPresenceIfMissing(
+            withReleaseSizeIfMissing(cached.result, sizeFromMetadata),
+          );
           versionEntries[versionKey] = result;
           nextListingCacheEntries[versionKey] = {
             ...cached,

--- a/scripts/lib/downloads-full/integrity-completeness.ts
+++ b/scripts/lib/downloads-full/integrity-completeness.ts
@@ -116,6 +116,29 @@ export function withReleaseSizeIfMissing(
   };
 }
 
+// Backfills the buildings-index presence keys onto a reused cache entry without
+// re-inspecting the zip. Entries written before the buildings_index_json/_bin split
+// only carry the combined buildings_index match; no release ships the binary twin yet,
+// so the binary is known-absent and the recorded buildings_index match is the JSON form.
+// This keeps the report homogeneous (every map entry has both keys) without a rules-version
+// bump that would force a full re-download. No-op for entries that already have the keys
+// (fresh inspections set them) and for non-map entries (no buildings_index key).
+export function withBuildingsIndexPresenceIfMissing(
+  result: IntegrityVersionEntry,
+): IntegrityVersionEntry {
+  const matched = result.matched_files;
+  if (!matched || !("buildings_index" in matched)) return result;
+  if ("buildings_index_json" in matched && "buildings_index_bin" in matched) return result;
+  return {
+    ...result,
+    matched_files: {
+      ...matched,
+      buildings_index_json: matched.buildings_index_json ?? matched.buildings_index ?? null,
+      buildings_index_bin: matched.buildings_index_bin ?? null,
+    },
+  };
+}
+
 export function resolveExpectedCustomReleaseManifestAssetName(
   candidate: CustomVersionCandidate,
   warnings: string[],

--- a/scripts/lib/integrity.ts
+++ b/scripts/lib/integrity.ts
@@ -446,11 +446,22 @@ async function inspectMapZip(
     }
   }
 
-  const buildingsIndex = firstMatch(files, ["buildings_index.json", "buildings_index.json.gz"]);
-  requiredChecks.buildings_index = buildingsIndex !== null;
-  matchedFiles.buildings_index = buildingsIndex;
-  if (!buildingsIndex) {
-    errors.push("missing top-level buildings_index.json or buildings_index.json.gz");
+  // Buildings index ships as JSON and/or a packed binary twin (buildings_index.bin.gz).
+  // The sim reads JSON on builds <=1.3.0 and the binary on newer builds, so a release is
+  // complete as long as it carries at least one form. Both presences are recorded
+  // separately so a version's allowable game-version range can later be composed from
+  // which form(s) are present. No release carries the .bin yet, so buildings_index_bin
+  // is null across the board today.
+  const buildingsJson = firstMatch(files, ["buildings_index.json", "buildings_index.json.gz"]);
+  const buildingsBin = firstMatch(files, ["buildings_index.bin", "buildings_index.bin.gz"]);
+  requiredChecks.buildings_index = buildingsJson !== null || buildingsBin !== null;
+  matchedFiles.buildings_index = buildingsJson ?? buildingsBin;
+  matchedFiles.buildings_index_json = buildingsJson;
+  matchedFiles.buildings_index_bin = buildingsBin;
+  if (!buildingsJson && !buildingsBin) {
+    errors.push(
+      "missing top-level buildings index (need buildings_index.json/.json.gz or buildings_index.bin/.bin.gz)",
+    );
   }
 
   const roads = firstMatch(files, ["roads.geojson", "roads.geojson.gz"]);

--- a/scripts/tests/integrity.unit.test.ts
+++ b/scripts/tests/integrity.unit.test.ts
@@ -2,7 +2,21 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import JSZip from "jszip";
 import { inspectZipCompleteness, parseManifestGameDependency } from "../lib/integrity.js";
+import type { IntegrityVersionEntry } from "../lib/integrity.js";
 import type { CompiledSecurityRule } from "../lib/mod-security.js";
+import { withBuildingsIndexPresenceIfMissing } from "../lib/downloads-full/integrity-completeness.js";
+
+function makeCachedEntry(matchedFiles: Record<string, string | null>): IntegrityVersionEntry {
+  return {
+    is_complete: true,
+    errors: [],
+    required_checks: { buildings_index: true },
+    matched_files: matchedFiles,
+    source: { update_type: "github", repo: "owner/repo", tag: "v1.0.0" },
+    fingerprint: "rules:v6:github:owner/repo:v1.0.0",
+    checked_at: "2026-01-01T00:00:00Z",
+  };
+}
 
 test("parseManifestGameDependency extracts game_version and other deps", () => {
   const result = parseManifestGameDependency(
@@ -72,9 +86,67 @@ test("map integrity requires exact top-level files including city pmtiles", asyn
   assert.equal(result.requiredChecks.roads_geojson, true);
   assert.equal(result.requiredChecks.runways_taxiways_geojson, true);
   assert.equal(result.requiredChecks.city_pmtiles, true);
+  // JSON-only buildings index: json form recorded, binary twin absent.
+  assert.equal(result.matchedFiles.buildings_index, "buildings_index.json");
+  assert.equal(result.matchedFiles.buildings_index_json, "buildings_index.json");
+  assert.equal(result.matchedFiles.buildings_index_bin, null);
   assert.ok(result.fileSizes);
   assert.equal(typeof result.fileSizes?.["config.json"], "number");
   assert.equal(typeof result.fileSizes?.["ABC.pmtiles"], "number");
+});
+
+test("map integrity accepts a binary-only buildings index", async () => {
+  const zipBuffer = await makeZip({
+    "config.json": "{\"code\":\"ABC\"}",
+    "demand_data.json": "{}",
+    "buildings_index.bin.gz": "stub",
+    "roads.geojson": "{}",
+    "runways_taxiways.geojson": "{}",
+    "ABC.pmtiles": "stub",
+  });
+
+  const result = await inspectZipCompleteness("map", zipBuffer, { cityCode: "ABC" });
+  assert.equal(result.isComplete, true);
+  assert.equal(result.requiredChecks.buildings_index, true);
+  assert.equal(result.matchedFiles.buildings_index, "buildings_index.bin.gz");
+  assert.equal(result.matchedFiles.buildings_index_json, null);
+  assert.equal(result.matchedFiles.buildings_index_bin, "buildings_index.bin.gz");
+});
+
+test("map integrity records both buildings index forms when present", async () => {
+  const zipBuffer = await makeZip({
+    "config.json": "{\"code\":\"ABC\"}",
+    "demand_data.json": "{}",
+    "buildings_index.json": "{}",
+    "buildings_index.bin.gz": "stub",
+    "roads.geojson": "{}",
+    "runways_taxiways.geojson": "{}",
+    "ABC.pmtiles": "stub",
+  });
+
+  const result = await inspectZipCompleteness("map", zipBuffer, { cityCode: "ABC" });
+  assert.equal(result.isComplete, true);
+  assert.equal(result.requiredChecks.buildings_index, true);
+  // Combined key prefers the JSON form; both presences recorded separately.
+  assert.equal(result.matchedFiles.buildings_index, "buildings_index.json");
+  assert.equal(result.matchedFiles.buildings_index_json, "buildings_index.json");
+  assert.equal(result.matchedFiles.buildings_index_bin, "buildings_index.bin.gz");
+});
+
+test("map integrity fails when neither buildings index form is present", async () => {
+  const zipBuffer = await makeZip({
+    "config.json": "{\"code\":\"ABC\"}",
+    "demand_data.json": "{}",
+    "roads.geojson": "{}",
+    "runways_taxiways.geojson": "{}",
+    "ABC.pmtiles": "stub",
+  });
+
+  const result = await inspectZipCompleteness("map", zipBuffer, { cityCode: "ABC" });
+  assert.equal(result.isComplete, false);
+  assert.equal(result.requiredChecks.buildings_index, false);
+  assert.equal(result.matchedFiles.buildings_index, null);
+  assert.ok(result.errors.some((error) => error.includes("buildings index")));
 });
 
 test("map integrity rejects nested paths and missing top-level city pmtiles", async () => {
@@ -235,4 +307,30 @@ test("mod integrity records security WARNING rule without blocking completion", 
   assert.equal(result.requiredChecks.security_scan_passed, true);
   assert.ok(result.warnings.some((warning) => warning.includes("security scan detected")));
   assert.equal(result.securityIssue?.findings[0]?.severity, "WARNING");
+});
+
+test("withBuildingsIndexPresenceIfMissing backfills legacy map cache entries", async () => {
+  // Pre-split cache entry: only the combined buildings_index match, no per-form keys.
+  const legacy = makeCachedEntry({ buildings_index: "buildings_index.json" });
+  const patched = withBuildingsIndexPresenceIfMissing(legacy);
+  // Binary is known-absent; JSON form derived from the recorded match. No re-inspection.
+  assert.equal(patched.matched_files.buildings_index_json, "buildings_index.json");
+  assert.equal(patched.matched_files.buildings_index_bin, null);
+  assert.equal(patched.matched_files.buildings_index, "buildings_index.json");
+});
+
+test("withBuildingsIndexPresenceIfMissing leaves already-split entries untouched", async () => {
+  const fresh = makeCachedEntry({
+    buildings_index: "buildings_index.bin.gz",
+    buildings_index_json: null,
+    buildings_index_bin: "buildings_index.bin.gz",
+  });
+  const patched = withBuildingsIndexPresenceIfMissing(fresh);
+  assert.equal(patched, fresh); // no-op: returns the same reference
+});
+
+test("withBuildingsIndexPresenceIfMissing ignores non-map (mod) entries", async () => {
+  const mod = makeCachedEntry({ release_manifest_asset: "manifest.json", zip_manifest_json: "manifest.json" });
+  const patched = withBuildingsIndexPresenceIfMissing(mod);
+  assert.equal(patched, mod); // no buildings_index key → untouched
 });


### PR DESCRIPTION
## What

jp-data's `process_buildings_index` now ships a packed binary twin, `buildings_index.bin.gz`, alongside `buildings_index.json` in map release zips (sim builds >1.3.0 read the binary; <=1.3.0 read the JSON). This teaches the integrity generator to recognize and record which form(s) each map version carries, so the report can drive a per-version game-version range (composing with the manifest `game_version` work already on main).

## Changes

- **`inspectMapZip`** — buildings index is now an **either/or** requirement (JSON form **or** binary form present). Records both presences separately as `matched_files.buildings_index_json` / `buildings_index_bin`, keeping the combined `buildings_index` key (JSON-preferred) for back-compat.
- **`withBuildingsIndexPresenceIfMissing`** — backfills the per-form keys onto reused cache entries from data already cached (binary is known-absent — no release ships it yet; JSON = the recorded `buildings_index` match). Applied on both cache-reuse paths.
- Tests: binary-only / both-forms / neither-form inspection cases + backfill unit tests.

## No rules-version bump

The new field is derivable for every existing entry without re-inspecting any zip, so **`INTEGRITY_RULES_VERSION` is unchanged**. Regenerating `maps/integrity.json` (`generate-downloads --type map --mode full`) reuses every cached entry — no zip downloads — and backfills the keys, keeping the report homogeneous. No release carries the `.bin` yet, so `buildings_index_bin` is `null` across the board and no map's completeness changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)