### PR TITLE
Fix data-quality invite: dropdown prefill blanks the issue form

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -345,19 +345,20 @@ jobs:
             sample.sort((a, b) => b.lastUpdated - a.lastUpdated);
             const sampleIds = sample.slice(0, 5).map((s) => s.id);
 
+            // Prefill only input fields: prefilling a dropdown via query
+            // params makes GitHub fall back to the blank issue editor.
             const params = new URLSearchParams({
               template: 'data-quality.yml',
               title: `[Data Quality]: ${mapId}`,
               'map-id': mapId,
             });
             if (sampleIds.length > 0) {
-              params.set('same-methodology', 'Yes — same methodology as my other maps in this country');
               params.set('same-methodology-sample', sampleIds.join(', '));
             }
             const inviteUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/issues/new?${params.toString()}`;
 
             const sampleNote = sampleIds.length > 0
-              ? `\n\nIf this map was generated with the same methodology as your other scored ${country} maps (${sampleIds.map((id) => `[\`${id}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/tree/main/maps/${id})`).join(', ')}), answering **Yes** to the first question inherits their answers automatically.`
+              ? `\n\nIf this map was generated with the same methodology as your other scored ${country} maps (${sampleIds.map((id) => `[\`${id}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/tree/main/maps/${id})`).join(', ')}), select **Yes** on the first question to inherit their answers automatically.`
               : '';
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
Alex's test surfaced that the phase-two invite URL renders a **blank issue editor** instead of the form. The template itself is valid (checked against YAML, GitHub's issue-forms schema, and the working publish-map emitter) — the failure is the URL: **prefilling a dropdown field (`same-methodology`) via query params makes GitHub fall back to the blank template**. Input/textarea prefills are the reliably supported kind.

Fix: the invite prefills only `map-id` and the `same-methodology-sample` reference input; the comment text now says "select **Yes** on the first question" instead of pre-answering it.

To re-test with your existing map: open
`https://github.com/Subway-Builder-Modded/registry/issues/new?template=data-quality.yml&title=%5BData+Quality%5D%3A+asdfasdf&map-id=asdfasdf&same-methodology-sample=yukina-osaka%2C+yukina-fukuoka%2C+yukina-hakodate%2C+yukina-hiroshima-kure%2C+yukina-keihanshin`
— this should render the full form with Map ID and the sample field filled.

(Also verified while investigating: the wording-alignment commit did make it into the #5854 squash — main's form already speaks the guide's language.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)