### PR TITLE
fix(workflows): bot PR bypass merge — use --admin and propagate retry failures

### DIFF
--- a/.github/actions/bot-pr-automation/action.yml
+++ b/.github/actions/bot-pr-automation/action.yml
@@ -96,12 +96,17 @@ runs:
           local delay=5
           local attempt=1
           local output=""
+          local status=0
           while true; do
+            # Capture the command's status directly: `$?` read after an
+            # if-statement whose condition failed is the if's status (0),
+            # which made terminal failures return success.
             if output="$("$@" 2>&1)"; then
               printf '%s' "$output"
               return 0
+            else
+              status=$?
             fi
-            local status=$?
             if [ "$attempt" -ge "$max_attempts" ]; then
               echo "$output" >&2
               return "$status"
@@ -119,11 +124,13 @@ runs:
           shift
           local delay=5
           local attempt=1
+          local status=0
           while true; do
             if "$@"; then
               return 0
+            else
+              status=$?
             fi
-            local status=$?
             if [ "$attempt" -ge "$max_attempts" ]; then
               return "$status"
             fi
@@ -166,7 +173,11 @@ runs:
         # the old auto-approve dispatch workflow is gone.
         merged_directly=false
         if [ -n "${INPUT_MERGE_TOKEN}" ]; then
-          if retry_run 2 env GH_TOKEN="${INPUT_MERGE_TOKEN}" gh pr merge "${PR_NUMBER}" --repo "${REPO}" --squash; then
+          # --admin: a plain merge is refused while the ruleset's review
+          # requirement is unmet ("base branch policy prohibits the merge")
+          # even for a bypass actor — the override path is what exercises
+          # the app's Main-ruleset bypass.
+          if retry_run 2 env GH_TOKEN="${INPUT_MERGE_TOKEN}" gh pr merge "${PR_NUMBER}" --repo "${REPO}" --squash --admin; then
             merged_directly=true
             echo "Merged PR #${PR_NUMBER} directly with the bot app identity."
           else


### PR DESCRIPTION
Diagnosis of why bot PRs #6274/#6275/#6281 never merged — two stacked bugs plus one GitHub-side incident:

1. **Plain merges don't exercise the ruleset bypass.** The [15:00 run log](https://github.com/Subway-Builder-Modded/registry/actions/runs/30371199654) shows `gh pr merge --squash` with the app token refused with *'base branch policy prohibits the merge'* despite the app being a bypass actor — the bypass only applies on the **override path**, so the merge now uses `--admin` (with the app token, not an admin PAT).
2. **`retry_cmd`/`retry_run` swallowed terminal failures**: they read `$?` after an `if` whose condition failed — that's the `if`'s own status (0) — so the composite believed the merge succeeded, logged *'Merged PR directly'*, and **skipped the auto-merge fallback**, leaving the PRs with no merge path at all.
3. Separately, the repo's Actions queue was **wedged from 15:58 Jul 28 onward** (runs stuck `in_progress`/`queued` ~19h, past the 6h job limit; new dispatches accepted but never materialized) — force-cancelling the stuck runs unwedged it; scheduled runs should resume on their own.

After this merges, the next hourly cycles force-update the three stranded PR branches and merge them via the fixed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)