### PR TITLE
chore(data-quality): placeholder for the sample reference field

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-quality.yml
+++ b/.github/ISSUE_TEMPLATE/data-quality.yml
@@ -58,7 +58,10 @@
     "attributes":
       "label": "Same-Methodology Sample (reference)"
       "description": "Auto-filled when you arrive via a prefilled link — the maps a Yes answer
-        inherits from. Display-only: the registry re-derives the authoritative list."
+        inherits from. Display-only: the registry re-derives the authoritative list, so it
+        is safe to leave blank."
+      "placeholder": "Leave blank — auto-filled by the invite link; the registry derives the real
+        list either way."
     "validations":
       "required": false
   - "type": "markdown"

--- a/scripts/generate-map-templates.ts
+++ b/scripts/generate-map-templates.ts
@@ -491,8 +491,12 @@ const dataQualityTemplateBaseDoc: TemplateDoc = {
     input(
       "same-methodology-sample",
       "Same-Methodology Sample (reference)",
-      "Auto-filled when you arrive via a prefilled link — the maps a Yes answer inherits from. Display-only: the registry re-derives the authoritative list.",
-      { required: false },
+      "Auto-filled when you arrive via a prefilled link — the maps a Yes answer inherits from. Display-only: the registry re-derives the authoritative list, so it is safe to leave blank.",
+      {
+        placeholder:
+          "Leave blank — auto-filled by the invite link; the registry derives the real list either way.",
+        required: false,
+      },
     ),
     spacer(),
     markdown(


### PR DESCRIPTION
The empty box read awkwardly when arriving without a prefilled invite
link; the placeholder now says it is safe to leave blank.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
