### PR TITLE
Dedup: extract shared Cloudflare capture pipeline

### DIFF
--- a/scripts/lib/website-analytics-capture.ts
+++ b/scripts/lib/website-analytics-capture.ts
@@ -1,0 +1,119 @@
+import {
+  normalizeAndCanonicalizePath,
+  sortMetricMap,
+  type WebsiteAnalyticsSnapshot,
+  type WebsiteAnalyticsMetricMap,
+} from "./website-analytics.js";
+import {
+  fetchCloudflareWindowMetrics,
+  resolveZoneTag,
+  resolveApiToken,
+  type CloudflareWebsiteAnalyticsQueryParams,
+} from "./cloudflare-website-analytics.js";
+
+export interface CloudflareCredentials {
+  zoneTag: string;
+  apiToken: string;
+}
+
+export function requireCloudflareCredentials(): CloudflareCredentials {
+  const zoneTag = resolveZoneTag();
+  const apiToken = resolveApiToken();
+
+  if (!zoneTag) {
+    throw new Error(
+      "Cloudflare zone identifier not found. Set CLOUDFLARE_ZONE_TAG.",
+    );
+  }
+
+  if (!apiToken) {
+    throw new Error(
+      "Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN.",
+    );
+  }
+
+  return { zoneTag, apiToken };
+}
+
+function normalizeCloudflareMetricMap(
+  raw: Record<string, unknown>,
+  pathAliases: Record<string, string>,
+  canonicalizePath: boolean,
+): WebsiteAnalyticsMetricMap {
+  const normalized: WebsiteAnalyticsMetricMap = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    const visits = typeof value === "object" && value !== null && "visits" in value
+      ? typeof (value as Record<string, unknown>).visits === "number"
+        ? (value as Record<string, unknown>).visits as number
+        : 0
+      : 0;
+
+    if (visits <= 0) continue;
+
+    if (canonicalizePath) {
+      const normKey = normalizeAndCanonicalizePath(key, pathAliases);
+      if (!normKey) continue;
+      if (!normalized[normKey]) {
+        normalized[normKey] = 0;
+      }
+      normalized[normKey] += visits;
+    } else {
+      normalized[key] = visits;
+    }
+  }
+
+  return sortMetricMap(normalized);
+}
+
+export interface CaptureWindowSnapshotArgs extends CloudflareCredentials {
+  pathAliases: Record<string, string>;
+  windowStartIso: string;
+  windowEndIso: string;
+  capturedAtIso: string;
+  verbose?: boolean;
+}
+
+/**
+ * Fetches one Cloudflare analytics window and normalizes it into a
+ * WebsiteAnalyticsSnapshot (page paths canonicalized via the alias map; other
+ * dimensions passed through). Shared by the hourly capture script and the
+ * ops backfill gap-filler.
+ */
+export async function captureWindowSnapshot(
+  args: CaptureWindowSnapshotArgs,
+): Promise<WebsiteAnalyticsSnapshot> {
+  const queryParams: CloudflareWebsiteAnalyticsQueryParams = {
+    zoneTag: args.zoneTag,
+    apiToken: args.apiToken,
+    windowStartIso: args.windowStartIso,
+    windowEndIso: args.windowEndIso,
+  };
+
+  if (args.verbose) {
+    console.log(
+      `Querying Cloudflare for window ${args.windowStartIso} to ${args.windowEndIso}...`,
+    );
+  }
+  const metrics = await fetchCloudflareWindowMetrics(queryParams);
+
+  if (args.verbose) {
+    console.log(
+      `Received ${metrics.totalVisits} total visits, ${Object.keys(metrics.pages).length} pages`,
+    );
+  }
+
+  return {
+    captured_at: args.capturedAtIso,
+    window_start: args.windowStartIso,
+    window_end: args.windowEndIso,
+    totals: {
+      visits: metrics.totalVisits,
+    },
+    pages: normalizeCloudflareMetricMap(metrics.pages, args.pathAliases, true),
+    countries: normalizeCloudflareMetricMap(metrics.countries, args.pathAliases, false),
+    browsers: normalizeCloudflareMetricMap(metrics.browsers, args.pathAliases, false),
+    operating_systems: normalizeCloudflareMetricMap(metrics.operatingSystems, args.pathAliases, false),
+    devices: normalizeCloudflareMetricMap(metrics.devices, args.pathAliases, false),
+  };
+}

--- a/scripts/ops/backfill-website-analytics.ts
+++ b/scripts/ops/backfill-website-analytics.ts
@@ -7,24 +7,18 @@ import {
   updateValidPaths,
   toHourBucketIso,
   toDateKey,
-  normalizeAndCanonicalizePath,
   mergeSortedUniqueStrings,
-  sortMetricMap,
   type WebsiteAnalyticsSnapshot,
-  type WebsiteAnalyticsMetricMap,
 } from "../lib/website-analytics.js";
 import {
-  fetchCloudflareWindowMetrics,
-  resolveZoneTag,
-  resolveApiToken,
-  type CloudflareWebsiteAnalyticsQueryParams,
-} from "../lib/cloudflare-website-analytics.js";
+  captureWindowSnapshot,
+  requireCloudflareCredentials,
+  type CloudflareCredentials,
+} from "../lib/website-analytics-capture.js";
 import { loadLocalDotEnv, resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
 
-interface CliArgs {
+interface CliArgs extends CloudflareCredentials {
   repoRoot: string;
-  zoneTag: string;
-  apiToken: string;
   days: number;
   resetHistory: boolean;
 }
@@ -35,20 +29,7 @@ function parseArgs(argv: string[]): CliArgs {
   const repoRoot = resolveRepoRoot(import.meta.dirname);
   loadLocalDotEnv(repoRoot);
 
-  const zoneTag = resolveZoneTag();
-  const apiToken = resolveApiToken();
-
-  if (!zoneTag) {
-    throw new Error(
-      "Cloudflare zone identifier not found. Set CLOUDFLARE_ZONE_TAG.",
-    );
-  }
-
-  if (!apiToken) {
-    throw new Error(
-      "Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN.",
-    );
-  }
+  const credentials = requireCloudflareCredentials();
 
   let days = DEFAULT_BACKFILL_DAYS;
   let resetHistory = false;
@@ -76,79 +57,9 @@ function parseArgs(argv: string[]): CliArgs {
 
   return {
     repoRoot,
-    zoneTag,
-    apiToken,
+    ...credentials,
     days,
     resetHistory,
-  };
-}
-
-function normalizeMetricMap(
-  raw: Record<string, unknown>,
-  pathAliases: Record<string, string>,
-  canonicalizePath: boolean,
-): WebsiteAnalyticsMetricMap {
-  const normalized: WebsiteAnalyticsMetricMap = {};
-
-  for (const [key, value] of Object.entries(raw)) {
-    const visits = typeof value === "object" && value !== null && "visits" in value
-      ? typeof (value as Record<string, unknown>).visits === "number"
-        ? (value as Record<string, unknown>).visits as number
-        : 0
-      : 0;
-
-    if (visits <= 0) continue;
-
-    if (canonicalizePath) {
-      const normKey = normalizeAndCanonicalizePath(key, pathAliases);
-      if (!normKey) continue;
-      if (!normalized[normKey]) {
-        normalized[normKey] = 0;
-      }
-      normalized[normKey] += visits;
-    } else {
-      normalized[key] = visits;
-    }
-  }
-
-  return sortMetricMap(normalized);
-}
-
-async function captureWindowAnalytics(
-  zoneTag: string,
-  apiToken: string,
-  pathAliases: Record<string, string>,
-  windowStartIso: string,
-  windowEndIso: string,
-  capturedAtIso: string,
-): Promise<WebsiteAnalyticsSnapshot> {
-  const queryParams: CloudflareWebsiteAnalyticsQueryParams = {
-    zoneTag,
-    apiToken,
-    windowStartIso,
-    windowEndIso,
-  };
-
-  const metrics = await fetchCloudflareWindowMetrics(queryParams);
-
-  const normalizedPages = normalizeMetricMap(metrics.pages, pathAliases, true);
-  const normalizedCountries = normalizeMetricMap(metrics.countries, pathAliases, false);
-  const normalizedBrowsers = normalizeMetricMap(metrics.browsers, pathAliases, false);
-  const normalizedOs = normalizeMetricMap(metrics.operatingSystems, pathAliases, false);
-  const normalizedDevices = normalizeMetricMap(metrics.devices, pathAliases, false);
-
-  return {
-    captured_at: capturedAtIso,
-    window_start: windowStartIso,
-    window_end: windowEndIso,
-    totals: {
-      visits: metrics.totalVisits,
-    },
-    pages: normalizedPages,
-    countries: normalizedCountries,
-    browsers: normalizedBrowsers,
-    operating_systems: normalizedOs,
-    devices: normalizedDevices,
   };
 }
 
@@ -184,14 +95,14 @@ async function run(): Promise<void> {
     console.log(`Fetching hour ${hourKey}...`);
     let hourlySnapshot: WebsiteAnalyticsSnapshot;
     try {
-      hourlySnapshot = await captureWindowAnalytics(
-        args.zoneTag,
-        args.apiToken,
-        history.path_aliases,
+      hourlySnapshot = await captureWindowSnapshot({
+        zoneTag: args.zoneTag,
+        apiToken: args.apiToken,
+        pathAliases: history.path_aliases,
         windowStartIso,
         windowEndIso,
         capturedAtIso,
-      );
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (message.includes("cannot request data older than")) {

--- a/scripts/telemetry/capture-website-analytics.ts
+++ b/scripts/telemetry/capture-website-analytics.ts
@@ -5,129 +5,23 @@ import {
   upsertHourlySnapshot,
   updateValidPaths,
   toHourBucketIso,
-  normalizeAndCanonicalizePath,
   mergeSortedUniqueStrings,
-  sortMetricMap,
-  type WebsiteAnalyticsSnapshot,
-  type WebsiteAnalyticsMetricMap,
 } from "../lib/website-analytics.js";
 import {
-  fetchCloudflareWindowMetrics,
-  resolveZoneTag,
-  resolveApiToken,
-  type CloudflareWebsiteAnalyticsQueryParams,
-} from "../lib/cloudflare-website-analytics.js";
+  captureWindowSnapshot,
+  requireCloudflareCredentials,
+  type CloudflareCredentials,
+} from "../lib/website-analytics-capture.js";
 import { loadLocalDotEnv, resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
 
-interface CliArgs {
+interface CliArgs extends CloudflareCredentials {
   repoRoot: string;
-  zoneTag: string;
-  apiToken: string;
 }
 
 function parseArgs(): CliArgs {
   const repoRoot = resolveRepoRoot(import.meta.dirname);
   loadLocalDotEnv(repoRoot);
-
-  const zoneTag = resolveZoneTag();
-  const apiToken = resolveApiToken();
-
-  if (!zoneTag) {
-    throw new Error(
-      "Cloudflare zone identifier not found. Set CLOUDFLARE_ZONE_TAG.",
-    );
-  }
-
-  if (!apiToken) {
-    throw new Error(
-      "Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN.",
-    );
-  }
-
-  return {
-    repoRoot,
-    zoneTag,
-    apiToken,
-  };
-}
-
-function normalizeMetricMap(
-  raw: Record<string, unknown>,
-  pathAliases: Record<string, string>,
-  canonicalizePath: boolean,
-): WebsiteAnalyticsMetricMap {
-  const normalized: WebsiteAnalyticsMetricMap = {};
-
-  for (const [key, value] of Object.entries(raw)) {
-    const visits = typeof value === "object" && value !== null && "visits" in value
-      ? typeof (value as Record<string, unknown>).visits === "number"
-        ? (value as Record<string, unknown>).visits as number
-        : 0
-      : 0;
-
-    if (visits <= 0) continue;
-
-    if (canonicalizePath) {
-      const normKey = normalizeAndCanonicalizePath(key, pathAliases);
-      if (!normKey) continue;
-      if (!normalized[normKey]) {
-        normalized[normKey] = 0;
-      }
-      normalized[normKey] += visits;
-    } else {
-      normalized[key] = visits;
-    }
-  }
-
-  return sortMetricMap(normalized);
-}
-
-async function captureWindowAnalytics(
-  zoneTag: string,
-  apiToken: string,
-  pathAliases: Record<string, string>,
-  windowStartIso: string,
-  windowEndIso: string,
-  capturedAtIso: string,
-): Promise<WebsiteAnalyticsSnapshot> {
-  const queryParams: CloudflareWebsiteAnalyticsQueryParams = {
-    zoneTag,
-    apiToken,
-    windowStartIso,
-    windowEndIso,
-  };
-
-  console.log(
-    `Querying Cloudflare for window ${windowStartIso} to ${windowEndIso}...`,
-  );
-  const metrics = await fetchCloudflareWindowMetrics(queryParams);
-
-  console.log(
-    `Received ${metrics.totalVisits} total visits, ${Object.keys(metrics.pages).length} pages`,
-  );
-
-  // Normalize pages with path filtering
-  const normalizedPages = normalizeMetricMap(metrics.pages, pathAliases, true);
-
-  // Other dimensions: no special normalization needed
-  const normalizedCountries = normalizeMetricMap(metrics.countries, pathAliases, false);
-  const normalizedBrowsers = normalizeMetricMap(metrics.browsers, pathAliases, false);
-  const normalizedOs = normalizeMetricMap(metrics.operatingSystems, pathAliases, false);
-  const normalizedDevices = normalizeMetricMap(metrics.devices, pathAliases, false);
-
-  return {
-    captured_at: capturedAtIso,
-    window_start: windowStartIso,
-    window_end: windowEndIso,
-    totals: {
-      visits: metrics.totalVisits,
-    },
-    pages: normalizedPages,
-    countries: normalizedCountries,
-    browsers: normalizedBrowsers,
-    operating_systems: normalizedOs,
-    devices: normalizedDevices,
-  };
+  return { repoRoot, ...requireCloudflareCredentials() };
 }
 
 async function run(): Promise<void> {
@@ -143,14 +37,15 @@ async function run(): Promise<void> {
   const windowStartIso = hourBucketIso;
   const windowEndIso = new Date(new Date(windowStartIso).getTime() + 60 * 60 * 1000).toISOString();
 
-  const snapshot = await captureWindowAnalytics(
-    args.zoneTag,
-    args.apiToken,
-    history.path_aliases,
+  const snapshot = await captureWindowSnapshot({
+    zoneTag: args.zoneTag,
+    apiToken: args.apiToken,
+    pathAliases: history.path_aliases,
     windowStartIso,
     windowEndIso,
     capturedAtIso,
-  );
+    verbose: true,
+  });
 
   // Upsert the hourly snapshot
   history = upsertHourlySnapshot({


### PR DESCRIPTION
Dedup cluster 1 (stacked on #6288 — will retarget to main when it merges).

`capture-website-analytics` (hourly) and `ops/backfill-website-analytics` (gap-filler) each carried a full copy of the window-capture pipeline: credential validation, Cloudflare metric-map normalization (byte-identical 26-line function), and window fetch + snapshot assembly. All three now live in `lib/website-analytics-capture.ts` (named `normalizeCloudflareMetricMap` to avoid confusion with the unrelated private JSON normalizer in `website-analytics.ts`); the scripts keep only their distinct CLI parsing and loop/checkpoint logic. No behavior change — capture keeps its verbose logging via a `verbose` flag, backfill keeps its retention/rate-limit error mapping.

Verification: 267/267 tests, tsc clean (one pre-existing unrelated error), net −180 LoC across the two scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)