### PR TITLE
feat(workflows): optional bot-app identity so publish PRs get CI + instant validation ack

### DIFF
--- a/.github/workflows/bot-token-smoke.yml
+++ b/.github/workflows/bot-token-smoke.yml
@@ -9,6 +9,11 @@ name: Bot Token Smoke Test
 
 on:
   workflow_dispatch:
+  # Branch-only workflows cannot be dispatched by name; touching this file on
+  # the branch re-runs the smoke test instead.
+  push:
+    branches: [feat/publish-ci-bot-token]
+    paths: [".github/workflows/bot-token-smoke.yml"]
 
 permissions:
   contents: write

--- a/.github/workflows/bot-token-smoke.yml
+++ b/.github/workflows/bot-token-smoke.yml
@@ -1,0 +1,68 @@
+name: Bot Token Smoke Test
+
+# Manual diagnostic for the registry bot app (REGISTRY_BOT_APP_ID variable +
+# REGISTRY_BOT_PRIVATE_KEY secret): mints an installation token, pushes a
+# scratch branch touching maps/ with it, and opens a draft PR — if the app is
+# healthy, pull_request CI (e.g. Check Data Quality) appears on that PR within
+# a minute, which GITHUB_TOKEN pushes can never do. Clean up by closing the PR
+# and deleting the test/bot-token-smoke branch.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.bot-token.outputs.token }}
+
+      - name: Push scratch branch with app identity
+        run: |
+          set -euo pipefail
+          git config user.name "registry-bot-smoke"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B test/bot-token-smoke
+          date -u > maps/.bot-token-smoke
+          git add maps/.bot-token-smoke
+          git commit -m "test: bot token smoke (safe to delete)"
+          git push --force origin test/bot-token-smoke
+
+      - name: Open draft PR with app token
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.bot-token.outputs.token }}
+          script: |
+            const head = `${context.repo.owner}:test/bot-token-smoke`;
+            const { data: existing } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head,
+              state: 'open',
+            });
+            if (existing.length > 0) {
+              console.log(`Smoke PR already open: #${existing[0].number}`);
+              return;
+            }
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'test: bot token smoke (do not merge)',
+              body: 'Scratch PR from the Bot Token Smoke Test workflow. If the bot app is healthy, CI checks appear here within a minute. Close and delete the branch when done.',
+              head: 'test/bot-token-smoke',
+              base: 'main',
+              draft: true,
+            });
+            console.log(`Opened smoke PR #${pr.number} — check whether CI checks appear on it.`);

--- a/.github/workflows/process-data-quality.yml
+++ b/.github/workflows/process-data-quality.yml
@@ -33,7 +33,20 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      # Optional CI-triggering bot identity — see publish.yml. With it, the
+      # push carrying the answers retriggers CI on the target PR (provisional
+      # report + publish gate); without it the flow still works, comment-only.
+      - name: Mint bot token
+        id: bot-token
+        if: vars.REGISTRY_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.bot-token.outputs.token || github.token }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -48,6 +61,19 @@ jobs:
       - name: Install script dependencies
         run: pnpm install --frozen-lockfile
         working-directory: scripts
+
+      - name: Acknowledge submission
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Validating your data-quality answers — [follow the run here](${runUrl}). Results are posted in this issue when it finishes (usually a few minutes).`
+            });
 
       - name: Acknowledge revalidation
         if: github.event_name == 'issue_comment'
@@ -154,6 +180,7 @@ jobs:
         if: steps.target.outputs.mode != 'publish'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.bot-token.outputs.token || github.token }}
           script: |
             const branch = 'dq/${{ fromJson(steps.parser.outputs.jsonString).map-id }}';
             const { data: existing } = await github.rest.pulls.list({

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,23 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      # CI-triggering identity (optional): pushes and PRs made with the
+      # workflow's GITHUB_TOKEN never trigger pull_request workflows, so
+      # publish PRs get no CI. When the registry bot app is configured
+      # (REGISTRY_BOT_APP_ID repo variable + REGISTRY_BOT_PRIVATE_KEY secret),
+      # branch pushes and PR creation use its token instead and CI runs
+      # normally. Falls back to GITHUB_TOKEN when unconfigured.
+      - name: Mint bot token
+        id: bot-token
+        if: vars.REGISTRY_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.bot-token.outputs.token || github.token }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -40,6 +56,19 @@ jobs:
       - name: Install script dependencies
         run: pnpm install --frozen-lockfile
         working-directory: scripts
+
+      - name: Acknowledge submission
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Validating your submission — [follow the run here](${runUrl}). Results are posted in this issue when it finishes (usually a few minutes).`
+            });
 
       - name: Acknowledge revalidation
         if: github.event_name == 'issue_comment'
@@ -92,6 +121,7 @@ jobs:
       - name: Create or update pull request
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.bot-token.outputs.token || github.token }}
           script: |
             const branch = 'publish/mod/${{ fromJson(steps.parser.outputs.jsonString).mod-id }}';
             const { data: existing } = await github.rest.pulls.list({
@@ -188,7 +218,18 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      # See the publish-mod job for why this optional bot identity exists.
+      - name: Mint bot token
+        id: bot-token
+        if: vars.REGISTRY_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.bot-token.outputs.token || github.token }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -203,6 +244,19 @@ jobs:
       - name: Install script dependencies
         run: pnpm install --frozen-lockfile
         working-directory: scripts
+
+      - name: Acknowledge submission
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Validating your submission — [follow the run here](${runUrl}). Results are posted in this issue when it finishes (usually a few minutes).`
+            });
 
       - name: Acknowledge revalidation
         if: github.event_name == 'issue_comment'
@@ -270,6 +324,7 @@ jobs:
       - name: Create or update pull request
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.bot-token.outputs.token || github.token }}
           script: |
             const branch = 'publish/map/${{ fromJson(steps.parser.outputs.jsonString).map-id }}';
             const { data: existing } = await github.rest.pulls.list({

--- a/.github/workflows/rescore-data.yml
+++ b/.github/workflows/rescore-data.yml
@@ -7,9 +7,11 @@ name: Rescore Data
 # map's manifest, and pushes the result to the PR branch. Optional arguments
 # select specific maps: `rescore_data map-id-a map-id-b`.
 #
-# The commit is pushed with GITHUB_TOKEN, which does NOT retrigger the PR's CI
-# — the CLI runs the same consistency verification itself and the result is
-# posted in the confirmation comment.
+# When the registry bot app is configured (REGISTRY_BOT_APP_ID variable +
+# REGISTRY_BOT_PRIVATE_KEY secret), the confirmation commit is pushed with its
+# token so the PR's CI re-runs on it. Without it the push uses GITHUB_TOKEN,
+# which does NOT retrigger CI — the CLI runs the same consistency verification
+# itself either way and the result is posted in the confirmation comment.
 
 on:
   issue_comment:
@@ -41,9 +43,18 @@ jobs:
               content: "eyes",
             });
 
+      - name: Mint bot token
+        id: bot-token
+        if: vars.REGISTRY_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.bot-token.outputs.token || github.token }}
 
       - name: Check out PR branch
         id: pr
@@ -162,8 +173,11 @@ jobs:
                 ? fs.readFileSync("apply-output.txt", "utf8").trim()
                 : "(no output)";
               const ok = "${{ steps.apply.outcome }}" === "success";
+              const ciNote = "${{ steps.bot-token.outcome }}" === "success"
+                ? "CI re-runs on the pushed commit"
+                : "CI does not retrigger on this push";
               body = ok
-                ? `✅ \`rescore_data\` applied and self-verified (CI does not retrigger on this push):\n\n\`\`\`\n${output}\n\`\`\``
+                ? `✅ \`rescore_data\` applied and self-verified (${ciNote}):\n\n\`\`\`\n${output}\n\`\`\``
                 : `❌ \`rescore_data\` failed — nothing was pushed:\n\n\`\`\`\n${output}\n\`\`\``;
               if ("${{ steps.undraft.outputs.undrafted }}" === "true") {
                 body += "\n\nData quality confirmed — this publish PR is now marked **ready for review** and can merge.";


### PR DESCRIPTION
Follow-up to #6256. Publish/dq PRs are created and pushed with `GITHUB_TOKEN`, which never triggers `pull_request` workflows — so no CI (including the new `--require-scored` publish gate) ever runs on them. This PR adds an **optional GitHub App identity** for those pushes/PR creations, plus an instant acknowledgment comment for submitters.

## What changes

- **`publish.yml`, `process-data-quality.yml`, `rescore-data.yml`**: when the app is configured, a short-lived installation token is minted (`actions/create-github-app-token`) and used for the branch push and PR creation. Events caused by the app trigger workflows normally, so publish PRs get real CI: the data-quality gate goes red until confirmed, the provisional-score report posts automatically when answers land, and `rescore_data`'s confirmation commit is re-verified by CI (its comment states which behavior applied).
- **Graceful fallback**: with the app unconfigured, every workflow behaves exactly as today (`GITHUB_TOKEN`, comment-only). Merging this PR changes nothing until the secrets exist.
- **Instant ack**: opening a publish or data-quality issue now gets an immediate "Validating your submission — follow the run here" comment with a link to the Actions run, closing the silent window before the bot's validation reply. `revalidate` keeps its 👀 reaction.
- Scope is deliberately limited to these three workflows — the hourly metadata/download bots keep their cheap no-CI behavior, and the **draft mechanism from #6256 remains the hard merge gate** (CI here is signal, not the lock).

## One-time setup (admin, ~30 min)

1. Register a GitHub App on the org (e.g. `railyard-registry-bot`): no webhook; repository permissions **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write**.
2. Generate a private key; install the app on `Subway-Builder-Modded/registry`.
3. In the registry repo settings, add repo **variable** `REGISTRY_BOT_APP_ID` (the app's numeric ID) and **secret** `REGISTRY_BOT_PRIVATE_KEY` (the PEM contents).

The IDE/actionlint warning "Context access might be invalid" on those two names is expected until they exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)