### PR TITLE
fix(data-quality): run dq tooling from main against stale publish branches

### DIFF
--- a/.github/workflows/process-data-quality.yml
+++ b/.github/workflows/process-data-quality.yml
@@ -98,6 +98,11 @@ jobs:
         # Unmerged maps (plan C1.2): when the map is not on main but an open
         # publish branch exists, the answers land on that branch so the publish
         # PR carries them — review gates the publish merge itself.
+        #
+        # Only the submission's maps/<id> directory is overlaid; the working
+        # tree stays on main so validation runs with current scripts/schemas.
+        # Old publish branches predate the data-quality tooling entirely —
+        # checking out the whole branch broke on "Missing script".
         id: target
         env:
           MAP_ID: ${{ fromJson(steps.parser.outputs.jsonString).map-id }}
@@ -106,7 +111,7 @@ jobs:
           if [ ! -f "maps/${MAP_ID}/manifest.json" ] \
             && git ls-remote --exit-code origin "refs/heads/publish/map/${MAP_ID}" >/dev/null 2>&1; then
             git fetch origin "publish/map/${MAP_ID}"
-            git checkout -B "publish/map/${MAP_ID}" "origin/publish/map/${MAP_ID}"
+            git checkout FETCH_HEAD -- "maps/${MAP_ID}"
             echo "mode=publish" >> "$GITHUB_OUTPUT"
           else
             echo "mode=merged" >> "$GITHUB_OUTPUT"
@@ -126,12 +131,21 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add maps/
+          # Commit through a worktree pinned to the publish branch tip: the
+          # main working tree only holds the maps/<id> overlay + validation
+          # output, never a full checkout of the (possibly stale) branch.
+          git fetch origin "publish/map/${MAP_ID}"
+          git worktree add /tmp/publish-branch FETCH_HEAD
+          mkdir -p "/tmp/publish-branch/maps/${MAP_ID}"
+          cp "maps/${MAP_ID}/data-quality.json" "/tmp/publish-branch/maps/${MAP_ID}/"
+          cp "maps/${MAP_ID}/manifest.json" "/tmp/publish-branch/maps/${MAP_ID}/"
+          cd /tmp/publish-branch
+          git add "maps/${MAP_ID}"
           if git diff --cached --quiet; then
             echo "No changes (answers already on the publish branch)."
           else
             git commit -m "chore(data-quality): answers for ${MAP_ID} (self-reported)"
-            git push origin "publish/map/${MAP_ID}"
+            git push origin "HEAD:publish/map/${MAP_ID}"
           fi
 
       - name: Comment on publish pull request

--- a/.github/workflows/rescore-data.yml
+++ b/.github/workflows/rescore-data.yml
@@ -56,19 +56,27 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.bot-token.outputs.token || github.token }}
 
-      - name: Check out PR branch
+      - name: Locate PR branch
+        # The working tree stays on main so the apply CLI runs with current
+        # scripts/schemas — publish branches can be arbitrarily old (some
+        # predate the data-quality tooling). The PR's maps/<id> directories
+        # are overlaid below; commits go through a worktree pinned to the
+        # PR head.
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          cross="$(gh pr view "${{ github.event.issue.number }}" --json isCrossRepository -q .isCrossRepository)"
+          info="$(gh pr view "${{ github.event.issue.number }}" --json isCrossRepository,headRefName)"
+          cross="$(echo "$info" | jq -r .isCrossRepository)"
+          head_ref="$(echo "$info" | jq -r .headRefName)"
           echo "cross=${cross}" >> "$GITHUB_OUTPUT"
+          echo "head_ref=${head_ref}" >> "$GITHUB_OUTPUT"
           if [ "$cross" = "true" ]; then
             echo "Fork PR — cannot push; will comment instructions."
             exit 0
           fi
-          gh pr checkout "${{ github.event.issue.number }}"
+          git fetch origin "${head_ref}"
 
       - name: Explain fork limitation
         if: steps.pr.outputs.cross == 'true'
@@ -82,18 +90,23 @@ jobs:
               body: "`rescore_data` cannot push to a fork branch. Run locally instead:\n\n```\npnpm --dir scripts apply-data-quality --reviewer <your-login> <map-id>\n```",
             });
 
-      - name: Resolve target maps
+      - name: Resolve target maps and overlay PR content
         if: steps.pr.outputs.cross != 'true'
         id: targets
+        env:
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
         run: |
           set -euo pipefail
           args="$(echo "${{ github.event.comment.body }}" | head -1 | sed 's/^rescore_data//' | xargs || true)"
           if [ -n "$args" ]; then
             ids="$args"
           else
-            ids="$(git diff --name-only origin/main...HEAD -- 'maps/*/data-quality.json' | sed 's|maps/||; s|/data-quality.json||' | tr '\n' ' ' | xargs || true)"
+            ids="$(git diff --name-only "origin/main...origin/${HEAD_REF}" -- 'maps/*/data-quality.json' | sed 's|maps/||; s|/data-quality.json||' | tr '\n' ' ' | xargs || true)"
           fi
           echo "ids=${ids}" >> "$GITHUB_OUTPUT"
+          for id in ${ids}; do
+            git checkout "origin/${HEAD_REF}" -- "maps/${id}"
+          done
 
       - uses: pnpm/action-setup@v4
         if: steps.pr.outputs.cross != 'true' && steps.targets.outputs.ids != ''
@@ -121,16 +134,24 @@ jobs:
 
       - name: Commit and push
         if: steps.pr.outputs.cross != 'true' && steps.targets.outputs.ids != '' && steps.apply.outcome == 'success'
+        env:
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git worktree add /tmp/pr-branch "origin/${HEAD_REF}"
+          for id in ${{ steps.targets.outputs.ids }}; do
+            mkdir -p "/tmp/pr-branch/maps/${id}"
+            cp "maps/${id}/data-quality.json" "maps/${id}/manifest.json" "/tmp/pr-branch/maps/${id}/"
+          done
+          cd /tmp/pr-branch
           git add maps/
           if git diff --cached --quiet; then
             echo "No changes to commit (already applied)."
           else
             git commit -m "chore(data-quality): confirm reviewed answers via rescore_data (by ${{ github.event.comment.user.login }})"
-            git push
+            git push origin "HEAD:${HEAD_REF}"
           fi
 
       - name: Mark publish PR ready for review

--- a/scripts/validate-data-quality.ts
+++ b/scripts/validate-data-quality.ts
@@ -136,10 +136,17 @@ function main(): void {
 
   // If the map was previously scored, reset the manifest to the Unscored
   // marker so the branch stays CI-consistent; the reviewer re-stamps via
-  // rescore_data before merge.
+  // rescore_data before merge. Pre-migration publish branches carry no
+  // data_quality block at all — stamp the marker there too, or the manifest
+  // would fail --require-presence on main after the publish PR merges.
   const existingBlock = manifest.data_quality as { tier?: string } | undefined;
   let manifestReset = false;
-  if (existingBlock !== undefined && existingBlock.tier !== "unknown") {
+  let markerStamped = false;
+  if (existingBlock === undefined) {
+    manifest.data_quality = { tier: "unknown", rubric_version: RUBRIC_VERSION };
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    markerStamped = true;
+  } else if (existingBlock.tier !== "unknown") {
     manifest.data_quality = { tier: "unknown", rubric_version: RUBRIC_VERSION };
     writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
     manifestReset = true;
@@ -166,6 +173,11 @@ function main(): void {
   if (manifestReset) {
     extras.push(
       "This map was previously scored; its manifest is reset to `unknown` on this branch until a reviewer re-confirms with `rescore_data`.",
+    );
+  }
+  if (markerStamped) {
+    extras.push(
+      "The manifest predates the data-quality system; the `unknown` marker was stamped alongside the answers.",
     );
   }
   writeFileSync(


### PR DESCRIPTION
The brussels data-quality submission ([run 30343969100](https://github.com/Subway-Builder-Modded/registry/actions/runs/30343969100)) failed with `Missing script: validate-data-quality` — the C1.2 flow checked out the **whole** `publish/map/brussels` branch, which was cut months before the data-quality migration and has none of the tooling. `rescore_data` had the same latent bug via `gh pr checkout`.

Fix: the working tree always stays on `main` (current scripts/schemas); only the branch's `maps/<id>` content is overlaid for validation/apply, and commits go back through a git worktree pinned to the branch tip. Additionally, pre-migration manifests (no `data_quality` block) now get the `unknown` marker stamped alongside the answers, so the manifest passes `--require-presence` on `main` once the publish PR merges.

After merge, commenting `revalidate` on the brussels data-quality issue reprocesses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)