### PR TITLE
Fix data-quality form: YAML anchors made GitHub render a blank template

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-quality.yml
+++ b/.github/ISSUE_TEMPLATE/data-quality.yml
@@ -98,7 +98,7 @@
         map's demand points. If unsure: open the source table and look at what one row
         covers; when two grains are plausible, pick the coarser one and mention both in
         Methodology. See the guide's data-suppression note."
-      "options": &a1
+      "options":
         - "Small uniform grid squares, roughly 100–250 m"
         - "Individual buildings or census blocks"
         - "Neighborhoods or districts within a city"
@@ -156,7 +156,14 @@
       "label": "What is the smallest area your population numbers are reported for?"
       "description": "As with the workplace question: follow the guide's two rules — answer with
         the source table's areas — and account for potential data suppression."
-      "options": *a1
+      "options":
+        - "Small uniform grid squares, roughly 100–250 m"
+        - "Individual buildings or census blocks"
+        - "Neighborhoods or districts within a city"
+        - "Whole cities or municipalities"
+        - "Counties or larger regions"
+        - "States or provinces"
+        - "Not based on official statistics areas"
     "validations":
       "required": false
   - "type": "dropdown"
@@ -215,7 +222,14 @@
         options — it asks for the areas the commute table's origins and destinations refer
         to (a table of town-to-town flows covers whole towns). Leave it blank if there is no
         flow data — the grain of estimated flows is not scored."
-      "options": *a1
+      "options":
+        - "Small uniform grid squares, roughly 100–250 m"
+        - "Individual buildings or census blocks"
+        - "Neighborhoods or districts within a city"
+        - "Whole cities or municipalities"
+        - "Counties or larger regions"
+        - "States or provinces"
+        - "Not based on official statistics areas"
     "validations":
       "required": false
   - "type": "markdown"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -345,19 +345,20 @@ jobs:
             sample.sort((a, b) => b.lastUpdated - a.lastUpdated);
             const sampleIds = sample.slice(0, 5).map((s) => s.id);
 
+            // Prefill only input fields: prefilling a dropdown via query
+            // params makes GitHub fall back to the blank issue editor.
             const params = new URLSearchParams({
               template: 'data-quality.yml',
               title: `[Data Quality]: ${mapId}`,
               'map-id': mapId,
             });
             if (sampleIds.length > 0) {
-              params.set('same-methodology', 'Yes — same methodology as my other maps in this country');
               params.set('same-methodology-sample', sampleIds.join(', '));
             }
             const inviteUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/issues/new?${params.toString()}`;
 
             const sampleNote = sampleIds.length > 0
-              ? `\n\nIf this map was generated with the same methodology as your other scored ${country} maps (${sampleIds.map((id) => `[\`${id}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/tree/main/maps/${id})`).join(', ')}), answering **Yes** to the first question inherits their answers automatically.`
+              ? `\n\nIf this map was generated with the same methodology as your other scored ${country} maps (${sampleIds.map((id) => `[\`${id}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/tree/main/maps/${id})`).join(', ')}), select **Yes** on the first question to inherit their answers automatically.`
               : '';
 
             await github.rest.issues.createComment({

--- a/scripts/generate-map-templates.ts
+++ b/scripts/generate-map-templates.ts
@@ -30,6 +30,10 @@ const YAML_OPTIONS = {
   indent: 2,
   defaultStringType: "QUOTE_DOUBLE",
   blockQuote: true,
+  // GitHub's issue-form parser rejects YAML anchors/aliases, which the
+  // emitter otherwise produces when dropdowns share an options array
+  // (the whole template then falls back to the blank issue editor).
+  aliasDuplicateObjects: false,
 } as const;
 
 const OptionItemSchema = z.union([

--- a/scripts/tests/update-map-template.integration.test.ts
+++ b/scripts/tests/update-map-template.integration.test.ts
@@ -130,6 +130,27 @@ test("publish-map.yml enforces required publish fields with blank dropdown defau
   assert.equal(collaborators.validations?.required, false);
 });
 
+test("data-quality.yml contains no YAML anchors and repeats shared options inline", () => {
+  const scriptsRoot = resolve(import.meta.dirname, "..", "..");
+  const raw = readFileSync(
+    resolve(scriptsRoot, "..", ".github", "ISSUE_TEMPLATE", "data-quality.yml"),
+    "utf-8",
+  );
+  // GitHub's issue-form parser rejects anchors/aliases: the emitter must never
+  // deduplicate shared option arrays or the form falls back to the blank editor.
+  assert.doesNotMatch(raw, /[&*]a\d/);
+
+  const parsed = YAML.parse(raw) as { body: unknown[] };
+  const workplaceDetail = getField(parsed.body, "dq-workplace-detail");
+  const residenceDetail = getField(parsed.body, "dq-residence-detail");
+  const odDetail = getField(parsed.body, "dq-od-detail");
+  assert.deepEqual(
+    getDropdownOptions(residenceDetail),
+    getDropdownOptions(workplaceDetail),
+  );
+  assert.deepEqual(getDropdownOptions(odDetail), getDropdownOptions(workplaceDetail));
+});
+
 test("update-map.yml keeps map-id/terms required and makes other fields optional", () => {
   const parsed = parseTemplate("update-map.yml");
 


### PR DESCRIPTION
**This is the actual root cause of the blank form** (the prefill fix in #5863 was a red herring — worth keeping, but not the bug).

The template generator's YAML emitter deduplicated the three identical granularity option arrays (workplace detail / residence detail / O/D detail all share `GRANULARITY_FORM_LABELS`) into a YAML **anchor + alias**:

```yaml
"options": &a1
  - "Small uniform grid squares, roughly 100–250 m"
  ...
"options": *a1
```

GitHub's issue-form parser does not support anchors/aliases, rejects the template, and silently falls back to the blank issue editor — regardless of query params. Local validation passed because spec-compliant YAML parsers resolve aliases fine; the publish/update forms never share option arrays, which is why they were unaffected.

Fix: `aliasDuplicateObjects: false` in the emitter options (regenerated `data-quality.yml` now carries all options inline), plus a regression test asserting the generated file contains no anchor/alias syntax and that the three granularity dropdowns still expose identical option lists.

**After merging**, the form should render at:
`https://github.com/Subway-Builder-Modded/registry/issues/new?template=data-quality.yml&title=%5BData+Quality%5D%3A+asdfasdf&map-id=asdfasdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)