### PR TITLE
Fix clobbered sha detection for same-tag re-uploads

### DIFF
--- a/scripts/generate-downloads.ts
+++ b/scripts/generate-downloads.ts
@@ -31,6 +31,9 @@ import {
 } from "./lib/script-runtime.js";
 import { compareStableSemverAsc, isStableSemverTag } from "./lib/semver.js";
 import { filterListingMessages, isTestListing } from "./lib/test-listings.js";
+import { loadAuthorAliasIndex } from "./lib/author-aliases.js";
+import { buildIntegrityAlertEmbed } from "./lib/downloads-full/integrity-alerts.js";
+import { sendDiscordPayload } from "./lib/discord-webhook.js";
 
 export function listZeroValidSemverListings(integrity: IntegrityOutput): string[] {
   return Object.entries(integrity.listings)
@@ -261,6 +264,7 @@ async function run(): Promise<void> {
     versionBucketInputs,
     integrity,
     integrityCache,
+    integrityAlerts,
     stats,
     warnings,
     rateLimit,
@@ -305,6 +309,33 @@ async function run(): Promise<void> {
     writeJsonFile(integrityCachePath, integrityCache);
     writeJsonFile(pendingAnnouncementsPath, pendingAnnouncements);
     writeDownloadAttributionDeltaFile(attributionDeltaPath, attributionDelta);
+    const discordIntegrityWebhookUrl = process.env.DISCORD_INTEGRITY_WEBHOOK_URL?.trim() || undefined;
+    if (discordIntegrityWebhookUrl && integrityAlerts.length > 0) {
+      const authorIndex = loadAuthorAliasIndex(repoRoot);
+      const alertsByAuthorId = new Map<string, typeof integrityAlerts>();
+      for (const alert of integrityAlerts) {
+        if (!alertsByAuthorId.has(alert.authorId)) {
+          alertsByAuthorId.set(alert.authorId, []);
+        }
+        alertsByAuthorId.get(alert.authorId)!.push(alert);
+      }
+      for (const [authorId, authorAlerts] of alertsByAuthorId) {
+        const authorEntry = authorIndex.authors.find((a) => a.author_id === authorId);
+        const discordId = authorEntry?.discord_id;
+        const authorAlias = authorEntry?.author_alias ?? authorEntry?.author_id ?? authorId;
+        const content = discordId ? `<@${discordId}>` : undefined;
+        const noDiscordIdNote = discordId ? undefined : `No Discord ID on file for ${authorAlias}`;
+        const embeds = authorAlerts.slice(0, 10).map((alert) =>
+          buildIntegrityAlertEmbed(alert, authorAlias, noDiscordIdNote),
+        );
+        try {
+          await sendDiscordPayload(discordIntegrityWebhookUrl, content, embeds);
+          console.log(`[downloads][integrity-alert] Sent Discord alert for author=${authorId} (${authorAlerts.length} version(s))`);
+        } catch (error) {
+          console.warn(`[downloads][integrity-alert] Failed to send Discord alert for author=${authorId}: ${(error as Error).message}`);
+        }
+      }
+    }
     console.log(
       pendingAnnouncements.listings.length > 0
         ? `[downloads] Pending announcements: ${pendingAnnouncements.listings.map((entry) => entry.listing_id).join(", ")}`

--- a/scripts/lib/discord-server-metrics.ts
+++ b/scripts/lib/discord-server-metrics.ts
@@ -481,8 +481,12 @@ export function updateDiscordServerMessageDays(params: {
         || createdDelta.public_total_messages > 0
         || createdDelta.private_total_messages > 0
       ) {
-        const entry = nextMessageDays[dateKey] ?? emptyMessageDayMetrics();
-        nextMessageDays[dateKey] = {
+        // Messages newly found on historical dates are attributed to the capture date
+        // rather than their original creation date, since we can't tell when they
+        // actually appeared between the two captures.
+        const attributionDate = dateKey < params.captureDate ? params.captureDate : dateKey;
+        const entry = nextMessageDays[attributionDate] ?? emptyMessageDayMetrics();
+        nextMessageDays[attributionDate] = {
           messages_created: entry.messages_created + createdDelta.total_messages,
           messages_deleted: entry.messages_deleted,
           public_messages_created: entry.public_messages_created + createdDelta.public_total_messages,

--- a/scripts/lib/discord-webhook.ts
+++ b/scripts/lib/discord-webhook.ts
@@ -21,13 +21,15 @@ export function buildDiscordMarkdownMessage(options: SendDiscordMarkdownOptions)
   return messageLines.join("\n");
 }
 
-interface DiscordEmbed {
+export interface DiscordEmbed {
   title?: string;
   description: string;
   color: number;
+  footer?: { text: string };
 }
 
 interface DiscordWebhookPayload {
+  content?: string;
   embeds: DiscordEmbed[];
 }
 
@@ -115,6 +117,35 @@ export async function sendDiscordMarkdown(options: SendDiscordMarkdownOptions): 
       timeoutMs,
       heartbeatPrefix: "[discord]",
       heartbeatLabel: "send-webhook",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Discord webhook returned HTTP ${response.status}`);
+  }
+}
+
+export async function sendDiscordPayload(
+  webhookUrl: string,
+  content: string | undefined,
+  embeds: DiscordEmbed[],
+): Promise<void> {
+  const timeoutMs = resolveTimeoutMsFromEnv("DISCORD_WEBHOOK_TIMEOUT_MS", 15_000);
+  const payload: DiscordWebhookPayload = { embeds };
+  if (content && content.trim() !== "") {
+    payload.content = content;
+  }
+  const response = await fetchWithTimeout(
+    fetch,
+    webhookUrl,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+    {
+      timeoutMs,
+      heartbeatPrefix: "[discord]",
+      heartbeatLabel: "send-payload",
     },
   );
   if (!response.ok) {

--- a/scripts/lib/download-definitions.ts
+++ b/scripts/lib/download-definitions.ts
@@ -17,6 +17,7 @@ export interface GraphqlReleaseAssetNode {
   downloadCount: number;
   downloadUrl: string;
   size?: number | null;
+  updatedAt?: string | null;
 }
 
 export interface GraphqlReleaseNode {
@@ -64,6 +65,9 @@ export interface RepoReleaseTagData {
     downloadCount: number;
     downloadUrl: string | null;
     sizeBytes: number | null;
+    // ISO 8601 timestamp of last asset update from GitHub API; populated by full
+    // release-index path only. Used to detect asset replacement (clobber).
+    assetUpdatedAt?: string | null;
   }>;
 }
 
@@ -180,6 +184,7 @@ export const REPO_RELEASES_QUERY = `
               downloadCount
               downloadUrl
               size
+              updatedAt
             }
             pageInfo {
               hasNextPage

--- a/scripts/lib/download-definitions.ts
+++ b/scripts/lib/download-definitions.ts
@@ -125,11 +125,25 @@ export interface DownloadVersionBucketInput {
 
 export type VersionBucketInputsByListing = Record<string, Record<string, DownloadVersionBucketInput[]>>;
 
+export interface IntegrityAlert {
+  listingId: string;
+  listingName: string;
+  listingType: "map" | "mod";
+  authorId: string;
+  version: string;
+  isRegression: boolean;
+  failingChecks: string[];
+  errors: string[];
+  sourceRepo?: string;
+  sourceTag?: string;
+}
+
 export interface GenerateDownloadsResult {
   downloads: DownloadsByListing;
   versionBucketInputs: VersionBucketInputsByListing;
   integrity: IntegrityOutput;
   integrityCache: IntegrityCache;
+  integrityAlerts: IntegrityAlert[];
   stats: {
     listings: number;
     versions_checked: number;

--- a/scripts/lib/downloads-download-only.ts
+++ b/scripts/lib/downloads-download-only.ts
@@ -302,6 +302,7 @@ export async function generateDownloadsDataDownloadOnly(
     versionBucketInputs,
     integrity,
     integrityCache: loadIntegrityCache(repoRoot, dir),
+    integrityAlerts: [],
     stats: {
       listings: ids.length,
       versions_checked: versionsChecked,

--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -425,13 +425,14 @@ export async function generateDownloadsDataFull(
         versionsChecked += 1;
 
         const zipAssets = Array.from(releaseData.assets.entries())
-          .filter(([assetName]) => assetName.toLowerCase().endsWith(".zip"));
-        const zipAssetNames = zipAssets.map(([assetName]) => assetName).sort();
+          .filter(([assetName]) => assetName.toLowerCase().endsWith(".zip"))
+          .sort(([a], [b]) => a.localeCompare(b));
+        const zipAssetNames = zipAssets.map(([name]) => name);
         const securityFingerprintPart = getSecurityFingerprintPart(
           listingType,
           modSecurityRules,
         );
-        const fingerprintBase = zipAssetNames.length > 0
+        const fingerprintBase = zipAssets.length > 0
           ? `github:${repo}:${tag}:${zipAssetNames.join("|")}${securityFingerprintPart}`
           : `github:${repo}:${tag}:no-zip${securityFingerprintPart}`;
         const fingerprint = versionedFingerprint(fingerprintBase);
@@ -441,7 +442,13 @@ export async function generateDownloadsDataFull(
           repo,
           tag,
         };
-        const shouldReuseCached = (
+        const currentZipSizes: Record<string, number> = Object.fromEntries(
+          zipAssets.flatMap(([name, a]) => a.sizeBytes != null ? [[name, a.sizeBytes]] : []),
+        );
+        const currentZipUpdatedAt: Record<string, string> = Object.fromEntries(
+          zipAssets.flatMap(([name, a]) => a.assetUpdatedAt != null ? [[name, a.assetUpdatedAt]] : []),
+        );
+        let shouldReuseCached = (
           !forceIntegrityRecheck
           && shouldUseCachedIntegrity(
             cached,
@@ -452,6 +459,24 @@ export async function generateDownloadsDataFull(
           && !isLegacyMapCacheMissingFileSizes(listingType, cached)
           && !isLegacyModCacheMissingSecurityCheck(listingType, cached)
         );
+        if (shouldReuseCached && cached != null) {
+          // Prefer updatedAt timestamps (catches same-size replacements, e.g. config.json version bump).
+          // Fall back to byte-size check for entries written before updatedAt was recorded.
+          const storedUpdatedAt = cached.asset_updated_at;
+          const storedSizes = cached.asset_sizes;
+          const updatedAtMismatch = storedUpdatedAt != null && (
+            Object.keys(currentZipUpdatedAt).some((name) => currentZipUpdatedAt[name] !== storedUpdatedAt[name])
+            || Object.keys(storedUpdatedAt).some((name) => !(name in currentZipUpdatedAt))
+          );
+          const sizeMismatch = storedSizes != null && storedUpdatedAt == null && (
+            Object.keys(currentZipSizes).some((name) => currentZipSizes[name] !== storedSizes[name])
+            || Object.keys(storedSizes).some((name) => !(name in currentZipSizes))
+          );
+          if (updatedAtMismatch || sizeMismatch) {
+            warnListing(warnings, id, "zip asset replaced since last inspection; forcing re-check", tag);
+            shouldReuseCached = false;
+          }
+        }
 
         if (shouldReuseCached) {
           cacheHits += 1;
@@ -573,12 +598,16 @@ export async function generateDownloadsDataFull(
                 )
             );
           const previousVersionEntry = previousIntegrity?.listings[id]?.versions?.[tag];
+          const zipSizesEntry = Object.keys(currentZipSizes).length > 0 ? currentZipSizes : undefined;
+          const zipUpdatedAtEntry = Object.keys(currentZipUpdatedAt).length > 0 ? currentZipUpdatedAt : undefined;
           if (isGrandfatheredDowngrade(previousVersionEntry, result)) {
             versionEntries[tag] = previousVersionEntry!;
             nextListingCacheEntries[tag] = {
               fingerprint,
               last_checked_at: nowIso,
               result: previousVersionEntry!,
+              asset_sizes: zipSizesEntry,
+              asset_updated_at: zipUpdatedAtEntry,
             };
             const failingKeys = Object.entries(result.required_checks)
               .filter(([, v]) => !v).map(([k]) => k).join(", ");
@@ -589,6 +618,8 @@ export async function generateDownloadsDataFull(
               fingerprint,
               last_checked_at: nowIso,
               result,
+              asset_sizes: zipSizesEntry,
+              asset_updated_at: zipUpdatedAtEntry,
             };
           }
         }

--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -277,6 +277,7 @@ export async function generateDownloadsDataFull(
 
   const downloadsByListing: D.DownloadsByListing = {};
   const listingContexts = new Map<string, ListingContext>();
+  const listingMeta = new Map<string, { listingName: string; authorId: string }>();
   const repoSet = new Set<string>();
 
   // Pace unauthenticated raw.githubusercontent.com custom-update fetches to
@@ -294,6 +295,8 @@ export async function generateDownloadsDataFull(
       warnListing(warnings, id, `failed to read manifest (${(error as Error).message})`);
       continue;
     }
+
+    listingMeta.set(id, { listingName: manifest.name, authorId: manifest.author });
 
     if (manifest.update.type === "github") {
       const repo = manifest.update.repo.toLowerCase();
@@ -345,6 +348,7 @@ export async function generateDownloadsDataFull(
 
   const integrityListings: Record<string, ListingIntegrityEntry> = {};
   const versionBucketInputs: D.VersionBucketInputsByListing = {};
+  const integrityAlerts: D.IntegrityAlert[] = [];
   let versionsChecked = 0;
   let completeVersions = 0;
   let incompleteVersions = 0;
@@ -1000,6 +1004,29 @@ export async function generateDownloadsDataFull(
       if (cacheEntry) nextListingCacheEntries[version] = { ...cacheEntry, result: stamped };
     }
 
+    for (const [version, entry] of Object.entries(versionEntries)) {
+      if (!entry.is_complete && Object.values(entry.required_checks).some((v) => v === false)) {
+        const prevEntry = previousIntegrity?.listings[id]?.versions?.[version];
+        if (prevEntry === undefined || prevEntry.is_complete === true) {
+          const meta = listingMeta.get(id);
+          integrityAlerts.push({
+            listingId: id,
+            listingName: meta?.listingName ?? id,
+            listingType,
+            authorId: meta?.authorId ?? "",
+            version,
+            isRegression: prevEntry?.is_complete === true,
+            failingChecks: Object.entries(entry.required_checks)
+              .filter(([, v]) => v === false)
+              .map(([k]) => k),
+            errors: entry.errors,
+            sourceRepo: entry.source.repo,
+            sourceTag: entry.source.tag,
+          });
+        }
+      }
+    }
+
     for (const result of Object.values(versionEntries)) {
       if (result.is_complete) {
         completeVersions += 1;
@@ -1029,6 +1056,7 @@ export async function generateDownloadsDataFull(
       schema_version: 1,
       entries: sortObjectByKeys(nextCache.entries),
     },
+    integrityAlerts,
     stats: {
       listings: ids.length,
       versions_checked: versionsChecked,

--- a/scripts/lib/downloads-full/integrity-alerts.ts
+++ b/scripts/lib/downloads-full/integrity-alerts.ts
@@ -1,0 +1,70 @@
+import type { DiscordEmbed } from "../discord-webhook.js";
+import type { IntegrityAlert } from "../download-definitions.js";
+
+export const INTEGRITY_ALERT_EMBED_COLOR = 0xE8890C;
+
+export const INTEGRITY_CHECK_FIX_HINTS: Record<string, string> = {
+  // Map checks
+  config_json: "Add a `config.json` file to the top level of your ZIP and publish a new release.",
+  demand_data: "Add `demand_data.json` or `demand_data.json.gz` to the top level of your ZIP and publish a new release.",
+  demand_point_spacing: "Ensure every demand point in `demand_data.json` has at least one neighbor within 100 km, then publish a new release.",
+  demand_phantom_points: "Remove demand points with zero residents and zero jobs from `demand_data.json`, then publish a new release.",
+  demand_residents_match: "Fix the resident total mismatch in `demand_data.json` (sum across `points` must equal sum across `populations`), then publish a new release.",
+  buildings_index: "Add a buildings index (`buildings_index.json/.json.gz` or `.bin/.bin.gz`) to the top level of your ZIP and publish a new release.",
+  roads_geojson: "Add `roads.geojson` or `roads.geojson.gz` to the top level of your ZIP and publish a new release.",
+  runways_taxiways_geojson: "Add `runways_taxiways.geojson` or `runways_taxiways.geojson.gz` to the top level of your ZIP and publish a new release.",
+  city_pmtiles: "Add the `.pmtiles` file matching your `config.json` city code to the top level of your ZIP and publish a new release.",
+  config_version_matches_tag: "Update `version` in `config.json` to match the new release tag, then publish a new release.",
+  // Mod checks
+  zip_manifest_json: "Add `manifest.json` to the top level of your ZIP and publish a new release.",
+  manifest_version_matches_tag: "Update `version` in `manifest.json` to match the new release tag, then publish a new release.",
+  security_scan_passed: "Remove or fix the files flagged by the security scan (listed in the errors above), then publish a new release.",
+  release_manifest_asset: "Publish a new release with `manifest.json` uploaded as a separate release asset alongside the ZIP (not only inside it).",
+};
+
+export function buildIntegrityAlertEmbed(
+  alert: IntegrityAlert,
+  authorAlias: string,
+  noDiscordIdNote?: string,
+): DiscordEmbed {
+  const typeLabel = alert.listingType === "map" ? "Map" : "Mod";
+  const regressionLabel = alert.isRegression ? "regression" : "new version failure";
+
+  const lines: string[] = [
+    `**${alert.listingName}** \`${alert.version}\``,
+    `Author: ${authorAlias} | Status: \`alert\` (${regressionLabel})`,
+    "",
+    "**Failing checks:**",
+    ...alert.failingChecks.map((key) => {
+      const hint = INTEGRITY_CHECK_FIX_HINTS[key] ?? "Fix the issue and publish a new release.";
+      return `- \`${key}\`: ${hint}`;
+    }),
+  ];
+
+  if (alert.errors.length > 0) {
+    lines.push("", "**Errors:**");
+    const maxErrors = 8;
+    for (const error of alert.errors.slice(0, maxErrors)) {
+      lines.push(`- ${error}`);
+    }
+    if (alert.errors.length > maxErrors) {
+      lines.push(`- ...and ${alert.errors.length - maxErrors} more`);
+    }
+  }
+
+  if (alert.sourceRepo && alert.sourceTag) {
+    lines.push("", `Source: \`${alert.sourceRepo}@${alert.sourceTag}\``);
+  }
+
+  let description = lines.join("\n");
+  if (description.length > 4000) {
+    description = `${description.slice(0, 3997)}...`;
+  }
+
+  return {
+    title: `[${typeLabel}] Integrity alert: ${alert.listingName} ${alert.version}`,
+    description,
+    color: INTEGRITY_ALERT_EMBED_COLOR,
+    ...(noDiscordIdNote ? { footer: { text: noDiscordIdNote } } : {}),
+  };
+}

--- a/scripts/lib/integrity.ts
+++ b/scripts/lib/integrity.ts
@@ -105,6 +105,12 @@ export interface IntegrityCacheEntry {
   fingerprint: string;
   last_checked_at: string;
   result: IntegrityVersionEntry;
+  // Byte sizes of ZIP assets at inspection time. Written on fresh inspection; carried forward on cache hit.
+  // If present and current GitHub sizes differ, the cache entry is invalidated to detect asset replacement.
+  asset_sizes?: Record<string, number>;
+  // GitHub `updatedAt` timestamps of ZIP assets at inspection time. Preferred over asset_sizes for clobber
+  // detection since version-string-only changes (e.g. "0.2.0"→"0.3.0") produce same-size ZIPs.
+  asset_updated_at?: Record<string, string>;
 }
 
 export interface IntegrityCache {

--- a/scripts/lib/release-resolution.ts
+++ b/scripts/lib/release-resolution.ts
@@ -193,6 +193,7 @@ function aggregateReleaseDataByTag(releases: Array<{
     downloadCount: number;
     downloadUrl: string | null;
     sizeBytes: number | null;
+    updatedAt: string | null;
   }>;
 }>): Map<string, D.RepoReleaseTagData> {
   const byTag = new Map<string, D.RepoReleaseTagData>();
@@ -203,6 +204,7 @@ function aggregateReleaseDataByTag(releases: Array<{
       downloadCount: number;
       downloadUrl: string | null;
       sizeBytes: number | null;
+      assetUpdatedAt?: string | null;
     }>();
     let zipTotal = 0;
 
@@ -213,6 +215,7 @@ function aggregateReleaseDataByTag(releases: Array<{
         downloadCount: asset.downloadCount,
         downloadUrl: asset.downloadUrl,
         sizeBytes: Number.isFinite(asset.sizeBytes) ? asset.sizeBytes : null,
+        assetUpdatedAt: typeof asset.updatedAt === "string" && asset.updatedAt.trim() !== "" ? asset.updatedAt : null,
       });
       if (asset.name.toLowerCase().endsWith(".zip")) {
         zipTotal += asset.downloadCount;
@@ -272,6 +275,7 @@ async function fetchGraphqlReleaseIndexForRepo(
         downloadCount: asset.downloadCount,
         downloadUrl: asset.downloadUrl,
         sizeBytes: typeof asset.size === "number" && Number.isFinite(asset.size) ? asset.size : null,
+        updatedAt: typeof asset.updatedAt === "string" && asset.updatedAt.trim() !== "" ? asset.updatedAt : null,
       }));
       if (release.releaseAssets.pageInfo.hasNextPage) {
         warn(


### PR DESCRIPTION
Add GitHub asset updatedAt timestamps and byte sizes, so replaced ZIPs (including same-size ones where config.json is version bumped) are automatically re-inspected on the next analytics run. 

Also fixes a discord metrics bug where backdated message discoveries were attributed to the wrong day, and removes stale compiled test artifacts from an unmerged branch.

And now also pings individual authors who have linked GIthub ID if any of their assets fail