### PR TITLE
feat(data-quality): make review a blocking step for new map publishes

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-quality.yml
+++ b/.github/ISSUE_TEMPLATE/data-quality.yml
@@ -17,10 +17,10 @@
         until a reviewer works through them with you.
 
 
-        Please read the [Data Quality Questions
-        guide](https://github.com/Subway-Builder-Modded/registry/blob/main/docs/data-qualit\
-        y-questions.md) — it explains each question in plain language, including the golden
-        rule: **answer with where the numbers are published, not where you placed them**.
+        Please read the [Submission Questions
+        guide](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — it
+        explains each question in plain language, including the golden rule: **answer with
+        where the numbers are published, not where you placed them**.
 
 
         Your answers produce a provisional score in a pull request; a reviewer confirms it
@@ -36,7 +36,7 @@
     "attributes":
       "label": "Map ID"
       "description": "The ID of the map these answers describe. Must already exist in the registry
-        and be published by your GitHub account."
+        — or have an open publish submission — and be published by your GitHub account."
     "validations":
       "required": true
   - "type": "dropdown"

--- a/.github/ISSUE_TEMPLATE/publish-map.yml
+++ b/.github/ISSUE_TEMPLATE/publish-map.yml
@@ -102,14 +102,16 @@
         Provide details about your map's data source and level of detail. Be honest and
         transparent in your descriptions and please include the methodology you used to
         generate the map's data. See the [Data
-        Quality](https://subwaybuildermodded.com/wiki/railyard/latest/developers/data-quali\
-        ty) guide for more information.
+        Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more
+        information.
 
 
-        After your map is published, you will be invited to answer the [data-quality
-        questions](https://github.com/Subway-Builder-Modded/registry/blob/main/docs/data-qu\
-        ality-questions.md) so the map can receive its data-quality tier; until then it is
-        listed as `unknown-quality`."
+        After your submission is validated, you will be invited to answer the [data-quality
+        questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — a
+        **required step**: your map cannot merge until a maintainer confirms your answers,
+        and new submissions are subject to the [quality
+        floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for
+        countries with existing maps."
   - "type": "input"
     "id": "data_source"
     "attributes":

--- a/.github/ISSUE_TEMPLATE/update-map.yml
+++ b/.github/ISSUE_TEMPLATE/update-map.yml
@@ -91,14 +91,14 @@
         Provide details about your map's data source and level of detail. Be honest and
         transparent in your descriptions and please include the methodology you used to
         generate the map's data. See the [Data
-        Quality](https://subwaybuildermodded.com/wiki/railyard/latest/developers/data-quali\
-        ty) guide for more information.
+        Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more
+        information.
 
 
-        After your map is published, you will be invited to answer the [data-quality
-        questions](https://github.com/Subway-Builder-Modded/registry/blob/main/docs/data-qu\
-        ality-questions.md) so the map can receive its data-quality tier; until then it is
-        listed as `unknown-quality`."
+        Updating metadata does not change your map's data-quality tier. If the underlying
+        data changed, submit new answers via the [data-quality
+        questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions)
+        form."
   - "type": "input"
     "id": "data_source"
     "attributes":

--- a/.github/workflows/check-data-quality.yml
+++ b/.github/workflows/check-data-quality.yml
@@ -13,6 +13,9 @@ name: Check Data Quality
 
 on:
   pull_request:
+    # labeled/unlabeled: applying or removing dq-grandfathered must re-run the
+    # publish gate below.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "maps/**"
       - "schemas/**"
@@ -34,6 +37,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find manifests added in this PR
+        # Publish gate (plan C1.3): maps newly added relative to the base must
+        # carry a confirmed (non-unknown) data_quality tier before merge. The
+        # dq-grandfathered label exempts the whole PR.
+        id: added
+        if: >-
+          github.event_name == 'pull_request' &&
+          !contains(github.event.pull_request.labels.*.name, 'dq-grandfathered')
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+            base="$(git rev-parse "${head}~1" 2>/dev/null || git rev-parse "${head}")"
+          fi
+          ids="$(git diff --name-only --diff-filter=A "$base" "$head" -- 'maps/*/manifest.json' \
+            | sed 's|maps/||; s|/manifest.json||' | tr '\n' ' ' | xargs || true)"
+          echo "ids=${ids}" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v4
         with:
@@ -49,7 +73,9 @@ jobs:
       - name: Check data-quality consistency
         # --require-presence: post-backfill, every map manifest must carry a
         # data_quality block (plan D5).
-        run: pnpm --dir scripts check-data-quality --require-presence
+        run: >-
+          pnpm --dir scripts check-data-quality --require-presence
+          ${{ steps.added.outputs.ids != '' && format('--require-scored {0}', steps.added.outputs.ids) || '' }}
 
   report:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/process-data-quality.yml
+++ b/.github/workflows/process-data-quality.yml
@@ -2,8 +2,11 @@ name: Process Data Quality Submission
 
 # Phase two of a map submission: parses the data-quality issue form, resolves
 # same-methodology inheritance, writes maps/<id>/data-quality.json
-# (provenance self-reported), and opens a PR with the provisional scores.
-# A maintainer confirms on that PR with the `rescore_data` comment command.
+# (provenance self-reported), and lands it where the map lives:
+# - merged maps: a dq/<id> branch + standalone PR with the provisional scores
+# - unmerged maps: the open publish/map/<id> branch, so the publish PR carries
+#   the answers and stays draft until a maintainer confirms
+# A maintainer confirms with the `rescore_data` comment command on the PR.
 
 on:
   issues:
@@ -65,13 +68,80 @@ jobs:
           template-path: .github/ISSUE_TEMPLATE/data-quality.yml
           issue-body: ${{ github.event.issue.body }}
 
+      - name: Resolve target branch
+        # Unmerged maps (plan C1.2): when the map is not on main but an open
+        # publish branch exists, the answers land on that branch so the publish
+        # PR carries them — review gates the publish merge itself.
+        id: target
+        env:
+          MAP_ID: ${{ fromJson(steps.parser.outputs.jsonString).map-id }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "maps/${MAP_ID}/manifest.json" ] \
+            && git ls-remote --exit-code origin "refs/heads/publish/map/${MAP_ID}" >/dev/null 2>&1; then
+            git fetch origin "publish/map/${MAP_ID}"
+            git checkout -B "publish/map/${MAP_ID}" "origin/publish/map/${MAP_ID}"
+            echo "mode=publish" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=merged" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Validate answers
         env:
           ISSUE_JSON: ${{ steps.parser.outputs.jsonString }}
           ISSUE_AUTHOR_LOGIN: ${{ github.event.issue.user.login }}
         run: pnpm --dir scripts run validate-data-quality
 
+      - name: Commit and push to publish branch
+        if: steps.target.outputs.mode == 'publish'
+        env:
+          MAP_ID: ${{ fromJson(steps.parser.outputs.jsonString).map-id }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add maps/
+          if git diff --cached --quiet; then
+            echo "No changes (answers already on the publish branch)."
+          else
+            git commit -m "chore(data-quality): answers for ${MAP_ID} (self-reported)"
+            git push origin "publish/map/${MAP_ID}"
+          fi
+
+      - name: Comment on publish pull request
+        if: steps.target.outputs.mode == 'publish'
+        id: publish-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const branch = 'publish/map/${{ fromJson(steps.parser.outputs.jsonString).map-id }}';
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open'
+            });
+            if (prs.length === 0) {
+              core.setFailed(`No open PR found for ${branch}`);
+              return;
+            }
+            core.setOutput('number', prs[0].number);
+            let report = '';
+            try {
+              report = fs.readFileSync('dq-validation-report.md', 'utf-8');
+            } catch {}
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prs[0].number,
+              body: 'Self-reported data-quality answers from #${{ github.event.issue.number }} added to this publish PR.\n\n' +
+                report +
+                '\n\nA maintainer confirms by commenting `rescore_data` after review; the PR stays draft until then.'
+            });
+
       - name: Commit and push changes
+        if: steps.target.outputs.mode != 'publish'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -81,6 +151,7 @@ jobs:
           git push --force origin "dq/${{ fromJson(steps.parser.outputs.jsonString).map-id }}"
 
       - name: Create or update pull request
+        if: steps.target.outputs.mode != 'publish'
         uses: actions/github-script@v7
         with:
           script: |
@@ -138,11 +209,15 @@ jobs:
               report = fs.readFileSync('dq-validation-report.md', 'utf-8');
             } catch {}
 
+            const publishPr = '${{ steps.publish-pr.outputs.number }}';
+            const intro = '${{ steps.target.outputs.mode }}' === 'publish'
+              ? `Your data-quality answers have been added to your publish pull request (#${publishPr}). A maintainer will review and confirm them; once confirmed, your map merges with its tier.`
+              : 'A pull request has been created with your data-quality answers. A maintainer will review and confirm it shortly.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: 'A pull request has been created with your data-quality answers. A maintainer will review and confirm it shortly.\n\n' + report
+              body: intro + '\n\n' + report
             });
 
       - name: Handle failure

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -282,6 +282,11 @@ jobs:
               console.log(`PR #${existing[0].number} already exists — updated via force push`);
               return;
             }
+            // Draft until data quality is confirmed (plan C1): GitHub cannot
+            // merge a draft, which is the hard publish gate. rescore_data
+            // marks it ready after confirming the answers; a maintainer can
+            // mark it ready manually to grandfather (add dq-grandfathered so
+            // CI's publish gate is exempted too).
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -291,10 +296,13 @@ jobs:
                 '',
                 'Automated PR to add map `${{ fromJson(steps.parser.outputs.jsonString).map-id }}` to the registry.',
                 '',
-                'Submitted by @${{ github.event.issue.user.login }}'
+                'Submitted by @${{ github.event.issue.user.login }}',
+                '',
+                '**Draft until data quality is confirmed** — the author answers the data-quality questions (invite on the submission issue), then a maintainer reviews and comments `rescore_data` here, which marks this PR ready to merge.'
               ].join('\n'),
               head: branch,
-              base: 'main'
+              base: 'main',
+              draft: true
             });
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -366,7 +374,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: 'A pull request has been created for your map submission. A maintainer will review it shortly.\n\n' +
-                `**Next step — data quality:** once the PR merges, [answer the data-quality questions](${inviteUrl}) so your map can receive its data-quality tier. Until then it is listed as \`unknown-quality\`. The [guide](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/main/docs/data-quality-questions.md) explains every question in plain language.` +
+                `**Required next step — data quality:** [answer the data-quality questions](${inviteUrl}) so your map can receive its data-quality tier. **Your submission cannot merge until a maintainer confirms your answers**; the publish PR stays in draft until then. The [Submission Questions guide](https://subwaybuildermodded.com/registry/docs/data-quality/questions) explains every question in plain language, and new submissions are subject to the [quality floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for countries with existing maps.` +
                 sampleNote
             });
 

--- a/.github/workflows/rescore-data.yml
+++ b/.github/workflows/rescore-data.yml
@@ -122,6 +122,31 @@ jobs:
             git push
           fi
 
+      - name: Mark publish PR ready for review
+        # Publish PRs are created as drafts until data quality is confirmed
+        # (plan C1); a successful rescore_data is that confirmation.
+        if: steps.pr.outputs.cross != 'true' && steps.targets.outputs.ids != '' && steps.apply.outcome == 'success'
+        id: undraft
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            if (!pr.draft || !pr.head.ref.startsWith('publish/map/')) return;
+            await github.graphql(
+              `mutation($id: ID!) {
+                markPullRequestReadyForReview(input: { pullRequestId: $id }) {
+                  pullRequest { number }
+                }
+              }`,
+              { id: pr.node_id },
+            );
+            core.setOutput('undrafted', 'true');
+            console.log(`PR #${pr.number} marked ready for review.`);
+
       - name: Report result
         if: steps.pr.outputs.cross != 'true'
         uses: actions/github-script@v7
@@ -140,6 +165,9 @@ jobs:
               body = ok
                 ? `✅ \`rescore_data\` applied and self-verified (CI does not retrigger on this push):\n\n\`\`\`\n${output}\n\`\`\``
                 : `❌ \`rescore_data\` failed — nothing was pushed:\n\n\`\`\`\n${output}\n\`\`\``;
+              if ("${{ steps.undraft.outputs.undrafted }}" === "true") {
+                body += "\n\nData quality confirmed — this publish PR is now marked **ready for review** and can merge.";
+              }
             }
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/scripts/apply-data-quality.ts
+++ b/scripts/apply-data-quality.ts
@@ -1,7 +1,12 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { readJsonFile } from "./lib/json-utils.js";
-import { applyDataQualityAnswers } from "./lib/data-quality-apply.js";
+import {
+  applyDataQualityAnswers,
+  buildCountryFloorContext,
+  type CountryFloorPeer,
+  type ScoredDataQualityBlock,
+} from "./lib/data-quality-apply.js";
 import { checkMapDataQuality } from "./lib/data-quality-check.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..");
@@ -28,6 +33,40 @@ function parseArgs(argv: string[]): CliArgs {
     }
   }
   return { ids, reviewer, date };
+}
+
+/** Same-country maps with a scored (non-unknown) manifest block, self excluded. */
+function collectCountryPeers(id: string, country: string): CountryFloorPeer[] {
+  if (!country) return [];
+  const peers: CountryFloorPeer[] = [];
+  for (const entry of readdirSync(MAPS_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === id) continue;
+    const manifestPath = resolve(MAPS_DIR, entry.name, "manifest.json");
+    if (!existsSync(manifestPath)) continue;
+    try {
+      const manifest = readJsonFile<Record<string, unknown>>(manifestPath);
+      if (manifest.country !== country) continue;
+      const block = manifest.data_quality as
+        | Partial<ScoredDataQualityBlock>
+        | undefined;
+      if (
+        !block ||
+        block.tier === undefined ||
+        block.tier === ("unknown" as string) ||
+        typeof block.weighted_score !== "number"
+      ) {
+        continue;
+      }
+      peers.push({
+        id: entry.name,
+        tier: block.tier,
+        weightedScore: block.weighted_score,
+      });
+    } catch {
+      // Unreadable manifests never block a confirmation; skip.
+    }
+  }
+  return peers;
 }
 
 function main(): void {
@@ -82,6 +121,12 @@ function main(): void {
       console.log(
         `${id}: ${block.tier} (raw ${block.raw_score}, weighted ${block.weighted_score})${flipped}`,
       );
+      const country = String(manifest.country ?? "");
+      const context = buildCountryFloorContext(
+        { id, country, tier: block.tier },
+        collectCountryPeers(id, country),
+      );
+      for (const line of context.lines) console.log(line);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       failures.push(message);

--- a/scripts/check-data-quality.ts
+++ b/scripts/check-data-quality.ts
@@ -63,11 +63,12 @@ function runReport(paths: string[]): void {
   process.stdout.write(`${buildProvisionalReport(entries)}\n`);
 }
 
-function runCheck(requirePresence: boolean): void {
+function runCheck(requirePresence: boolean, requireScoredIds: string[]): void {
   const ids = listMapIds();
   const errors: string[] = [];
   let scored = 0;
   let withAnswers = 0;
+  const scoredIds = new Set<string>();
 
   for (const id of ids) {
     const manifest = readJsonFile<Record<string, unknown>>(
@@ -83,12 +84,26 @@ function runCheck(requirePresence: boolean): void {
       (dataQuality as Record<string, unknown>).tier !== "unknown"
     ) {
       scored += 1;
+      scoredIds.add(id);
     }
     errors.push(
       ...checkMapDataQuality(
         { id, manifestDataQuality: dataQuality, answersFile },
         { requirePresence },
       ),
+    );
+  }
+
+  // Publish gate (plan C1.3): manifests newly added in a PR must carry a
+  // confirmed scored block before the PR can merge. The workflow computes the
+  // added ids; the dq-grandfathered label bypasses this rule entirely.
+  for (const id of requireScoredIds) {
+    if (scoredIds.has(id)) continue;
+    errors.push(
+      `maps/${id}: new maps require a confirmed data-quality tier before merge — ` +
+        `the author answers the data-quality questions (see the publish issue's invite), ` +
+        `then a maintainer confirms with the \`rescore_data\` PR comment. ` +
+        `Maintainers can exempt this PR with the \`dq-grandfathered\` label.`,
     );
   }
 
@@ -107,5 +122,10 @@ const reportIndex = args.indexOf("--report");
 if (reportIndex !== -1) {
   runReport(args.slice(reportIndex + 1).filter((a) => !a.startsWith("--")));
 } else {
-  runCheck(args.includes("--require-presence"));
+  const requireScoredIndex = args.indexOf("--require-scored");
+  const requireScoredIds =
+    requireScoredIndex === -1
+      ? []
+      : args.slice(requireScoredIndex + 1).filter((a) => !a.startsWith("--"));
+  runCheck(args.includes("--require-presence"), requireScoredIds);
 }

--- a/scripts/generate-map-templates.ts
+++ b/scripts/generate-map-templates.ts
@@ -246,6 +246,19 @@ function withTemplatePolicy(baseDoc: TemplateDoc, mode: TemplateMode): TemplateD
       field.attributes.description =
         "Leave blank to keep current additional cities. Enter `None` to clear. Otherwise, enter a comma-separated list to replace (e.g. `Gdynia, Sopot`).";
     }
+
+    // The publish attestation describes the required data-quality step, which
+    // only applies to NEW submissions; metadata updates never re-gate on it.
+    if (
+      mode === "update" &&
+      type === "markdown" &&
+      field.attributes &&
+      typeof field.attributes.value === "string" &&
+      field.attributes.value.startsWith("## Data Attestation")
+    ) {
+      field.attributes.value =
+        "## Data Attestation\n\nProvide details about your map's data source and level of detail. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nUpdating metadata does not change your map's data-quality tier. If the underlying data changed, submit new answers via the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) form.";
+    }
   }
 
   return doc;
@@ -290,7 +303,7 @@ const SHARED_FIELDS_AFTER_MAP_ID = [
   spacer(),
   // ===== Data Validation ===== //
   markdown(
-    "## Data Attestation\n\nProvide details about your map's data source and level of detail. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/wiki/railyard/latest/developers/data-quality) guide for more information.\n\nAfter your map is published, you will be invited to answer the [data-quality questions](https://github.com/Subway-Builder-Modded/registry/blob/main/docs/data-quality-questions.md) so the map can receive its data-quality tier; until then it is listed as `unknown-quality`.",
+    "## Data Attestation\n\nProvide details about your map's data source and level of detail. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nAfter your submission is validated, you will be invited to answer the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — a **required step**: your map cannot merge until a maintainer confirms your answers, and new submissions are subject to the [quality floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for countries with existing maps.",
   ),
   input(
     "data_source",
@@ -463,11 +476,11 @@ const dataQualityTemplateBaseDoc: TemplateDoc = {
   labels: ["data-quality"],
   body: [
     markdown(
-      "# Map Data Quality\n\nThese questions classify the census / official data behind your map so it can receive a data-quality tier. Every question is optional — **leaving a question blank is always safe** — but unanswered questions may keep the map at `unknown-quality` until a reviewer works through them with you.\n\nPlease read the [Data Quality Questions guide](https://github.com/Subway-Builder-Modded/registry/blob/main/docs/data-quality-questions.md) — it explains each question in plain language, including the golden rule: **answer with where the numbers are published, not where you placed them**.\n\nYour answers produce a provisional score in a pull request; a reviewer confirms it before the tier appears.\n\nIf validation fails, you can edit this issue and comment **revalidate** to retry.",
+      "# Map Data Quality\n\nThese questions classify the census / official data behind your map so it can receive a data-quality tier. Every question is optional — **leaving a question blank is always safe** — but unanswered questions may keep the map at `unknown-quality` until a reviewer works through them with you.\n\nPlease read the [Submission Questions guide](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — it explains each question in plain language, including the golden rule: **answer with where the numbers are published, not where you placed them**.\n\nYour answers produce a provisional score in a pull request; a reviewer confirms it before the tier appears.\n\nIf validation fails, you can edit this issue and comment **revalidate** to retry.",
     ),
     spacer(),
     mapIdField(
-      "The ID of the map these answers describe. Must already exist in the registry and be published by your GitHub account.",
+      "The ID of the map these answers describe. Must already exist in the registry — or have an open publish submission — and be published by your GitHub account.",
     ),
     dropdown(
       "same-methodology",

--- a/scripts/lib/data-quality-apply.ts
+++ b/scripts/lib/data-quality-apply.ts
@@ -1,8 +1,11 @@
 import {
+  DATA_QUALITY_TIERS,
   DataQualityAnswersFileSchema,
   RUBRIC_VERSION,
   type DataQualityAnswersFile,
+  type DataQualityTier,
   type ManifestDataQuality,
+  type ScoredDataQualityTier,
 } from "@subway-builder-modded/registry-schemas";
 import {
   computeScores,
@@ -93,4 +96,71 @@ export function applyDataQualityAnswers(
   };
 
   return { id, answersFile, manifestBlock, scores, provenanceFlipped };
+}
+
+/** A same-country map considered for the quality-floor context. */
+export interface CountryFloorPeer {
+  id: string;
+  tier: ScoredDataQualityTier;
+  weightedScore: number;
+}
+
+export interface CountryFloorContext {
+  /** Plain-text lines for the (code-fenced) rescore_data comment. */
+  lines: string[];
+  /** True when the confirmed tier sits below the country's best scored tier. */
+  floorViolation: boolean;
+}
+
+function tierRank(tier: DataQualityTier): number {
+  return DATA_QUALITY_TIERS.indexOf(tier);
+}
+
+/**
+ * Builds the country quality-floor context shown in the rescore_data
+ * confirmation comment: the country's other scored maps ranked best-first,
+ * plus an explicit FLOOR VIOLATION line when the newly confirmed tier falls
+ * below the country's demonstrated best. Advisory by design — whether the
+ * city-specific exception applies is reviewer judgment (see the Quality
+ * Floor policy).
+ */
+export function buildCountryFloorContext(
+  target: { id: string; country: string; tier: ScoredDataQualityTier },
+  peers: CountryFloorPeer[],
+): CountryFloorContext {
+  const country = target.country || "??";
+  if (peers.length === 0) {
+    return {
+      lines: [
+        `Country floor (${country}): no other scored maps — this confirmation sets the floor.`,
+      ],
+      floorViolation: false,
+    };
+  }
+
+  const sorted = [...peers].sort(
+    (a, b) =>
+      tierRank(a.tier) - tierRank(b.tier) || b.weightedScore - a.weightedScore,
+  );
+  const best = sorted[0];
+  const lines = [
+    `Country floor context (${country}):`,
+    ...sorted.map(
+      (peer) =>
+        `  ${peer.tier} (${peer.weightedScore.toFixed(2)})  ${peer.id}`,
+    ),
+  ];
+
+  const floorViolation = tierRank(target.tier) > tierRank(best.tier);
+  if (floorViolation) {
+    lines.push(
+      `FLOOR VIOLATION: ${target.id} confirmed at ${target.tier}, below the ${country} floor of ${best.tier} (set by ${best.id}).`,
+      `A city-specific exception may apply — reviewer judgment. See the Quality Floor policy before merging.`,
+    );
+  } else {
+    lines.push(
+      `${target.id} (${target.tier}) meets the ${country} floor (${best.tier}, set by ${best.id}).`,
+    );
+  }
+  return { lines, floorViolation };
 }

--- a/scripts/tests/data-quality-apply.unit.test.ts
+++ b/scripts/tests/data-quality-apply.unit.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { applyDataQualityAnswers } from "../lib/data-quality-apply.js";
+import {
+  applyDataQualityAnswers,
+  buildCountryFloorContext,
+} from "../lib/data-quality-apply.js";
 import { checkMapDataQuality } from "../lib/data-quality-check.js";
 import type { DataQualityAnswers } from "../lib/data-quality.js";
 
@@ -107,4 +110,46 @@ test("rejects id mismatches and invalid files", () => {
     () => applyDataQualityAnswers(ID, { schema_version: 1 }, OPTIONS),
     /is invalid/,
   );
+});
+
+test("country floor context: no peers sets the floor", () => {
+  const context = buildCountryFloorContext(
+    { id: ID, country: "TW", tier: "high" },
+    [],
+  );
+  assert.equal(context.floorViolation, false);
+  assert.match(context.lines[0], /no other scored maps — this confirmation sets the floor/);
+});
+
+test("country floor context: meeting the floor lists peers best-first", () => {
+  const context = buildCountryFloorContext(
+    { id: ID, country: "TW", tier: "high" },
+    [
+      { id: "tw-low", tier: "low", weightedScore: 0.35 },
+      { id: "tw-high", tier: "high", weightedScore: 0.65 },
+      { id: "tw-high-2", tier: "high", weightedScore: 0.61 },
+    ],
+  );
+  assert.equal(context.floorViolation, false);
+  assert.deepEqual(context.lines, [
+    "Country floor context (TW):",
+    "  high (0.65)  tw-high",
+    "  high (0.61)  tw-high-2",
+    "  low (0.35)  tw-low",
+    `${ID} (high) meets the TW floor (high, set by tw-high).`,
+  ]);
+});
+
+test("country floor context: flags a violation below the country's best tier", () => {
+  const context = buildCountryFloorContext(
+    { id: "istanbul-mini", country: "TR", tier: "low" },
+    [{ id: "istanbul-detailed", tier: "medium", weightedScore: 0.47 }],
+  );
+  assert.equal(context.floorViolation, true);
+  const violation = context.lines.find((line) => line.startsWith("FLOOR VIOLATION"));
+  assert.match(
+    violation ?? "",
+    /istanbul-mini confirmed at low, below the TR floor of medium \(set by istanbul-detailed\)/,
+  );
+  assert.match(context.lines.at(-1) ?? "", /city-specific exception may apply/);
 });

--- a/scripts/validate-data-quality.ts
+++ b/scripts/validate-data-quality.ts
@@ -50,9 +50,14 @@ function main(): void {
   const { input, errors } = parseDataQualityIssue(data);
   if (!input) fail(errors);
 
+  // The workflow checks out the open publish/map/<id> branch first when the
+  // map is not yet on main, so an unmerged submission's manifest is present
+  // here too. Reaching this failure means neither exists.
   const manifestPath = resolve(MAPS_DIR, input.mapId, "manifest.json");
   if (!existsSync(manifestPath)) {
-    fail([`**map-id**: No map \`${input.mapId}\` exists in the registry.`]);
+    fail([
+      `**map-id**: No map \`${input.mapId}\` exists in the registry or in a pending publish submission. Submit the map first (**Publish New Map**) — the data-quality invite follows automatically.`,
+    ]);
   }
   const manifest = readJsonFile<Record<string, unknown>>(manifestPath);
   if (manifest.author !== issueAuthorLogin) {


### PR DESCRIPTION
Registry PR 2 of the data-quality docs-and-blocking plan (the website docs suite shipped separately and is live on the dev site; production ships with the monorepo release train).

## The gate

**New map publish PRs are created as drafts** and stay draft until a maintainer confirms the submission's data-quality answers with `rescore_data` — GitHub cannot merge a draft, so this is a hard block with no branch-protection changes. This mechanism was chosen because publish PRs are created/pushed by `GITHUB_TOKEN`, which never triggers `pull_request` CI — a CI-only rule would never run on exactly the PRs it needs to block.

- **Flow**: publish issue → draft PR + required data-quality invite → author answers the questions → answers land **on the publish branch** (the publish PR carries both the listing and its provisional score) → maintainer reviews, comments `rescore_data` → answers confirmed, manifest stamped, **PR marked ready for review** → normal code-owner review + merge.
- **Grandfather valve**: a maintainer marks the PR ready manually and applies the `dq-grandfathered` label (exempts the CI gate below). The map merges as `unknown-quality`.
- **Defense-in-depth CI rule**: `check-data-quality --require-scored` fails a PR whose *added* manifests lack a confirmed tier (runs on human-pushed PRs; `labeled`/`unlabeled` retrigger it so the label works without a new push).

## Floor enforcement (advisory, plan E1)

`rescore_data`'s confirmation comment now includes a country floor context — the country's scored maps best-first, with an explicit `FLOOR VIOLATION` line when the confirmed tier falls below the country's best. Whether the city-specific exception applies stays reviewer judgment, per the Quality Floor policy page.

## Link hygiene (C3)

Issue forms and invite comments move off the dead `/wiki/...` URL and GitHub blob links to `https://subwaybuildermodded.com/registry/docs/data-quality` (+ `/questions`, `/quality-floor`). The update-map attestation gets update-specific wording (metadata updates never re-gate). Templates regenerated.

## Follow-up (not in this PR)

- C2 sweep: required invites + draft conversion on the ~7 open publish map issues
- Phase 2 (if needed): curated `quality-floors.json` hard enforcement

All 264 script tests pass; gate smoke-tested both directions; floor context smoke-tested on the TW cohort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)