### PR TITLE
Unify maintainer/supporter credits under authors/index.json

### DIFF
--- a/authors/index.json
+++ b/authors/index.json
@@ -31,7 +31,10 @@
       "discord_id": "1434489559605055508",
       "attribution_link": "https://github.com/stefanorigano",
       "ko_fi_username": "stenori",
-      "contributor_tier": "executive"
+      "contributor_tier": "executive",
+      "credit_roles": [
+        "supporter"
+      ]
     },
     {
       "github_id": 8761780,
@@ -48,7 +51,10 @@
       "discord_username": "_yukina-",
       "discord_id": "146677783299358720",
       "attribution_link": "https://subwaybuildermodded.com/credits",
-      "contributor_tier": "developer"
+      "contributor_tier": "developer",
+      "credit_roles": [
+        "maintainer"
+      ]
     },
     {
       "github_id": 28826346,
@@ -63,7 +69,10 @@
       "author_alias": "Kronifer",
       "attribution_method": "github",
       "attribution_link": "https://github.com/Kronifer",
-      "contributor_tier": "developer"
+      "contributor_tier": "developer",
+      "credit_roles": [
+        "maintainer"
+      ]
     },
     {
       "github_id": 51029078,
@@ -97,7 +106,10 @@
       "discord_id": "735183767945216021",
       "attribution_link": "https://github.com/Maximilian284",
       "ko_fi_username": "max02",
-      "contributor_tier": "engineer"
+      "contributor_tier": "engineer",
+      "credit_roles": [
+        "supporter"
+      ]
     },
     {
       "github_id": 63876261,
@@ -172,7 +184,10 @@
       "author_alias": "slurry",
       "attribution_method": "github",
       "attribution_link": "https://github.com/rslurry",
-      "contributor_tier": "developer"
+      "contributor_tier": "developer",
+      "credit_roles": [
+        "maintainer"
+      ]
     },
     {
       "github_id": 112905459,
@@ -228,7 +243,10 @@
       "discord_username": "kaicardenas2",
       "discord_id": "1456791639346381013",
       "attribution_link": "https://github.com/kaicardenas0618",
-      "contributor_tier": "developer"
+      "contributor_tier": "developer",
+      "credit_roles": [
+        "maintainer"
+      ]
     },
     {
       "github_id": 156072592,
@@ -348,6 +366,28 @@
       "author_alias": "pierreggt",
       "attribution_method": "github",
       "attribution_link": "https://github.com/pierreggt"
+    },
+    {
+      "author_id": "Bill",
+      "author_alias": "Bill",
+      "attribution_method": "custom",
+      "attribution_link": "https://ko-fi.com/H4C223IBGR",
+      "ko_fi_username": "H4C223IBGR",
+      "contributor_tier": "executive",
+      "credit_roles": [
+        "supporter"
+      ]
+    },
+    {
+      "author_id": "ByteOfBacon",
+      "author_alias": "ByteOfBacon",
+      "attribution_method": "custom",
+      "attribution_link": "https://github.com/ByteOfBacon",
+      "ko_fi_username": "F1F6123UV",
+      "contributor_tier": "conductor",
+      "credit_roles": [
+        "supporter"
+      ]
     }
   ]
 }

--- a/scripts/lib/author-aliases.ts
+++ b/scripts/lib/author-aliases.ts
@@ -3,10 +3,13 @@ import { dirname, resolve } from "node:path";
 import { isObject } from "./json-utils.js";
 
 export type AttributionMethod = "github" | "discord" | "custom";
-export type ContributorTier = "developer" | "executive" | "engineer" | "collaborator";
+export type ContributorTier = "developer" | "executive" | "engineer" | "conductor" | "collaborator";
+export type CreditRole = "maintainer" | "supporter";
 
 export interface AuthorAliasEntry {
-  github_id: number;
+  // Absent for credit-only entries (supporters/maintainers without a GitHub
+  // account); those are keyed by author_id instead.
+  github_id?: number;
   author_id?: string;
   author_alias?: string;
   attribution_method?: AttributionMethod;
@@ -15,6 +18,10 @@ export interface AuthorAliasEntry {
   attribution_link?: string;
   ko_fi_username?: string;
   contributor_tier?: ContributorTier;
+  // Which credits sections (website + app) this person appears in. Authors of
+  // listings appear in credits regardless; these roles cover maintainers and
+  // ko-fi supporters, who may have no listings at all (issue #1901).
+  credit_roles?: CreditRole[];
 }
 
 export interface AuthorAliasIndex {
@@ -39,10 +46,30 @@ function parseAttributionMethod(value: unknown): AttributionMethod {
 }
 
 function parseContributorTier(value: unknown): ContributorTier | undefined {
-  if (value === "developer" || value === "executive" || value === "engineer" || value === "collaborator") {
+  if (
+    value === "developer" || value === "executive" || value === "engineer"
+    || value === "conductor" || value === "collaborator"
+  ) {
     return value;
   }
   return undefined;
+}
+
+function parseCreditRoles(value: unknown): CreditRole[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const roles = value.filter((role): role is CreditRole => role === "maintainer" || role === "supporter");
+  return roles.length > 0 ? roles : undefined;
+}
+
+// GitHub-backed entries first (by id), then credit-only entries (by author_id)
+// so rewrites are deterministic.
+function sortAuthorEntries(authors: AuthorAliasEntry[]): AuthorAliasEntry[] {
+  return [...authors].sort((a, b) => {
+    const aId = a.github_id ?? Number.POSITIVE_INFINITY;
+    const bId = b.github_id ?? Number.POSITIVE_INFINITY;
+    if (aId !== bId) return aId - bId;
+    return (a.author_id ?? "").localeCompare(b.author_id ?? "");
+  });
 }
 
 function trimmedStringOrUndefined(value: unknown): string | undefined {
@@ -70,7 +97,9 @@ export function loadAuthorAliasIndex(repoRoot: string): AuthorAliasIndex {
     const authors = raw.authors
       .filter((entry): entry is Record<string, unknown> => isObject(entry))
       .map((entry) => ({
-        github_id: typeof entry.github_id === "number" && Number.isFinite(entry.github_id) ? entry.github_id : 0,
+        github_id: typeof entry.github_id === "number" && Number.isFinite(entry.github_id) && entry.github_id > 0
+          ? entry.github_id
+          : undefined,
         author_id: trimmedStringOrUndefined(entry.author_id),
         author_alias: trimmedStringOrUndefined(entry.author_alias),
         attribution_method: parseAttributionMethod(entry.attribution_method),
@@ -79,13 +108,15 @@ export function loadAuthorAliasIndex(repoRoot: string): AuthorAliasIndex {
         attribution_link: trimmedStringOrUndefined(entry.attribution_link),
         ko_fi_username: trimmedStringOrUndefined(entry.ko_fi_username),
         contributor_tier: parseContributorTier(entry.contributor_tier),
+        credit_roles: parseCreditRoles(entry.credit_roles),
       }))
-      .filter((entry) => entry.github_id > 0)
-      .sort((a, b) => a.github_id - b.github_id);
+      // Credit-only entries (no GitHub account) are keyed by author_id;
+      // entries with neither identity are dropped as malformed.
+      .filter((entry) => entry.github_id !== undefined || entry.author_id !== undefined);
 
     return {
       schema_version: 1,
-      authors,
+      authors: sortAuthorEntries(authors),
     };
   } catch {
     return { schema_version: 1, authors: [] };
@@ -180,10 +211,10 @@ export function updateAuthorEntry(
     entry.attribution_link = updates.attribution_link;
   }
 
-  const authors = [
+  const authors = sortAuthorEntries([
     ...index.authors.filter((e) => e.github_id !== githubId),
     entry,
-  ].sort((a, b) => a.github_id - b.github_id);
+  ]);
 
   return { schema_version: 1, authors };
 }
@@ -205,7 +236,7 @@ export function ensureAuthorAliasPrefill(
     return { created: false, path };
   }
 
-  const authors: AuthorAliasEntry[] = [
+  const authors: AuthorAliasEntry[] = sortAuthorEntries([
     ...index.authors,
     {
       github_id: githubId,
@@ -214,7 +245,7 @@ export function ensureAuthorAliasPrefill(
       attribution_method: "github" as AttributionMethod,
       attribution_link: `https://github.com/${normalizedAuthorLogin}`,
     },
-  ].sort((a, b) => a.github_id - b.github_id);
+  ]);
 
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(

--- a/scripts/tests/author-aliases.unit.test.ts
+++ b/scripts/tests/author-aliases.unit.test.ts
@@ -223,3 +223,99 @@ test("updateAuthorEntry stores discord fields without affecting attribution", ()
   assert.equal(alice.discord_id, "123456789012345678");
   assert.equal(alice.attribution_method, "github");
 });
+
+test("loadAuthorAliasIndex keeps credit-only entries (no github_id) with roles and conductor tier", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "railyard-author-credit-only-test-"));
+  try {
+    writeJson(join(repoRoot, "authors", "index.json"), {
+      schema_version: 1,
+      authors: [
+        {
+          github_id: 10,
+          author_id: "alice",
+          author_alias: "Alice",
+          credit_roles: ["maintainer"],
+        },
+        {
+          author_id: "supporter-only",
+          author_alias: "Supporter",
+          attribution_method: "custom",
+          attribution_link: "https://ko-fi.com/supporter",
+          ko_fi_username: "supporter-kofi",
+          contributor_tier: "conductor",
+          credit_roles: ["supporter"],
+        },
+      ],
+    });
+
+    const aliases = loadAuthorAliasIndex(repoRoot);
+    assert.equal(aliases.authors.length, 2);
+    const supporter = aliases.authors.find((entry) => entry.author_id === "supporter-only");
+    assert.ok(supporter);
+    assert.equal(supporter.github_id, undefined);
+    assert.equal(supporter.contributor_tier, "conductor");
+    assert.deepEqual(supporter.credit_roles, ["supporter"]);
+    const alice = aliases.authors.find((entry) => entry.author_id === "alice");
+    assert.ok(alice);
+    assert.deepEqual(alice.credit_roles, ["maintainer"]);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("ensureAuthorAliasPrefill rewrite preserves credit-only entries", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "railyard-author-credit-rewrite-test-"));
+  try {
+    writeJson(join(repoRoot, "authors", "index.json"), {
+      schema_version: 1,
+      authors: [
+        {
+          author_id: "supporter-only",
+          author_alias: "Supporter",
+          attribution_method: "custom",
+          attribution_link: "https://ko-fi.com/supporter",
+          contributor_tier: "executive",
+          credit_roles: ["supporter"],
+        },
+      ],
+    });
+
+    const result = ensureAuthorAliasPrefill(repoRoot, 20, "newauthor");
+    assert.equal(result.created, true);
+
+    const raw = JSON.parse(readFileSync(join(repoRoot, "authors", "index.json"), "utf-8")) as {
+      authors: Array<{ author_id?: string; github_id?: number; credit_roles?: string[] }>;
+    };
+    assert.equal(raw.authors.length, 2);
+    // GitHub-backed entries sort first; credit-only entries follow.
+    assert.equal(raw.authors[0].github_id, 20);
+    assert.equal(raw.authors[1].author_id, "supporter-only");
+    assert.deepEqual(raw.authors[1].credit_roles, ["supporter"]);
+    assert.equal("github_id" in raw.authors[1], false);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("updateAuthorEntry preserves credit-only entries and their order", () => {
+  const index: AuthorAliasIndex = {
+    schema_version: 1,
+    authors: [
+      { github_id: 10, author_id: "alice", author_alias: "Alice", attribution_method: "github" },
+      {
+        author_id: "supporter-only",
+        author_alias: "Supporter",
+        attribution_method: "custom",
+        contributor_tier: "engineer",
+        credit_roles: ["supporter"],
+      },
+    ],
+  };
+
+  const result = updateAuthorEntry(index, 10, "alice", { author_alias: "Alice Prime" });
+  assert.equal(result.authors.length, 2);
+  assert.equal(result.authors[0].github_id, 10);
+  assert.equal(result.authors[0].author_alias, "Alice Prime");
+  assert.equal(result.authors[1].author_id, "supporter-only");
+  assert.deepEqual(result.authors[1].credit_roles, ["supporter"]);
+});


### PR DESCRIPTION
Part 1 of resolving #1901 ("Unify Maintainer Credits ... taking into account not all collaborators/devs will be authors").

## Problem
Tier/credit data is duplicated three ways today — `authors/index.json`, `credits/supporters.json`, `credits/maintainers.json` — all hand-synced. Worse, `loadAuthorAliasIndex` filtered out any entry without a positive `github_id` and **rewrites the whole file on every listing publish**, so a GitHub-less supporter added to the index would be silently deleted.

## Changes
- Credit-only entries (no `github_id`, keyed by `author_id`) are now first-class in the alias index; deterministic sort puts GitHub-backed entries first (by id), credit-only after (by author_id).
- New `credit_roles: ("maintainer" | "supporter")[]` field; tier vocabulary gains `conductor` (already rendered by both the app and website tier styles).
- Data: roles stamped on the six tiered authors; credit-only supporter entries added for **Bill** (executive) and **ByteOfBacon** (conductor) — the two people who currently cannot appear in the app credits modal.
- Tests: 3 new cases proving credit-only entries survive `ensureAuthorAliasPrefill` and `updateAuthorEntry` rewrites (267/267 pass).

## Compatibility with shipped app clients
- The Go app parses only `author_id/author_alias/attribution_link/contributor_tier` from the index — unknown fields are ignored and `github_id` isn't even read; no historical app version ever read it either.
- Credit-only entries are never resolved by `resolveManifestAuthor` (no manifest references them), so old clients never see them or the `conductor` tier.

## Sequencing
`credits/*.json` is untouched here. Next: monorepo PR points the website credits page at its already-materialized authors index copy and surfaces credited non-authors in the app modal; after that deploys, a final registry PR prunes `credits/` and closes #1901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)