### PR TITLE
feat(forms): drop the deprecated level_of_detail dropdown (D4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/publish-map.yml
+++ b/.github/ISSUE_TEMPLATE/publish-map.yml
@@ -99,11 +99,10 @@
       "value": "## Data Attestation
 
 
-        Provide details about your map's data source and level of detail. Be honest and
-        transparent in your descriptions and please include the methodology you used to
-        generate the map's data. See the [Data
-        Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more
-        information.
+        Provide details about your map's data source. Be honest and transparent in your
+        descriptions and please include the methodology you used to generate the map's data.
+        See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality)
+        guide for more information.
 
 
         After your submission is validated, you will be invited to answer the [data-quality
@@ -122,20 +121,6 @@
       "value": "OSM"
     "validations":
       "required": false
-  - "type": "dropdown"
-    "id": "level_of_detail"
-    "attributes":
-      "label": "Level of Detail"
-      "description": "Approximate level of detail of your map. Demand resolution at the level of
-        census blocks is considered high-detail, while neighborhood/city resolutions are
-        considered low-detail."
-      "options":
-        - ""
-        - "low-detail"
-        - "medium-detail"
-        - "high-detail"
-    "validations":
-      "required": true
   - "type": "input"
     "id": "methodology"
     "attributes":

--- a/.github/ISSUE_TEMPLATE/update-map.yml
+++ b/.github/ISSUE_TEMPLATE/update-map.yml
@@ -88,11 +88,10 @@
       "value": "## Data Attestation
 
 
-        Provide details about your map's data source and level of detail. Be honest and
-        transparent in your descriptions and please include the methodology you used to
-        generate the map's data. See the [Data
-        Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more
-        information.
+        Provide details about your map's data source. Be honest and transparent in your
+        descriptions and please include the methodology you used to generate the map's data.
+        See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality)
+        guide for more information.
 
 
         Updating metadata does not change your map's data-quality tier. If the underlying
@@ -105,20 +104,6 @@
       "label": "Data Source"
       "description": "Enter the data source used to generate the demand data for your map. The
         source name should use common abbreviations like LODES/INSEE/ONS etc."
-    "validations":
-      "required": false
-  - "type": "dropdown"
-    "id": "level_of_detail"
-    "attributes":
-      "label": "Level of Detail"
-      "description": "Approximate level of detail of your map. Demand resolution at the level of
-        census blocks is considered high-detail, while neighborhood/city resolutions are
-        considered low-detail."
-      "options":
-        - ""
-        - "low-detail"
-        - "medium-detail"
-        - "high-detail"
     "validations":
       "required": false
   - "type": "input"

--- a/scripts/create-listing.ts
+++ b/scripts/create-listing.ts
@@ -8,6 +8,7 @@ import {
 } from "./lib/gallery.js";
 import {
   getMapDataSource,
+  getMapLevelOfDetail,
   getOptionalIssueValue,
   getRequiredIssueValue,
 } from "./lib/map-field-utils.js";
@@ -71,10 +72,10 @@ async function buildMapManifestData(data: Record<string, unknown>): Promise<{
   tags: string[];
   mapFields: Omit<MapManifest, keyof ModManifest>;
 }> {
-  const levelOfDetail = getRequiredIssueValue(
-    "level_of_detail",
-    data.level_of_detail,
-  );
+  // level_of_detail is deprecated (D4): the form no longer asks; new listings
+  // get the conservative default. The manifest field stays until pre-0.2.9
+  // clients (which still read it) have aged out.
+  const levelOfDetail = getMapLevelOfDetail(data.level_of_detail);
   const dataSource = getMapDataSource(data.data_source);
   // location is machine-managed: derived from the country code, never
   // user-selected (validate-publish rejects unmapped countries first).

--- a/scripts/generate-map-templates.ts
+++ b/scripts/generate-map-templates.ts
@@ -12,7 +12,6 @@ import {
 } from "@subway-builder-modded/registry-schemas";
 import {
   DEFAULT_MAP_DATA_SOURCE,
-  LEVEL_OF_DETAIL_VALUES,
   SPECIAL_DEMAND_TAGS,
 } from "./lib/map-constants.js";
 
@@ -257,7 +256,7 @@ function withTemplatePolicy(baseDoc: TemplateDoc, mode: TemplateMode): TemplateD
       field.attributes.value.startsWith("## Data Attestation")
     ) {
       field.attributes.value =
-        "## Data Attestation\n\nProvide details about your map's data source and level of detail. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nUpdating metadata does not change your map's data-quality tier. If the underlying data changed, submit new answers via the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) form.";
+        "## Data Attestation\n\nProvide details about your map's data source. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nUpdating metadata does not change your map's data-quality tier. If the underlying data changed, submit new answers via the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) form.";
     }
   }
 
@@ -303,20 +302,13 @@ const SHARED_FIELDS_AFTER_MAP_ID = [
   spacer(),
   // ===== Data Validation ===== //
   markdown(
-    "## Data Attestation\n\nProvide details about your map's data source and level of detail. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nAfter your submission is validated, you will be invited to answer the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — a **required step**: your map cannot merge until a maintainer confirms your answers, and new submissions are subject to the [quality floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for countries with existing maps.",
+    "## Data Attestation\n\nProvide details about your map's data source. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nAfter your submission is validated, you will be invited to answer the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — a **required step**: your map cannot merge until a maintainer confirms your answers, and new submissions are subject to the [quality floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for countries with existing maps.",
   ),
   input(
     "data_source",
     "Data Source",
     "Enter the data source used to generate the demand data for your map. The source name should use common abbreviations like LODES/INSEE/ONS etc.",
     { placeholder: "LODES, etc.", value: DEFAULT_MAP_DATA_SOURCE, required: false },
-  ),
-  dropdown(
-    "level_of_detail",
-    "Level of Detail",
-    "Approximate level of detail of your map. Demand resolution at the level of census blocks is considered high-detail, while neighborhood/city resolutions are considered low-detail.",
-    LEVEL_OF_DETAIL_VALUES,
-    true,
   ),
   input(
     "methodology",

--- a/scripts/lib/map-update-logic.ts
+++ b/scripts/lib/map-update-logic.ts
@@ -84,6 +84,9 @@ export function applyMapManifestUpdates(
   if (isPresentIssueValue(data["city-code"])) manifest.city_code = data["city-code"];
   if (isPresentIssueValue(data.country)) manifest.country = data.country;
 
+  // level_of_detail is deprecated (D4) and no longer on the form; the first
+  // branch only fires for issues predating its removal. Existing manifest
+  // values are preserved (pre-0.2.9 clients still read the field).
   if (isPresentIssueValue(data.level_of_detail)) {
     manifest.level_of_detail = data.level_of_detail as LevelOfDetail;
   } else if (!isPresentIssueValue(manifest.level_of_detail)) {

--- a/scripts/tests/update-map-template.integration.test.ts
+++ b/scripts/tests/update-map-template.integration.test.ts
@@ -5,7 +5,6 @@ import { resolve } from "node:path";
 import YAML from "yaml";
 import {
   DEFAULT_MAP_DATA_SOURCE,
-  LEVEL_OF_DETAIL_VALUES,
   SPECIAL_DEMAND_TAGS,
 } from "../lib/map-constants.js";
 
@@ -74,10 +73,12 @@ test("publish-map.yml enforces required publish fields with blank dropdown defau
     false,
   );
 
-  const levelOfDetail = getField(parsed.body, "level_of_detail");
-  assert.equal(levelOfDetail.type, "dropdown");
-  assert.deepEqual(getDropdownOptions(levelOfDetail), ["", ...LEVEL_OF_DETAIL_VALUES]);
-  assert.equal(levelOfDetail.validations?.required, true);
+  // level_of_detail is deprecated (D4) and no longer collected on the form;
+  // new listings default conservatively in create-listing.
+  assert.equal(
+    parsed.body.some((field) => (field as { id?: string }).id === "level_of_detail"),
+    false,
+  );
 
   // location is machine-managed (derived from the country code) and no
   // longer collected on the form.
@@ -165,7 +166,6 @@ test("update-map.yml keeps map-id/terms required and makes other fields optional
     "city-code",
     "country",
     "description",
-    "level_of_detail",
     "methodology",
     "gallery",
     "source",
@@ -186,8 +186,11 @@ test("update-map.yml keeps map-id/terms required and makes other fields optional
     false,
   );
 
-  const levelOfDetail = getField(parsed.body, "level_of_detail");
-  assert.deepEqual(getDropdownOptions(levelOfDetail), ["", ...LEVEL_OF_DETAIL_VALUES]);
+  // level_of_detail is deprecated (D4) and no longer collected on the form.
+  assert.equal(
+    parsed.body.some((field) => (field as { id?: string }).id === "level_of_detail"),
+    false,
+  );
 
   assert.equal(
     parsed.body.some((field) => (field as { id?: string }).id === "location"),

--- a/scripts/validate-publish.ts
+++ b/scripts/validate-publish.ts
@@ -47,7 +47,9 @@ const PublishMapInput = PublishModInput.omit({ "mod-id": true }).extend({
   // Tolerated for issues predating the field's removal from the form; never
   // used — source_quality is machine-managed (data-quality tiers supersede it).
   source_quality: z.enum(SOURCE_QUALITY_VALUES).optional(),
-  level_of_detail: z.enum(LEVEL_OF_DETAIL_VALUES),
+  // Tolerated for issues predating the field's removal from the form; never
+  // required — level_of_detail is deprecated (D4) and defaults conservatively.
+  level_of_detail: z.enum(LEVEL_OF_DETAIL_VALUES).optional(),
   // Tolerated for issues predating the field's removal from the form; never
   // used — location is machine-managed (derived from the country code).
   location: z.string().optional(),


### PR DESCRIPTION
First step of the D4 `level_of_detail` deprecation ladder (form → tag → schema):

- **Forms**: the dropdown is gone from publish-map/update-map; the Data Attestation intro no longer mentions level of detail. Old open issues that still carry the field are tolerated (same pattern as the `source_quality` removal).
- **Writers**: new listings get the conservative `low-detail` default; metadata updates preserve whatever the manifest already has.
- **Manifests keep the field** — pre-0.2.9 clients still read it; schema removal waits for 0.2.9 adoption.
- **Monorepo ingestion**: verified zero `level_of_detail`/`levelOfDetail`/`*-detail` references across `apps/`, `packages/`, and `website/src` on current main — the 0.2.9 clean-break already scrubbed it, so nothing to do there.

All 261 script tests pass (template assertions updated to expect the field's absence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)