### PR TITLE
Dedup: shared CLI, git-history, and small helper libs

### DIFF
--- a/scripts/announce/make-announcement.ts
+++ b/scripts/announce/make-announcement.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { pathToFileURL } from 'url';
 import { loadAuthorAliasIndex, resolveAuthorPresentation } from '../lib/author-aliases.js';
+import { parseRetryAfterMs } from '../lib/discord-webhook.js';
 import { resolveRepoRoot } from '../lib/script-runtime.js';
 
 const CONTENT_ANNOUNCEMENTS_ROLE_ID = '1492005223680446567';
@@ -23,20 +24,6 @@ const ALLOWED_MENTIONS = {
 
 function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function parseRetryAfterMs(payload: unknown): number | null {
-    if (!payload || typeof payload !== 'object') {
-        return null;
-    }
-    const retryAfter = (payload as { retry_after?: unknown }).retry_after;
-    if (typeof retryAfter !== 'number' || !Number.isFinite(retryAfter) || retryAfter < 0) {
-        return null;
-    }
-    if (retryAfter > 1000) {
-        return Math.ceil(retryAfter);
-    }
-    return Math.ceil(retryAfter * 1000);
 }
 
 async function sendAnnouncementRequest(webhookUrl: string, init: RequestInit): Promise<void> {

--- a/scripts/downloads/generate-download-history.ts
+++ b/scripts/downloads/generate-download-history.ts
@@ -5,21 +5,8 @@ import {
   backfillDownloadAttributionHistorySnapshots,
   generateDownloadAttributionHistorySnapshot,
 } from "../lib/download-attribution-history.js";
-import { appendGitHubOutput, resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
+import { appendGitHubOutput, resolveRepoRoot, runAndExitOnError, toWarningsOutputJson } from "../lib/script-runtime.js";
 import { isTestListing } from "../lib/test-listings.js";
-
-function toWarningsOutputJson(warnings: string[]): string {
-  const MAX_WARNINGS = 30;
-  const normalized = warnings
-    .map((warning) => warning.trim())
-    .filter((warning) => warning !== "")
-    .map((warning) => `download-history: ${warning}`);
-  const displayed = normalized.slice(0, MAX_WARNINGS);
-  if (normalized.length > displayed.length) {
-    displayed.push(`...and ${normalized.length - displayed.length} more warnings`);
-  }
-  return JSON.stringify(displayed);
-}
 
 function filterHistoryWarningsForDiscord(repoRoot: string, warnings: string[]): string[] {
   return warnings.filter((warning) => {
@@ -100,7 +87,7 @@ async function run(): Promise<void> {
       "mods_net_downloads=",
       "mods_entries=",
       `warning_count=${warningCount}`,
-      `warnings_json=${toWarningsOutputJson(filteredWarnings)}`,
+      `warnings_json=${toWarningsOutputJson("download-history: ", filteredWarnings)}`,
     ]);
     return;
   }
@@ -149,7 +136,7 @@ async function run(): Promise<void> {
     `mods_net_downloads=${result.snapshot.mods.net_downloads}`,
     `mods_entries=${result.snapshot.mods.entries}`,
     `warning_count=${warningCount}`,
-    `warnings_json=${toWarningsOutputJson(filteredWarnings)}`,
+    `warnings_json=${toWarningsOutputJson("download-history: ", filteredWarnings)}`,
   ]);
 }
 

--- a/scripts/downloads/generate-downloads.ts
+++ b/scripts/downloads/generate-downloads.ts
@@ -29,6 +29,7 @@ import {
   isTruthyEnv,
   resolveRepoRoot,
   runAndExitOnError,
+  toWarningsOutputJson,
 } from "../lib/script-runtime.js";
 import { compareStableSemverAsc, isStableSemverTag } from "../lib/semver.js";
 import { filterListingMessages, isTestListing } from "../lib/test-listings.js";
@@ -61,19 +62,6 @@ function resolveMode(rawValue: string | undefined): "full" | "download-only" {
     return rawValue;
   }
   throw new Error("Missing or invalid --mode. Expected one of: full, download-only");
-}
-
-function toWarningsOutputJson(listingType: ManifestType, warnings: string[]): string {
-  const MAX_WARNINGS = 30;
-  const normalized = warnings
-    .map((warning) => warning.trim())
-    .filter((warning) => warning !== "")
-    .map((warning) => `${listingType}: ${warning}`);
-  const displayed = normalized.slice(0, MAX_WARNINGS);
-  if (normalized.length > displayed.length) {
-    displayed.push(`...and ${normalized.length - displayed.length} more warnings`);
-  }
-  return JSON.stringify(displayed);
 }
 
 function toLimitedOutputJson(items: string[]): string {
@@ -401,7 +389,7 @@ async function run(): Promise<void> {
   const tokenAuthStatus = !token ? "missing" : hasAuthFailure401 ? "invalid" : "ok";
   appendGitHubOutput([
     `warning_count=${warningsForGitHub.length}`,
-    `warnings_json=${toWarningsOutputJson(listingType, warningsForGitHub)}`,
+    `warnings_json=${toWarningsOutputJson(`${listingType}: `, warningsForGitHub)}`,
     `security_error_count=${securityErrorsForOutput.length}`,
     `security_warning_count=${securityWarningsForOutput.length}`,
     `security_errors_json=${toLimitedOutputJson(securityErrorsForOutput)}`,

--- a/scripts/downloads/generate-downloads.ts
+++ b/scripts/downloads/generate-downloads.ts
@@ -1,3 +1,4 @@
+import { getFlagValue, hasFlag } from "../lib/cli.js";
 import { writeJsonFile } from "../lib/json-utils.js";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -45,28 +46,6 @@ export function listZeroValidSemverListings(integrity: IntegrityOutput): string[
 export function buildZeroValidSemverWarnings(integrity: IntegrityOutput): string[] {
   return listZeroValidSemverListings(integrity)
     .map((listingId) => `listing=${listingId}: no valid semver release tags found`);
-}
-
-function getArgValue(name: string): string | undefined {
-  const exact = `--${name}=`;
-  for (const arg of process.argv.slice(2)) {
-    if (arg.startsWith(exact)) {
-      return arg.slice(exact.length);
-    }
-  }
-
-  const args = process.argv.slice(2);
-  for (let index = 0; index < args.length; index += 1) {
-    if (args[index] === `--${name}`) {
-      return args[index + 1];
-    }
-  }
-  return undefined;
-}
-
-function hasArgFlag(name: string): boolean {
-  const target = `--${name}`;
-  return process.argv.slice(2).includes(target);
 }
 
 function resolveListingType(rawValue: string | undefined): ManifestType {
@@ -211,18 +190,19 @@ function collectSecurityAlerts(integrity: IntegrityOutput, listingType: Manifest
 }
 
 async function run(): Promise<void> {
+  const argv = process.argv.slice(2);
   const listingType = resolveListingType(
-    getArgValue("type") ?? process.env.LISTING_TYPE,
+    getFlagValue(argv, "type") ?? process.env.LISTING_TYPE,
   );
-  const mode = resolveMode(getArgValue("mode") ?? process.env.DOWNLOADS_MODE);
+  const mode = resolveMode(getFlagValue(argv, "mode") ?? process.env.DOWNLOADS_MODE);
   const strictFingerprintCache = (
-    hasArgFlag("strict-fingerprint-cache")
+    hasFlag(argv, "strict-fingerprint-cache")
     || isTruthyEnv(process.env.STRICT_FINGERPRINT_CACHE)
     || isTruthyEnv(process.env.REGISTRY_STRICT_FINGERPRINT_CACHE)
   );
   const forceIntegrityRecheck = (
-    hasArgFlag("force")
-    || hasArgFlag("force-integrity")
+    hasFlag(argv, "force")
+    || hasFlag(argv, "force-integrity")
     || isTruthyEnv(process.env.FORCE_INTEGRITY_RECHECK)
   );
   const repoRoot = process.env.RAILYARD_REPO_ROOT ?? resolveRepoRoot(import.meta.dirname);
@@ -238,7 +218,7 @@ async function run(): Promise<void> {
   const pendingAnnouncementsPath = resolve(repoRoot, outputDir, "pending-announcements.json");
   const defaultAttributionDeltaPath = resolve(repoRoot, outputDir, "download-attribution-delta.json");
   const attributionDeltaPath = (
-    getArgValue("attribution-delta-path")
+    getFlagValue(argv, "attribution-delta-path")
     ?? getNonEmptyEnv("DOWNLOAD_ATTRIBUTION_DELTA_PATH")
     ?? defaultAttributionDeltaPath
   );

--- a/scripts/intake/create-listing.ts
+++ b/scripts/intake/create-listing.ts
@@ -7,9 +7,11 @@ import {
   downloadGalleryImages,
 } from "../lib/gallery.js";
 import {
+  combineMapTags,
   getMapDataSource,
   getOptionalIssueValue,
   getRequiredIssueValue,
+  parseCheckedBoxes,
 } from "../lib/map-field-utils.js";
 import {
   COUNTRY_TO_LOCATION,
@@ -41,11 +43,7 @@ function parseTags(raw: unknown): string[] {
   if (typeof raw !== "string") return [];
   // Handle checkbox markdown format: "- [X] tag\n- [x] tag"
   if (raw.includes("- [")) {
-    return raw
-      .split("\n")
-      .filter((line) => line.startsWith("- [X]") || line.startsWith("- [x]"))
-      .map((line) => line.replace(/^- \[[Xx]\]\s*/, "").trim())
-      .filter(Boolean);
+    return parseCheckedBoxes(raw);
   }
   // Handle comma-separated: "tag1, tag2, tag3"
   return raw.split(",").map((t) => t.trim()).filter(Boolean);
@@ -61,10 +59,6 @@ function buildUpdate(data: Record<string, unknown>): ModManifest["update"] {
     return { type: "github", repo: String(data["github-repo"]) };
   }
   return { type: "custom", url: String(data["custom-update-url"]) };
-}
-
-function combineMapTags(location: string, specialDemand: string[]): string[] {
-  return Array.from(new Set([location, ...specialDemand]));
 }
 
 async function buildMapManifestData(data: Record<string, unknown>): Promise<{

--- a/scripts/intake/update-listing.ts
+++ b/scripts/intake/update-listing.ts
@@ -14,6 +14,7 @@ import {
 import {
   getOptionalIssueValue,
   isPresentIssueValue,
+  parseCheckedBoxes as parseCheckedBoxesList,
 } from "../lib/map-field-utils.js";
 import {
   ensureCollaboratorAuthorAliasPrefills,
@@ -26,17 +27,7 @@ import { assertValidRegistryManifest } from "../lib/registry-manifest.js";
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..");
 
 function parseCheckedBoxes(raw: unknown): string[] | null {
-  if (!raw) return null;
-  if (Array.isArray(raw)) {
-    const selected = raw.map((tag) => String(tag).trim()).filter(Boolean);
-    return selected.length > 0 ? selected : null;
-  }
-  if (typeof raw !== "string") return null;
-  const checked = raw
-    .split("\n")
-    .filter((line) => line.startsWith("- [X]") || line.startsWith("- [x]"))
-    .map((line) => line.replace(/^- \[[Xx]\]\s*/, "").trim())
-    .filter(Boolean);
+  const checked = parseCheckedBoxesList(raw);
   // Return null if nothing was checked (user wants to keep current tags)
   return checked.length > 0 ? checked : null;
 }

--- a/scripts/intake/validate-publish.ts
+++ b/scripts/intake/validate-publish.ts
@@ -18,6 +18,7 @@ import {
 import {
   getOptionalIssueValue,
   isPresentIssueValue,
+  parseCheckedBoxes,
 } from "../lib/map-field-utils.js";
 import { resolveAndExtractDemandStatsForMapSource } from "../lib/map-demand-stats.js";
 import { checkCityCodeUniqueness, checkCrossTypeIdUniqueness } from "../lib/registry-uniqueness.js";
@@ -57,18 +58,6 @@ const PublishMapInput = PublishModInput.omit({ "mod-id": true }).extend({
 interface ValidationResult {
   success: boolean;
   errors: string[];
-}
-
-function parseCheckedBoxes(raw: unknown): string[] {
-  if (Array.isArray(raw)) {
-    return raw.map((tag) => String(tag).trim()).filter(Boolean);
-  }
-  if (typeof raw !== "string" || !raw || raw === "_No response_") return [];
-  return raw
-    .split("\n")
-    .filter((line) => line.startsWith("- [X]") || line.startsWith("- [x]"))
-    .map((line) => line.replace(/^- \[[Xx]\]\s*/, "").trim())
-    .filter(Boolean);
 }
 
 async function validateMod(data: Record<string, string>): Promise<ValidationResult> {

--- a/scripts/lib/analytics-core.ts
+++ b/scripts/lib/analytics-core.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { getFlagValue } from "./cli.js";
 import { writeCsv } from "./csv.js";
 import { isFiniteNumber, isObject, readJsonFile } from "./json-utils.js";
 import { resolveRepoRoot } from "./script-runtime.js";
@@ -213,21 +214,6 @@ type ListingKey = `${"maps" | "mods"}:${string}`;
 const DEFAULT_TOP_LISTINGS: number | null = null;
 const DEFAULT_TOP_AUTHORS: number | null = null;
 const WINDOWS = [1, 3, 7, 14, 30] as const;
-
-function getArgValue(argv: string[], name: string): string | undefined {
-  const exact = `--${name}=`;
-  for (const arg of argv) {
-    if (arg.startsWith(exact)) {
-      return arg.slice(exact.length);
-    }
-  }
-  for (let index = 0; index < argv.length; index += 1) {
-    if (argv[index] === `--${name}`) {
-      return argv[index + 1];
-    }
-  }
-  return undefined;
-}
 
 function validateArgs(argv: string[]): void {
   const valueFlags = new Set(["--top-k-listings", "--top-k-authors"]);
@@ -1190,14 +1176,14 @@ export function runGenerateAnalyticsCli(
   const resolvedRepoRoot = repoRoot ?? process.env.RAILYARD_REPO_ROOT ?? resolveRepoRoot(import.meta.dirname);
   validateArgs(argv);
   const topListings = parseTopK(
-    getArgValue(argv, "top-k-listings")
+    getFlagValue(argv, "top-k-listings")
       ?? process.env.ANALYTICS_TOP_K_LISTINGS
       ?? process.env.ANALYTICS_TOP_K,
     DEFAULT_TOP_LISTINGS,
     "top-k-listings",
   );
   const topAuthors = parseTopK(
-    getArgValue(argv, "top-k-authors") ?? process.env.ANALYTICS_TOP_K_AUTHORS,
+    getFlagValue(argv, "top-k-authors") ?? process.env.ANALYTICS_TOP_K_AUTHORS,
     DEFAULT_TOP_AUTHORS,
     "top-k-authors",
   );

--- a/scripts/lib/analytics-core.ts
+++ b/scripts/lib/analytics-core.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { getFlagValue } from "./cli.js";
 import { writeCsv } from "./csv.js";
+import { findLastAtOrBefore, listSnapshotFileNames } from "./history-utils.js";
 import { isFiniteNumber, isObject, readJsonFile } from "./json-utils.js";
 import { resolveRepoRoot } from "./script-runtime.js";
 import { isTestListing } from "./test-listings.js";
@@ -255,8 +256,7 @@ function parseSnapshotDate(fileName: string): Date | null {
 }
 
 function listSnapshots(historyDir: string): SnapshotEntry[] {
-  return readdirSync(historyDir)
-    .filter((file) => /^snapshot_\d{4}_\d{2}_\d{2}\.json$/.test(file))
+  return listSnapshotFileNames(historyDir)
     .map((file) => ({ file, date: parseSnapshotDate(file) }))
     .filter((entry): entry is SnapshotEntry => entry.date instanceof Date)
     .sort((a, b) => a.date.getTime() - b.date.getTime());
@@ -388,15 +388,7 @@ function addDays(date: Date, days: number): Date {
 }
 
 function findSnapshotAtOrBefore(snapshots: SnapshotEntry[], targetDate: Date): SnapshotEntry | null {
-  let selected: SnapshotEntry | null = null;
-  for (const entry of snapshots) {
-    if (entry.date <= targetDate) {
-      selected = entry;
-    } else {
-      break;
-    }
-  }
-  return selected;
+  return findLastAtOrBefore(snapshots, (entry) => entry.date.getTime(), targetDate.getTime());
 }
 
 function resolveBaselineSnapshot(snapshots: SnapshotEntry[], latestDate: Date, days: number): SnapshotEntry {

--- a/scripts/lib/cli.ts
+++ b/scripts/lib/cli.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared CLI argv primitives.
+ *
+ * These are lenient scanners: unknown arguments are ignored. Scripts that need
+ * strict validation (unknown-argument errors, positional handling, per-flag
+ * error messages) keep their own parse loops.
+ */
+
+/**
+ * Return the value for `--flag=value` (checked first, anywhere in argv) or
+ * `--flag value`, or undefined when the flag is absent.
+ */
+export function getFlagValue(argv: string[], flag: string): string | undefined {
+  const exact = `--${flag}=`;
+  for (const arg of argv) {
+    if (arg.startsWith(exact)) {
+      return arg.slice(exact.length);
+    }
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === `--${flag}`) {
+      return argv[index + 1];
+    }
+  }
+  return undefined;
+}
+
+/** True when argv contains the bare `--flag` token. */
+export function hasFlag(argv: string[], flag: string): boolean {
+  return argv.includes(`--${flag}`);
+}

--- a/scripts/lib/discord-server-metrics.ts
+++ b/scripts/lib/discord-server-metrics.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { isObject, sortObjectByKeys, toFiniteNonNegativeNumber } from "./json-utils.js";
+import { toDateKey } from "./time-buckets.js";
 
 const DISCORD_SERVER_METRICS_HISTORY_FILE = ["history", "discord_server_metrics.json"] as const;
 export const DEFAULT_DISCORD_SERVER_GUILD_ID = "1476290196139147376";
@@ -109,17 +110,7 @@ export function getDiscordServerMetricsHistoryPath(repoRoot: string): string {
   return resolve(repoRoot, ...DISCORD_SERVER_METRICS_HISTORY_FILE);
 }
 
-export function toHourBucketIso(date: Date): string {
-  const bucket = new Date(date.getTime());
-  bucket.setUTCMinutes(0, 0, 0);
-  return bucket.toISOString();
-}
-
-export function toDateKey(isoValue: string): string | null {
-  const parsed = Date.parse(isoValue);
-  if (!Number.isFinite(parsed)) return null;
-  return new Date(parsed).toISOString().slice(0, 10);
-}
+export { toDateKey, toHourBucketIso } from "./time-buckets.js";
 
 function normalizeMessageCreationCounts(value: unknown): DiscordMessageCreationCounts | null {
   if (!isObject(value)) return null;

--- a/scripts/lib/discord-webhook.ts
+++ b/scripts/lib/discord-webhook.ts
@@ -1,5 +1,21 @@
 import { fetchWithTimeout, resolveTimeoutMsFromEnv } from "./http.js";
 
+/**
+ * Retry delay in milliseconds from a Discord 429 payload's retry_after field
+ * (seconds, or already-milliseconds when > 1000), or null when absent/invalid.
+ */
+export function parseRetryAfterMs(payload: unknown): number | null {
+  if (!payload || typeof payload !== "object") return null;
+  const retryAfter = (payload as { retry_after?: unknown }).retry_after;
+  if (typeof retryAfter !== "number" || !Number.isFinite(retryAfter) || retryAfter < 0) {
+    return null;
+  }
+  if (retryAfter > 1000) {
+    return Math.ceil(retryAfter);
+  }
+  return Math.ceil(retryAfter * 1000);
+}
+
 interface SendDiscordMarkdownOptions {
   webhookUrl: string;
   title: string;

--- a/scripts/lib/download-attribution-backfill-core.ts
+++ b/scripts/lib/download-attribution-backfill-core.ts
@@ -1,7 +1,6 @@
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { appendFileSync, existsSync, readFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
 import JSZip from "jszip";
 import {
   createDownloadAttributionDelta,
@@ -13,6 +12,14 @@ import {
   writeDownloadAttributionLedger,
   type DownloadAttributionDelta,
 } from "./download-attribution.js";
+import {
+  fetchGitHubArrayBuffer,
+  fetchGitHubJson,
+  readJsonFromCommit,
+  resolveSourceCommitAtTime,
+  runGitCommand,
+  type GitHubFetchOptions,
+} from "./git-history.js";
 import type { MapManifest } from "./manifests.js";
 import { resolveZipUrlForMapSource } from "./map-demand-stats/source-resolution.js";
 import { parseGitHubReleaseAssetDownloadUrl } from "./release-resolution.js";
@@ -182,46 +189,17 @@ function parseArgs(argv: string[]): CliArgs {
   };
 }
 
+const GITHUB_FETCH_OPTIONS: GitHubFetchOptions = {
+  userAgent: "registry-download-attribution-backfill",
+  timeoutMs: FETCH_TIMEOUT_MS,
+};
+
 async function fetchJson<T>(url: string, token: string): Promise<T> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    const response = await fetch(url, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "User-Agent": "registry-download-attribution-backfill",
-      },
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    return await response.json() as T;
-  } finally {
-    clearTimeout(timeout);
-  }
+  return fetchGitHubJson<T>(url, token, GITHUB_FETCH_OPTIONS);
 }
 
 async function fetchArrayBuffer(url: string, token: string): Promise<ArrayBuffer> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    const response = await fetch(url, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "User-Agent": "registry-download-attribution-backfill",
-      },
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    return response.arrayBuffer();
-  } finally {
-    clearTimeout(timeout);
-  }
+  return fetchGitHubArrayBuffer(url, token, GITHUB_FETCH_OPTIONS);
 }
 
 function buildLineToAssetKeyIndex(repoRoot: string): Map<string, string> {
@@ -387,19 +365,6 @@ function workflowSourceLabel(workflowFile: string): string {
   return `backfill:${workflowFile.replace(/\.yml$/i, "")}`;
 }
 
-function runGitCommand(repoRoot: string, args: string[]): string | null {
-  try {
-    const output = execFileSync("git", args, {
-      cwd: repoRoot,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    return output === "" ? null : output;
-  } catch {
-    return null;
-  }
-}
-
 function listCommitShasForPathSince(
   repoRoot: string,
   relativePath: string,
@@ -415,20 +380,6 @@ function listCommitShasForPathSince(
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line !== "");
-}
-
-function readJsonFromCommit(
-  repoRoot: string,
-  commitSha: string,
-  relativePath: string,
-): unknown | null {
-  const raw = runGitCommand(repoRoot, ["show", `${commitSha}:${relativePath}`]);
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
 }
 
 function collectDeltasFromGitHistory(
@@ -475,13 +426,6 @@ function collectDeltasFromGitHistory(
   }
 
   return { deltas, stats, runIdsWithDelta };
-}
-
-function resolveSourceCommitAtTime(repoRoot: string, timestampIso: string): string | null {
-  return runGitCommand(
-    repoRoot,
-    ["rev-list", "-1", "--first-parent", `--before=${timestampIso}`, "HEAD"],
-  );
 }
 
 function readTextAtSource(

--- a/scripts/lib/download-attribution-backfill-core.ts
+++ b/scripts/lib/download-attribution-backfill-core.ts
@@ -24,6 +24,7 @@ import type { MapManifest } from "./manifests.js";
 import { resolveZipUrlForMapSource } from "./map-demand-stats/source-resolution.js";
 import { parseGitHubReleaseAssetDownloadUrl } from "./release-resolution.js";
 import { resolveRepoRoot } from "./script-runtime.js";
+import { toUtcDateKey } from "./time-buckets.js";
 import { isObject } from "./json-utils.js";
 
 const GITHUB_API_BASE = "https://api.github.com";
@@ -248,12 +249,6 @@ function addIntegrityMappingsToLineIndex(
       index.set(`${listingId}::${version}::${assetName.toLowerCase()}`, assetKey);
     }
   }
-}
-
-function toUtcDateKey(isoLike: string): string | null {
-  const parsed = Date.parse(isoLike);
-  if (!Number.isFinite(parsed)) return null;
-  return new Date(parsed).toISOString().slice(0, 10).replaceAll("-", "_");
 }
 
 function parseDownloadsFetchZipHits(

--- a/scripts/lib/download-attribution.ts
+++ b/scripts/lib/download-attribution.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import type { ParsedReleaseAssetUrl } from "./download-definitions.js";
 import { isObject, toFiniteNonNegativeNumber, sortObjectByKeys, writeJsonFile } from "./json-utils.js";
 import { parseGitHubReleaseAssetDownloadUrl } from "./release-resolution.js";
+import { toUtcDateKey as toUtcDateKeyFromIso } from "./time-buckets.js";
 import type {
   DownloadAttributionEntry,
   DownloadAttributionDailyEntry,
@@ -379,12 +380,6 @@ export function adjustDownloadCount(
     subtracted: normalizedRaw - adjusted,
     clamped: false,
   };
-}
-
-function toUtcDateKeyFromIso(isoLike: string): string | null {
-  const parsed = Date.parse(isoLike);
-  if (!Number.isFinite(parsed)) return null;
-  return new Date(parsed).toISOString().slice(0, 10).replaceAll("-", "_");
 }
 
 function hasTimelineEntries(ledger: DownloadAttributionLedger): boolean {

--- a/scripts/lib/git-history.ts
+++ b/scripts/lib/git-history.ts
@@ -1,0 +1,113 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Shared git/GitHub history access helpers.
+ *
+ * The git helpers are the lenient variants (null on failure, stderr
+ * suppressed, trimmed output). ops/rebuild-download-history-from-git.ts keeps
+ * its own strict, throwing variants on purpose: they propagate git stderr and
+ * fail loudly, which that ops tool relies on.
+ */
+
+export interface GitHubFetchOptions {
+  /** Value sent as the User-Agent header. */
+  userAgent: string;
+  /** When set, abort the request via AbortController after this many milliseconds. */
+  timeoutMs?: number;
+  /** Message for non-2xx responses; defaults to `HTTP ${status}`. */
+  formatHttpError?: (status: number, url: string) => string;
+}
+
+function buildGitHubHeaders(token: string, userAgent: string): Record<string, string> {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "User-Agent": userAgent,
+  };
+}
+
+export async function fetchGitHubJson<T>(
+  url: string,
+  token: string,
+  options: GitHubFetchOptions,
+): Promise<T> {
+  const controller = options.timeoutMs === undefined ? null : new AbortController();
+  const timeout = controller === null
+    ? null
+    : setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const response = await fetch(url, {
+      headers: buildGitHubHeaders(token, options.userAgent),
+      ...(controller === null ? {} : { signal: controller.signal }),
+    });
+    if (!response.ok) {
+      throw new Error(options.formatHttpError?.(response.status, url) ?? `HTTP ${response.status}`);
+    }
+    return await response.json() as T;
+  } finally {
+    if (timeout !== null) clearTimeout(timeout);
+  }
+}
+
+export async function fetchGitHubArrayBuffer(
+  url: string,
+  token: string,
+  options: GitHubFetchOptions,
+): Promise<ArrayBuffer> {
+  const controller = options.timeoutMs === undefined ? null : new AbortController();
+  const timeout = controller === null
+    ? null
+    : setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const response = await fetch(url, {
+      headers: buildGitHubHeaders(token, options.userAgent),
+      ...(controller === null ? {} : { signal: controller.signal }),
+    });
+    if (!response.ok) {
+      throw new Error(options.formatHttpError?.(response.status, url) ?? `HTTP ${response.status}`);
+    }
+    // Intentionally not awaited: the timeout (when set) is cleared once the
+    // headers arrive and never aborts the body read, matching the original
+    // backfill implementation.
+    return response.arrayBuffer();
+  } finally {
+    if (timeout !== null) clearTimeout(timeout);
+  }
+}
+
+/** Run a git command; trimmed stdout, or null on failure or empty output. */
+export function runGitCommand(repoRoot: string, args: string[]): string | null {
+  try {
+    const output = execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return output === "" ? null : output;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse a JSON file as it existed at a commit; null when missing or invalid. */
+export function readJsonFromCommit(
+  repoRoot: string,
+  commitSha: string,
+  relativePath: string,
+): unknown | null {
+  const raw = runGitCommand(repoRoot, ["show", `${commitSha}:${relativePath}`]);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/** Latest first-parent commit at or before the timestamp, or null. */
+export function resolveSourceCommitAtTime(repoRoot: string, timestampIso: string): string | null {
+  return runGitCommand(
+    repoRoot,
+    ["rev-list", "-1", "--first-parent", `--before=${timestampIso}`, "HEAD"],
+  );
+}

--- a/scripts/lib/history-utils.ts
+++ b/scripts/lib/history-utils.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs";
 import { resolve } from "node:path";
 
 export const CANONICAL_HISTORY_CUTOFF_HOUR_UTC = 4;
@@ -13,4 +14,33 @@ export function toCanonicalHistoryCutoffIso(snapshotDate: string): string {
 
 export function getHistoryDir(repoRoot: string): string {
   return resolve(repoRoot, "history");
+}
+
+/** snapshot_YYYY_MM_DD.json file names in the history dir, in readdir order. */
+export function listSnapshotFileNames(historyDir: string): string[] {
+  return readdirSync(historyDir)
+    .filter((name) => /^snapshot_\d{4}_\d{2}_\d{2}\.json$/.test(name));
+}
+
+/**
+ * Last item whose timestamp is at or before targetMs. Items must be in
+ * ascending time order; items with a null timestamp are skipped, and scanning
+ * stops at the first item past the target.
+ */
+export function findLastAtOrBefore<T>(
+  items: readonly T[],
+  toTimeMs: (item: T) => number | null,
+  targetMs: number,
+): T | null {
+  let selected: T | null = null;
+  for (const item of items) {
+    const timeMs = toTimeMs(item);
+    if (timeMs === null) continue;
+    if (timeMs <= targetMs) {
+      selected = item;
+    } else {
+      break;
+    }
+  }
+  return selected;
 }

--- a/scripts/lib/manifests.ts
+++ b/scripts/lib/manifests.ts
@@ -1,3 +1,6 @@
+import { resolve } from "node:path";
+import { readJsonFile } from "./json-utils.js";
+
 export type ManifestType = "map" | "mod";
 export type ManifestDirectory = "maps" | "mods";
 
@@ -34,4 +37,15 @@ export function resolveListingIdAndDir(
     return { id: String(data["map-id"]), dir: "maps" };
   }
   return { id: String(data["mod-id"]), dir: "mods" };
+}
+
+/** Listing ids from <dir>/index.json (its "maps"/"mods" array), in index order. */
+export function readListingIdsFromIndex(repoRoot: string, dir: ManifestDirectory): string[] {
+  const indexPath = resolve(repoRoot, dir, "index.json");
+  const parsed = readJsonFile<Record<string, unknown>>(indexPath);
+  const ids = parsed[dir];
+  if (!Array.isArray(ids)) {
+    throw new Error(`Invalid ${dir}/index.json at ${indexPath}: missing ${dir} array`);
+  }
+  return ids.filter((value): value is string => typeof value === "string");
 }

--- a/scripts/lib/map-field-utils.ts
+++ b/scripts/lib/map-field-utils.ts
@@ -21,6 +21,23 @@ export function isPresentIssueValue(value: unknown): value is string {
   return getOptionalIssueValue(value) !== undefined;
 }
 
+/** Selected labels from an issue-form checkbox field (array or markdown checkbox lines). */
+export function parseCheckedBoxes(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.map((tag) => String(tag).trim()).filter(Boolean);
+  }
+  if (typeof raw !== "string" || !raw || raw === "_No response_") return [];
+  return raw
+    .split("\n")
+    .filter((line) => line.startsWith("- [X]") || line.startsWith("- [x]"))
+    .map((line) => line.replace(/^- \[[Xx]\]\s*/, "").trim())
+    .filter(Boolean);
+}
+
+export function combineMapTags(location: string, specialDemand: string[]): string[] {
+  return Array.from(new Set([location, ...specialDemand]));
+}
+
 export function getRequiredIssueValue(fieldName: string, value: unknown): string {
   const resolved = getOptionalIssueValue(value);
   if (!resolved) {

--- a/scripts/lib/map-update-logic.ts
+++ b/scripts/lib/map-update-logic.ts
@@ -10,23 +10,7 @@ import {
   SOURCE_QUALITY_SET,
   SPECIAL_DEMAND_TAG_SET,
 } from "./map-constants.js";
-import { isPresentIssueValue } from "./map-field-utils.js";
-
-function parseCheckedBoxes(raw: unknown): string[] {
-  if (Array.isArray(raw)) {
-    return raw.map((tag) => String(tag).trim()).filter(Boolean);
-  }
-  if (typeof raw !== "string" || !raw || raw === "_No response_") return [];
-  return raw
-    .split("\n")
-    .filter((line) => line.startsWith("- [X]") || line.startsWith("- [x]"))
-    .map((line) => line.replace(/^- \[[Xx]\]\s*/, "").trim())
-    .filter(Boolean);
-}
-
-function combineMapTags(location: string, specialDemand: string[]): string[] {
-  return Array.from(new Set([location, ...specialDemand]));
-}
+import { combineMapTags, isPresentIssueValue, parseCheckedBoxes } from "./map-field-utils.js";
 
 function requireManifestString(
   fieldName: string,

--- a/scripts/lib/railyard-app-downloads.ts
+++ b/scripts/lib/railyard-app-downloads.ts
@@ -7,6 +7,8 @@ import {
 } from "./semver.js";
 export { normalizeStableSemverTag } from "./semver.js";
 import { isObject, toFiniteNonNegativeNumber, sortObjectByKeys } from "./json-utils.js";
+import { findLastAtOrBefore } from "./history-utils.js";
+import { toUtcDateKey } from "./time-buckets.js";
 
 const RAILYARD_APP_DOWNLOAD_HISTORY_FILE = ["history", "railyard_app_downloads.json"] as const;
 
@@ -81,11 +83,7 @@ export function getRailyardAppDownloadHistoryPath(repoRoot: string): string {
   return resolve(repoRoot, ...RAILYARD_APP_DOWNLOAD_HISTORY_FILE);
 }
 
-export function toHourBucketIso(date: Date): string {
-  const bucket = new Date(date.getTime());
-  bucket.setUTCMinutes(0, 0, 0);
-  return bucket.toISOString();
-}
+export { toHourBucketIso } from "./time-buckets.js";
 
 export function compareSemverDescending(a: string, b: string): number {
   return compareStableSemverDesc(a, b);
@@ -249,24 +247,11 @@ function listSnapshotKeys(history: RailyardAppDownloadHistory): string[] {
   return Object.keys(history.snapshots).sort((a, b) => Date.parse(a) - Date.parse(b));
 }
 
-function toDateKey(isoValue: string): string | null {
-  const parsed = Date.parse(isoValue);
-  if (!Number.isFinite(parsed)) return null;
-  return new Date(parsed).toISOString().slice(0, 10).replaceAll("-", "_");
-}
-
 function findSnapshotAtOrBefore(history: RailyardAppDownloadHistory, targetMs: number): string | null {
-  let selected: string | null = null;
-  for (const key of listSnapshotKeys(history)) {
+  return findLastAtOrBefore(listSnapshotKeys(history), (key) => {
     const keyMs = Date.parse(key);
-    if (!Number.isFinite(keyMs)) continue;
-    if (keyMs <= targetMs) {
-      selected = key;
-    } else {
-      break;
-    }
-  }
-  return selected;
+    return Number.isFinite(keyMs) ? keyMs : null;
+  }, targetMs);
 }
 
 function toWindowDelta(current: number, baseline: number): number {
@@ -403,7 +388,7 @@ export function buildRailyardAppByDayCsvRows(history: RailyardAppDownloadHistory
 
   const dayToSnapshot = new Map<string, RailyardAppHistorySnapshot>();
   for (const key of snapshotKeys) {
-    const dateKey = toDateKey(key);
+    const dateKey = toUtcDateKey(key);
     if (!dateKey) continue;
     dayToSnapshot.set(dateKey, history.snapshots[key]!);
   }

--- a/scripts/lib/script-runtime.ts
+++ b/scripts/lib/script-runtime.ts
@@ -37,6 +37,20 @@ export function appendGitHubOutput(lines: string[]): void {
   appendFileSync(outputPath, `${lines.join("\n")}\n`);
 }
 
+/** JSON array of prefixed warnings capped at 30 entries for GitHub Actions output. */
+export function toWarningsOutputJson(prefix: string, warnings: string[]): string {
+  const MAX_WARNINGS = 30;
+  const normalized = warnings
+    .map((warning) => warning.trim())
+    .filter((warning) => warning !== "")
+    .map((warning) => `${prefix}${warning}`);
+  const displayed = normalized.slice(0, MAX_WARNINGS);
+  if (normalized.length > displayed.length) {
+    displayed.push(`...and ${normalized.length - displayed.length} more warnings`);
+  }
+  return JSON.stringify(displayed);
+}
+
 function stripWrappedQuotes(value: string): string {
   if (value.length >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
     return value.slice(1, -1);

--- a/scripts/lib/time-buckets.ts
+++ b/scripts/lib/time-buckets.ts
@@ -1,0 +1,22 @@
+/** Shared UTC date/hour bucket helpers. */
+
+/** ISO timestamp truncated to the start of the UTC hour. */
+export function toHourBucketIso(date: Date): string {
+  const bucket = new Date(date.getTime());
+  bucket.setUTCMinutes(0, 0, 0);
+  return bucket.toISOString();
+}
+
+/** UTC date key in YYYY-MM-DD form, or null when the input does not parse. */
+export function toDateKey(isoValue: string): string | null {
+  const parsed = Date.parse(isoValue);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString().slice(0, 10);
+}
+
+/** UTC date key in YYYY_MM_DD form, or null when the input does not parse. */
+export function toUtcDateKey(isoLike: string): string | null {
+  const parsed = Date.parse(isoLike);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString().slice(0, 10).replaceAll("-", "_");
+}

--- a/scripts/lib/website-analytics-capture.ts
+++ b/scripts/lib/website-analytics-capture.ts
@@ -1,0 +1,119 @@
+import {
+  normalizeAndCanonicalizePath,
+  sortMetricMap,
+  type WebsiteAnalyticsSnapshot,
+  type WebsiteAnalyticsMetricMap,
+} from "./website-analytics.js";
+import {
+  fetchCloudflareWindowMetrics,
+  resolveZoneTag,
+  resolveApiToken,
+  type CloudflareWebsiteAnalyticsQueryParams,
+} from "./cloudflare-website-analytics.js";
+
+export interface CloudflareCredentials {
+  zoneTag: string;
+  apiToken: string;
+}
+
+export function requireCloudflareCredentials(): CloudflareCredentials {
+  const zoneTag = resolveZoneTag();
+  const apiToken = resolveApiToken();
+
+  if (!zoneTag) {
+    throw new Error(
+      "Cloudflare zone identifier not found. Set CLOUDFLARE_ZONE_TAG.",
+    );
+  }
+
+  if (!apiToken) {
+    throw new Error(
+      "Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN.",
+    );
+  }
+
+  return { zoneTag, apiToken };
+}
+
+function normalizeCloudflareMetricMap(
+  raw: Record<string, unknown>,
+  pathAliases: Record<string, string>,
+  canonicalizePath: boolean,
+): WebsiteAnalyticsMetricMap {
+  const normalized: WebsiteAnalyticsMetricMap = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    const visits = typeof value === "object" && value !== null && "visits" in value
+      ? typeof (value as Record<string, unknown>).visits === "number"
+        ? (value as Record<string, unknown>).visits as number
+        : 0
+      : 0;
+
+    if (visits <= 0) continue;
+
+    if (canonicalizePath) {
+      const normKey = normalizeAndCanonicalizePath(key, pathAliases);
+      if (!normKey) continue;
+      if (!normalized[normKey]) {
+        normalized[normKey] = 0;
+      }
+      normalized[normKey] += visits;
+    } else {
+      normalized[key] = visits;
+    }
+  }
+
+  return sortMetricMap(normalized);
+}
+
+export interface CaptureWindowSnapshotArgs extends CloudflareCredentials {
+  pathAliases: Record<string, string>;
+  windowStartIso: string;
+  windowEndIso: string;
+  capturedAtIso: string;
+  verbose?: boolean;
+}
+
+/**
+ * Fetches one Cloudflare analytics window and normalizes it into a
+ * WebsiteAnalyticsSnapshot (page paths canonicalized via the alias map; other
+ * dimensions passed through). Shared by the hourly capture script and the
+ * ops backfill gap-filler.
+ */
+export async function captureWindowSnapshot(
+  args: CaptureWindowSnapshotArgs,
+): Promise<WebsiteAnalyticsSnapshot> {
+  const queryParams: CloudflareWebsiteAnalyticsQueryParams = {
+    zoneTag: args.zoneTag,
+    apiToken: args.apiToken,
+    windowStartIso: args.windowStartIso,
+    windowEndIso: args.windowEndIso,
+  };
+
+  if (args.verbose) {
+    console.log(
+      `Querying Cloudflare for window ${args.windowStartIso} to ${args.windowEndIso}...`,
+    );
+  }
+  const metrics = await fetchCloudflareWindowMetrics(queryParams);
+
+  if (args.verbose) {
+    console.log(
+      `Received ${metrics.totalVisits} total visits, ${Object.keys(metrics.pages).length} pages`,
+    );
+  }
+
+  return {
+    captured_at: args.capturedAtIso,
+    window_start: args.windowStartIso,
+    window_end: args.windowEndIso,
+    totals: {
+      visits: metrics.totalVisits,
+    },
+    pages: normalizeCloudflareMetricMap(metrics.pages, args.pathAliases, true),
+    countries: normalizeCloudflareMetricMap(metrics.countries, args.pathAliases, false),
+    browsers: normalizeCloudflareMetricMap(metrics.browsers, args.pathAliases, false),
+    operating_systems: normalizeCloudflareMetricMap(metrics.operatingSystems, args.pathAliases, false),
+    devices: normalizeCloudflareMetricMap(metrics.devices, args.pathAliases, false),
+  };
+}

--- a/scripts/lib/website-analytics.ts
+++ b/scripts/lib/website-analytics.ts
@@ -88,17 +88,7 @@ export function getWebsiteAnalyticsDayFilePath(repoRoot: string, dateKey: string
   );
 }
 
-export function toHourBucketIso(date: Date): string {
-  const bucket = new Date(date.getTime());
-  bucket.setUTCMinutes(0, 0, 0);
-  return bucket.toISOString();
-}
-
-export function toDateKey(isoValue: string): string | null {
-  const parsed = Date.parse(isoValue);
-  if (!Number.isFinite(parsed)) return null;
-  return new Date(parsed).toISOString().slice(0, 10);
-}
+export { toDateKey, toHourBucketIso } from "./time-buckets.js";
 
 function normalizeMetricMap(value: unknown): WebsiteAnalyticsMetricMap {
   const map: WebsiteAnalyticsMetricMap = {};

--- a/scripts/listings/generate-map-demand-stats.ts
+++ b/scripts/listings/generate-map-demand-stats.ts
@@ -6,7 +6,7 @@ import {
   sumDownloadAttributionDeltaFetches,
   writeDownloadAttributionDeltaFile,
 } from "../lib/download-attribution.js";
-import { appendGitHubOutput, getNonEmptyEnv, isTruthyEnv, resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
+import { appendGitHubOutput, getNonEmptyEnv, isTruthyEnv, resolveRepoRoot, runAndExitOnError, toWarningsOutputJson } from "../lib/script-runtime.js";
 import { filterListingMessages, isTestListing } from "../lib/test-listings.js";
 
 function parseCliArgs(argv: string[]): { force: boolean; mapId?: string; strictFingerprintCache: boolean } {
@@ -50,19 +50,6 @@ function parseCliArgs(argv: string[]): { force: boolean; mapId?: string; strictF
   }
 
   return { force, mapId, strictFingerprintCache };
-}
-
-function toWarningsOutputJson(prefix: string, warnings: string[]): string {
-  const MAX_WARNINGS = 30;
-  const normalized = warnings
-    .map((warning) => warning.trim())
-    .filter((warning) => warning !== "")
-    .map((warning) => `${prefix}${warning}`);
-  const displayed = normalized.slice(0, MAX_WARNINGS);
-  if (normalized.length > displayed.length) {
-    displayed.push(`...and ${normalized.length - displayed.length} more warnings`);
-  }
-  return JSON.stringify(displayed);
 }
 
 async function run(): Promise<void> {

--- a/scripts/listings/sync-last-updated.ts
+++ b/scripts/listings/sync-last-updated.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { writeJsonFile } from "../lib/json-utils.js";
+import { readListingIdsFromIndex } from "../lib/manifests.js";
 import { appendGitHubOutput, resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
 
 // sync-last-updated copies the per-listing `last_updated` (newest release date,
@@ -35,16 +36,6 @@ function readJsonFile<T>(path: string): T {
   return JSON.parse(readFileSync(path, "utf-8")) as T;
 }
 
-function getListingIds(repoRoot: string, dir: string): string[] {
-  const indexPath = resolve(repoRoot, dir, "index.json");
-  const parsed = readJsonFile<Record<string, unknown>>(indexPath);
-  const ids = parsed[dir];
-  if (!Array.isArray(ids)) {
-    throw new Error(`Invalid ${dir}/index.json at ${indexPath}: missing ${dir} array`);
-  }
-  return ids.filter((value): value is string => typeof value === "string");
-}
-
 function resolveLastUpdated(listing: ListingIntegrityEntry | undefined): number | undefined {
   const value = listing?.last_updated;
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
@@ -63,7 +54,7 @@ export function syncLastUpdatedFromIntegrity(repoRoot: string): SyncLastUpdatedR
     }
     const listings = integrity.listings as Record<string, ListingIntegrityEntry>;
 
-    for (const id of getListingIds(repoRoot, dir).sort()) {
+    for (const id of readListingIdsFromIndex(repoRoot, dir).sort()) {
       processed += 1;
       const lastUpdated = resolveLastUpdated(listings[id]);
       if (lastUpdated === undefined) {

--- a/scripts/listings/sync-map-file-sizes.ts
+++ b/scripts/listings/sync-map-file-sizes.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { writeJsonFile } from "../lib/json-utils.js";
+import { readListingIdsFromIndex } from "../lib/manifests.js";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { appendGitHubOutput, resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
@@ -53,15 +54,6 @@ function normalizeFileSizes(value: unknown): Record<string, number> {
   return sortNumericRecord(normalized);
 }
 
-function getMapIds(repoRoot: string): string[] {
-  const indexPath = resolve(repoRoot, "maps", "index.json");
-  const parsed = readJsonFile<{ maps?: unknown }>(indexPath);
-  if (!Array.isArray(parsed.maps)) {
-    throw new Error(`Invalid maps/index.json at ${indexPath}: missing maps array`);
-  }
-  return parsed.maps.filter((value): value is string => typeof value === "string");
-}
-
 function resolveLatestCompleteFileSizes(
   listing: ListingIntegrityEntry | undefined,
 ): {
@@ -107,7 +99,7 @@ export function syncMapFileSizesFromIntegrity(
   }
 
   const listings = integrity.listings as Record<string, ListingIntegrityEntry>;
-  const ids = getMapIds(repoRoot).sort();
+  const ids = readListingIdsFromIndex(repoRoot, "maps").sort();
   let updatedMaps = 0;
   let mapsWithoutCompleteVersion = 0;
   let mapsWithMissingFileSizes = 0;

--- a/scripts/ops/audit-download-history.ts
+++ b/scripts/ops/audit-download-history.ts
@@ -1,7 +1,8 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { DownloadHistorySnapshot } from "../lib/download-history.js";
+import { listSnapshotFileNames } from "../lib/history-utils.js";
 import { resolveRepoRoot } from "../lib/script-runtime.js";
 
 type SectionName = "maps" | "mods";
@@ -28,9 +29,7 @@ function sumDownloads(downloads: Record<string, Record<string, number>> | undefi
 }
 
 function listSnapshots(repoRoot: string): string[] {
-  return readdirSync(resolve(repoRoot, "history"))
-    .filter((name) => /^snapshot_\d{4}_\d{2}_\d{2}\.json$/.test(name))
-    .sort();
+  return listSnapshotFileNames(resolve(repoRoot, "history")).sort();
 }
 
 function readSnapshot(repoRoot: string, fileName: string): DownloadHistorySnapshot {

--- a/scripts/ops/backfill-website-analytics.ts
+++ b/scripts/ops/backfill-website-analytics.ts
@@ -7,24 +7,18 @@ import {
   updateValidPaths,
   toHourBucketIso,
   toDateKey,
-  normalizeAndCanonicalizePath,
   mergeSortedUniqueStrings,
-  sortMetricMap,
   type WebsiteAnalyticsSnapshot,
-  type WebsiteAnalyticsMetricMap,
 } from "../lib/website-analytics.js";
 import {
-  fetchCloudflareWindowMetrics,
-  resolveZoneTag,
-  resolveApiToken,
-  type CloudflareWebsiteAnalyticsQueryParams,
-} from "../lib/cloudflare-website-analytics.js";
+  captureWindowSnapshot,
+  requireCloudflareCredentials,
+  type CloudflareCredentials,
+} from "../lib/website-analytics-capture.js";
 import { loadLocalDotEnv, resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
 
-interface CliArgs {
+interface CliArgs extends CloudflareCredentials {
   repoRoot: string;
-  zoneTag: string;
-  apiToken: string;
   days: number;
   resetHistory: boolean;
 }
@@ -35,20 +29,7 @@ function parseArgs(argv: string[]): CliArgs {
   const repoRoot = resolveRepoRoot(import.meta.dirname);
   loadLocalDotEnv(repoRoot);
 
-  const zoneTag = resolveZoneTag();
-  const apiToken = resolveApiToken();
-
-  if (!zoneTag) {
-    throw new Error(
-      "Cloudflare zone identifier not found. Set CLOUDFLARE_ZONE_TAG.",
-    );
-  }
-
-  if (!apiToken) {
-    throw new Error(
-      "Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN.",
-    );
-  }
+  const credentials = requireCloudflareCredentials();
 
   let days = DEFAULT_BACKFILL_DAYS;
   let resetHistory = false;
@@ -76,79 +57,9 @@ function parseArgs(argv: string[]): CliArgs {
 
   return {
     repoRoot,
-    zoneTag,
-    apiToken,
+    ...credentials,
     days,
     resetHistory,
-  };
-}
-
-function normalizeMetricMap(
-  raw: Record<string, unknown>,
-  pathAliases: Record<string, string>,
-  canonicalizePath: boolean,
-): WebsiteAnalyticsMetricMap {
-  const normalized: WebsiteAnalyticsMetricMap = {};
-
-  for (const [key, value] of Object.entries(raw)) {
-    const visits = typeof value === "object" && value !== null && "visits" in value
-      ? typeof (value as Record<string, unknown>).visits === "number"
-        ? (value as Record<string, unknown>).visits as number
-        : 0
-      : 0;
-
-    if (visits <= 0) continue;
-
-    if (canonicalizePath) {
-      const normKey = normalizeAndCanonicalizePath(key, pathAliases);
-      if (!normKey) continue;
-      if (!normalized[normKey]) {
-        normalized[normKey] = 0;
-      }
-      normalized[normKey] += visits;
-    } else {
-      normalized[key] = visits;
-    }
-  }
-
-  return sortMetricMap(normalized);
-}
-
-async function captureWindowAnalytics(
-  zoneTag: string,
-  apiToken: string,
-  pathAliases: Record<string, string>,
-  windowStartIso: string,
-  windowEndIso: string,
-  capturedAtIso: string,
-): Promise<WebsiteAnalyticsSnapshot> {
-  const queryParams: CloudflareWebsiteAnalyticsQueryParams = {
-    zoneTag,
-    apiToken,
-    windowStartIso,
-    windowEndIso,
-  };
-
-  const metrics = await fetchCloudflareWindowMetrics(queryParams);
-
-  const normalizedPages = normalizeMetricMap(metrics.pages, pathAliases, true);
-  const normalizedCountries = normalizeMetricMap(metrics.countries, pathAliases, false);
-  const normalizedBrowsers = normalizeMetricMap(metrics.browsers, pathAliases, false);
-  const normalizedOs = normalizeMetricMap(metrics.operatingSystems, pathAliases, false);
-  const normalizedDevices = normalizeMetricMap(metrics.devices, pathAliases, false);
-
-  return {
-    captured_at: capturedAtIso,
-    window_start: windowStartIso,
-    window_end: windowEndIso,
-    totals: {
-      visits: metrics.totalVisits,
-    },
-    pages: normalizedPages,
-    countries: normalizedCountries,
-    browsers: normalizedBrowsers,
-    operating_systems: normalizedOs,
-    devices: normalizedDevices,
   };
 }
 
@@ -184,14 +95,14 @@ async function run(): Promise<void> {
     console.log(`Fetching hour ${hourKey}...`);
     let hourlySnapshot: WebsiteAnalyticsSnapshot;
     try {
-      hourlySnapshot = await captureWindowAnalytics(
-        args.zoneTag,
-        args.apiToken,
-        history.path_aliases,
+      hourlySnapshot = await captureWindowSnapshot({
+        zoneTag: args.zoneTag,
+        apiToken: args.apiToken,
+        pathAliases: history.path_aliases,
         windowStartIso,
         windowEndIso,
         capturedAtIso,
-      );
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (message.includes("cannot request data older than")) {

--- a/scripts/ops/create-manual-download-attribution.ts
+++ b/scripts/ops/create-manual-download-attribution.ts
@@ -12,6 +12,7 @@ import {
   toDownloadAttributionAssetKey,
   writeDownloadAttributionLedger,
 } from "../lib/download-attribution.js";
+import { getFlagValue, hasFlag } from "../lib/cli.js";
 import { readJsonFile, writeJsonFile } from "../lib/json-utils.js";
 import { resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
 
@@ -34,31 +35,14 @@ interface ModIntegrityCacheEntry {
   };
 }
 
-function getArgValue(args: string[], name: string): string | undefined {
-  const key = `--${name}=`;
-  for (const arg of args) {
-    if (arg.startsWith(key)) return arg.slice(key.length);
-  }
-  for (let i = 0; i < args.length; i += 1) {
-    if (args[i] === `--${name}`) {
-      return args[i + 1];
-    }
-  }
-  return undefined;
-}
-
-function hasFlag(args: string[], name: string): boolean {
-  return args.includes(`--${name}`);
-}
-
 function parseArgs(argv: string[]): CliArgs {
   const repoRoot = process.env.RAILYARD_REPO_ROOT ?? resolveRepoRoot(import.meta.dirname);
-  const specValue = getArgValue(argv, "spec");
+  const specValue = getFlagValue(argv, "spec");
   if (!specValue || specValue.trim() === "") {
     throw new Error("Missing --spec <path>.");
   }
   const specPath = resolve(repoRoot, specValue.trim());
-  const outputValue = getArgValue(argv, "output")?.trim();
+  const outputValue = getFlagValue(argv, "output")?.trim();
   const outputPath = outputValue
     ? resolve(repoRoot, outputValue)
     : resolve(repoRoot, "tmp", "manual-download-attribution.delta.json");

--- a/scripts/ops/spotcheck-attribution-logs.ts
+++ b/scripts/ops/spotcheck-attribution-logs.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import JSZip from "jszip";
+import { getFlagValue } from "../lib/cli.js";
 import { parseAttributionBackfillLogHits } from "../lib/download-attribution-backfill-core.js";
 import type { DownloadAttributionLedger } from "../lib/download-attribution.js";
 import type { IntegrityOutput } from "../lib/integrity.js";
@@ -47,19 +48,6 @@ function parseIntArg(value: string | undefined, fallback: number): number {
   return parsed;
 }
 
-function getArgValue(args: string[], name: string): string | undefined {
-  const key = `--${name}=`;
-  for (const arg of args) {
-    if (arg.startsWith(key)) return arg.slice(key.length);
-  }
-  for (let i = 0; i < args.length; i += 1) {
-    if (args[i] === `--${name}`) {
-      return args[i + 1];
-    }
-  }
-  return undefined;
-}
-
 function parseMaps(raw: string | undefined): string[] {
   if (!raw) return [];
   return raw
@@ -71,12 +59,12 @@ function parseMaps(raw: string | undefined): string[] {
 function parseArgs(argv: string[]): CliArgs {
   const repoRoot = process.env.RAILYARD_REPO_ROOT ?? resolveRepoRoot(import.meta.dirname);
   const repoFullName = (
-    getArgValue(argv, "repo")
+    getFlagValue(argv, "repo")
     ?? process.env.GITHUB_REPOSITORY
     ?? "Subway-Builder-Modded/registry"
   ).trim();
   const token = (
-    getArgValue(argv, "token")
+    getFlagValue(argv, "token")
     ?? process.env.GH_DOWNLOADS_TOKEN
     ?? process.env.GITHUB_TOKEN
     ?? ""
@@ -85,12 +73,12 @@ function parseArgs(argv: string[]): CliArgs {
     throw new Error("Missing token. Provide --token or GH_DOWNLOADS_TOKEN/GITHUB_TOKEN.");
   }
 
-  const days = parseIntArg(getArgValue(argv, "days"), 90);
-  const maxRuns = parseIntArg(getArgValue(argv, "max-runs"), 120);
-  const maps = parseMaps(getArgValue(argv, "maps"));
-  const compareRef = getArgValue(argv, "compare-ref")?.trim() || undefined;
-  const topLoss = parseIntArg(getArgValue(argv, "top-loss"), 12);
-  const outputPath = getArgValue(argv, "output")?.trim() || undefined;
+  const days = parseIntArg(getFlagValue(argv, "days"), 90);
+  const maxRuns = parseIntArg(getFlagValue(argv, "max-runs"), 120);
+  const maps = parseMaps(getFlagValue(argv, "maps"));
+  const compareRef = getFlagValue(argv, "compare-ref")?.trim() || undefined;
+  const topLoss = parseIntArg(getFlagValue(argv, "top-loss"), 12);
+  const outputPath = getFlagValue(argv, "output")?.trim() || undefined;
 
   return {
     repoRoot,

--- a/scripts/ops/spotcheck-attribution-logs.ts
+++ b/scripts/ops/spotcheck-attribution-logs.ts
@@ -4,6 +4,11 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import JSZip from "jszip";
 import { getFlagValue } from "../lib/cli.js";
+import {
+  fetchGitHubArrayBuffer,
+  fetchGitHubJson,
+  type GitHubFetchOptions,
+} from "../lib/git-history.js";
 import { parseAttributionBackfillLogHits } from "../lib/download-attribution-backfill-core.js";
 import type { DownloadAttributionLedger } from "../lib/download-attribution.js";
 import type { IntegrityOutput } from "../lib/integrity.js";
@@ -93,32 +98,17 @@ function parseArgs(argv: string[]): CliArgs {
   };
 }
 
+const GITHUB_FETCH_OPTIONS: GitHubFetchOptions = {
+  userAgent: "railyard-attribution-spotcheck",
+  formatHttpError: (status, url) => `GitHub API ${status} for ${url}`,
+};
+
 async function fetchJson<T>(url: string, token: string): Promise<T> {
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "User-Agent": "railyard-attribution-spotcheck",
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`GitHub API ${response.status} for ${url}`);
-  }
-  return await response.json() as T;
+  return fetchGitHubJson<T>(url, token, GITHUB_FETCH_OPTIONS);
 }
 
 async function fetchArrayBuffer(url: string, token: string): Promise<ArrayBuffer> {
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "User-Agent": "railyard-attribution-spotcheck",
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`GitHub API ${response.status} for ${url}`);
-  }
-  return await response.arrayBuffer();
+  return fetchGitHubArrayBuffer(url, token, GITHUB_FETCH_OPTIONS);
 }
 
 function normalizeAssetBaseKey(assetKey: string): string {

--- a/scripts/telemetry/capture-discord-server-metrics.ts
+++ b/scripts/telemetry/capture-discord-server-metrics.ts
@@ -1,4 +1,5 @@
 import { pathToFileURL } from "node:url";
+import { parseRetryAfterMs } from "../lib/discord-webhook.js";
 import { fetchWithTimeout } from "../lib/http.js";
 import {
   createEmptyDiscordServerMetricsHistory,
@@ -208,18 +209,6 @@ function normalizeGuildChannel(value: unknown): GuildChannel | null {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function parseRetryAfterMs(payload: unknown): number | null {
-  if (!payload || typeof payload !== "object") return null;
-  const retryAfter = (payload as { retry_after?: unknown }).retry_after;
-  if (typeof retryAfter !== "number" || !Number.isFinite(retryAfter) || retryAfter < 0) {
-    return null;
-  }
-  if (retryAfter > 1000) {
-    return Math.ceil(retryAfter);
-  }
-  return Math.ceil(retryAfter * 1000);
 }
 
 async function fetchDiscordResponse(url: string, token: string, heartbeatLabel: string): Promise<Response> {

--- a/scripts/telemetry/capture-website-analytics.ts
+++ b/scripts/telemetry/capture-website-analytics.ts
@@ -5,129 +5,23 @@ import {
   upsertHourlySnapshot,
   updateValidPaths,
   toHourBucketIso,
-  normalizeAndCanonicalizePath,
   mergeSortedUniqueStrings,
-  sortMetricMap,
-  type WebsiteAnalyticsSnapshot,
-  type WebsiteAnalyticsMetricMap,
 } from "../lib/website-analytics.js";
 import {
-  fetchCloudflareWindowMetrics,
-  resolveZoneTag,
-  resolveApiToken,
-  type CloudflareWebsiteAnalyticsQueryParams,
-} from "../lib/cloudflare-website-analytics.js";
+  captureWindowSnapshot,
+  requireCloudflareCredentials,
+  type CloudflareCredentials,
+} from "../lib/website-analytics-capture.js";
 import { loadLocalDotEnv, resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
 
-interface CliArgs {
+interface CliArgs extends CloudflareCredentials {
   repoRoot: string;
-  zoneTag: string;
-  apiToken: string;
 }
 
 function parseArgs(): CliArgs {
   const repoRoot = resolveRepoRoot(import.meta.dirname);
   loadLocalDotEnv(repoRoot);
-
-  const zoneTag = resolveZoneTag();
-  const apiToken = resolveApiToken();
-
-  if (!zoneTag) {
-    throw new Error(
-      "Cloudflare zone identifier not found. Set CLOUDFLARE_ZONE_TAG.",
-    );
-  }
-
-  if (!apiToken) {
-    throw new Error(
-      "Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN.",
-    );
-  }
-
-  return {
-    repoRoot,
-    zoneTag,
-    apiToken,
-  };
-}
-
-function normalizeMetricMap(
-  raw: Record<string, unknown>,
-  pathAliases: Record<string, string>,
-  canonicalizePath: boolean,
-): WebsiteAnalyticsMetricMap {
-  const normalized: WebsiteAnalyticsMetricMap = {};
-
-  for (const [key, value] of Object.entries(raw)) {
-    const visits = typeof value === "object" && value !== null && "visits" in value
-      ? typeof (value as Record<string, unknown>).visits === "number"
-        ? (value as Record<string, unknown>).visits as number
-        : 0
-      : 0;
-
-    if (visits <= 0) continue;
-
-    if (canonicalizePath) {
-      const normKey = normalizeAndCanonicalizePath(key, pathAliases);
-      if (!normKey) continue;
-      if (!normalized[normKey]) {
-        normalized[normKey] = 0;
-      }
-      normalized[normKey] += visits;
-    } else {
-      normalized[key] = visits;
-    }
-  }
-
-  return sortMetricMap(normalized);
-}
-
-async function captureWindowAnalytics(
-  zoneTag: string,
-  apiToken: string,
-  pathAliases: Record<string, string>,
-  windowStartIso: string,
-  windowEndIso: string,
-  capturedAtIso: string,
-): Promise<WebsiteAnalyticsSnapshot> {
-  const queryParams: CloudflareWebsiteAnalyticsQueryParams = {
-    zoneTag,
-    apiToken,
-    windowStartIso,
-    windowEndIso,
-  };
-
-  console.log(
-    `Querying Cloudflare for window ${windowStartIso} to ${windowEndIso}...`,
-  );
-  const metrics = await fetchCloudflareWindowMetrics(queryParams);
-
-  console.log(
-    `Received ${metrics.totalVisits} total visits, ${Object.keys(metrics.pages).length} pages`,
-  );
-
-  // Normalize pages with path filtering
-  const normalizedPages = normalizeMetricMap(metrics.pages, pathAliases, true);
-
-  // Other dimensions: no special normalization needed
-  const normalizedCountries = normalizeMetricMap(metrics.countries, pathAliases, false);
-  const normalizedBrowsers = normalizeMetricMap(metrics.browsers, pathAliases, false);
-  const normalizedOs = normalizeMetricMap(metrics.operatingSystems, pathAliases, false);
-  const normalizedDevices = normalizeMetricMap(metrics.devices, pathAliases, false);
-
-  return {
-    captured_at: capturedAtIso,
-    window_start: windowStartIso,
-    window_end: windowEndIso,
-    totals: {
-      visits: metrics.totalVisits,
-    },
-    pages: normalizedPages,
-    countries: normalizedCountries,
-    browsers: normalizedBrowsers,
-    operating_systems: normalizedOs,
-    devices: normalizedDevices,
-  };
+  return { repoRoot, ...requireCloudflareCredentials() };
 }
 
 async function run(): Promise<void> {
@@ -143,14 +37,15 @@ async function run(): Promise<void> {
   const windowStartIso = hourBucketIso;
   const windowEndIso = new Date(new Date(windowStartIso).getTime() + 60 * 60 * 1000).toISOString();
 
-  const snapshot = await captureWindowAnalytics(
-    args.zoneTag,
-    args.apiToken,
-    history.path_aliases,
+  const snapshot = await captureWindowSnapshot({
+    zoneTag: args.zoneTag,
+    apiToken: args.apiToken,
+    pathAliases: history.path_aliases,
     windowStartIso,
     windowEndIso,
     capturedAtIso,
-  );
+    verbose: true,
+  });
 
   // Upsert the hourly snapshot
   history = upsertHourlySnapshot({


### PR DESCRIPTION
Dedup clusters 2–10, stacked on #6288 (which now also carries cluster 1 via #6297). Together the dedup stack nets **−120 LoC with every extracted concept given exactly one home** (31 files, +488/−608 including cluster 1), verified behavior-preserving.

## New shared libs
- **`lib/cli.ts`** — lenient argv primitives (`getFlagValue` incl. `--flag=value` form, `hasFlag`). Converted the four scanners that map 1:1 (both ops attribution tools, generate-downloads, analytics-core). Strict parsers with per-script unknown-argument errors were deliberately left alone rather than changing accepted inputs.
- **`lib/git-history.ts`** — `runGitCommand`, `readJsonFromCommit`, `resolveSourceCommitAtTime`, and GitHub fetch helpers parameterized by user-agent/timeout/error-format so both prior copies' exact messages (and one documented timeout quirk) are reproduced. The rebuild script's strict-throwing variants and the two genuinely divergent `listWorkflowRuns` implementations stay local.
- **`lib/time-buckets.ts`** — `toHourBucketIso`/`toDateKey`/`toUtcDateKey` (previously 7 copies across 4 libs); prior export surfaces preserved via re-exports.
- Consolidated into existing homes: `parseCheckedBoxes` + `combineMapTags` → `map-field-utils` (update-listing keeps its null-on-empty wrapper, verified input-equivalent); `readListingIdsFromIndex` → `manifests`; `toWarningsOutputJson(prefix)` → `script-runtime`; snapshot listing/`findLastAtOrBefore` → `history-utils`; `parseRetryAfterMs` → `discord-webhook`.

## Deliberately skipped (behavior differs)
`sumDownloads` (finite-guard vs unchecked), `fetchZipBuffer` (signatures/timeouts/messages), `parsePositiveInteger` (null vs throw), `findDemandDataPath` (error-path semantics), map-demand-stats `getMapIds` (different error string), and all strict CLI loops. Each is a candidate for a future *behavior-changing* normalization pass, not a mechanical dedup.

## Verification
267/267 tests and clean tsc after every cluster commit, independently re-verified on the final stack; pre-existing TS7022 in capture-discord-server-metrics untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)