### PR TITLE
Decompose generateDownloadsDataFull into pipeline stages, behavior-locked

### DIFF
--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -1,15 +1,17 @@
-import type { MapManifest } from "./manifests.js";
+import type { ManifestDirectory, MapManifest } from "./manifests.js";
 import * as D from "./download-definitions.js";
 import { createGraphqlUsageState, fetchRepoReleaseIndexes, isSupportedReleaseTag, graphqlUsageSnapshot } from "./release-resolution.js";
 import type {
   IntegrityCache,
   IntegrityCacheEntry,
+  IntegrityOutput,
   IntegritySource,
   IntegrityVersionEntry,
   ListingIntegrityEntry,
   ManifestGameDependency,
 } from "./integrity.js";
 import { GAME_VERSION_REQUIRED_SINCE_EPOCH, parseManifestGameDependency } from "./integrity.js";
+import type { LoadedSecurityRules } from "./mod-security.js";
 import {
   type CustomVersionCandidate,
   type ListingContext,
@@ -244,47 +246,99 @@ function maxReleaseEpoch(values: Array<string | null | undefined>): number | und
   return best;
 }
 
-export async function generateDownloadsDataFull(
-  options: D.GenerateDownloadsOptions,
-): Promise<D.GenerateDownloadsResult> {
-  const repoRoot = options.repoRoot;
-  const listingType = options.listingType;
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const token = options.token;
-  const strictFingerprintCache = options.strictFingerprintCache === true;
-  const forceIntegrityRecheck = options.forceIntegrityRecheck === true;
-  const strictFingerprintCacheForMods = getStrictFingerprintCacheForListingType(
+// ---------------------------------------------------------------------------
+// Pipeline plumbing for generateDownloadsDataFull. The run is decomposed into
+// named stages; shared accumulators (warnings, stats, output maps) are carried
+// in FullRunContext and mutated by the stages exactly as the original inline
+// code did.
+// ---------------------------------------------------------------------------
+
+interface FullRunStats {
+  versionsChecked: number;
+  completeVersions: number;
+  incompleteVersions: number;
+  filteredVersions: number;
+  cacheHits: number;
+  adjustedDeltaTotal: number;
+  clampedVersions: number;
+}
+
+// Run-scope state shared by every pipeline stage.
+interface FullRunContext {
+  listingType: D.GenerateDownloadsOptions["listingType"];
+  fetchImpl: typeof fetch;
+  now: Date;
+  nowIso: string;
+  warnings: string[];
+  stats: FullRunStats;
+  strictFingerprintCacheForMods: boolean;
+  forceIntegrityRecheck: boolean;
+  modSecurityRules: LoadedSecurityRules | null;
+  attributionLedger: DownloadAttributionLedger;
+  attributionDelta: DownloadAttributionDelta;
+  previousIntegrity: IntegrityOutput | null;
+  previousDownloads: D.DownloadsByListing;
+  cache: IntegrityCache;
+  nextCache: IntegrityCache;
+  downloadsByListing: D.DownloadsByListing;
+  versionBucketInputs: D.VersionBucketInputsByListing;
+  integrityListings: Record<string, ListingIntegrityEntry>;
+  integrityAlerts: D.IntegrityAlert[];
+  listingMeta: Map<string, { listingName: string; authorId: string }>;
+  transientErrorListings: Set<string>;
+  repoIndexes: Map<string, D.RepoReleaseIndex>;
+  unavailableRepos: Set<string>;
+}
+
+type GithubReleaseAsset = D.RepoReleaseTagData["assets"] extends Map<string, infer V> ? V : never;
+
+// Per-listing working state built up while evaluating one listing's versions.
+interface ListingEvaluationState {
+  versionEntries: Record<string, IntegrityVersionEntry>;
+  // Per-version publish epoch (seconds); date-gates the game_version requirement.
+  publishEpochByVersion: Map<string, number | undefined>;
+  listingCacheEntries: Record<string, IntegrityCacheEntry>;
+  nextListingCacheEntries: Record<string, IntegrityCacheEntry>;
+  inspectZipWithMemo: ReturnType<typeof createInspectZipWithMemo>;
+}
+
+// Stage 1: read every listing manifest, resolve its update source (github repo
+// or custom update JSON), and collect the set of repos to index. Custom listings
+// whose update JSON fails transiently are recorded in transientErrorListings
+// with their previous download counts preserved.
+async function resolveListingContexts(params: {
+  ids: string[];
+  repoRoot: string;
+  dir: ManifestDirectory;
+  listingType: D.GenerateDownloadsOptions["listingType"];
+  fetchImpl: typeof fetch;
+  warnings: string[];
+  previousDownloads: D.DownloadsByListing;
+  downloadsByListing: D.DownloadsByListing;
+  listingContexts: Map<string, ListingContext>;
+  listingMeta: Map<string, { listingName: string; authorId: string }>;
+  repoSet: Set<string>;
+  transientErrorListings: Set<string>;
+}): Promise<void> {
+  const {
+    ids,
+    repoRoot,
+    dir,
     listingType,
-    strictFingerprintCache,
-  );
-  const warnings: string[] = [];
-  const dir = getDirectoryForType(listingType);
-  const ids = getIndexIds(repoRoot, dir);
-  const now = new Date();
-  const nowIso = now.toISOString();
-  const attributionLedger = options.attribution?.ledger ?? createEmptyDownloadAttributionLedger(nowIso);
-  const attributionDelta = options.attribution?.delta
-    ?? createDownloadAttributionDelta(`runtime:${listingType}:full`, undefined, nowIso);
-  const modSecurityRules = resolveModSecurityRules(listingType, repoRoot);
-  const previousIntegrity = loadIntegritySnapshot(repoRoot, dir);
-  const previousDownloads = loadDownloadsSnapshot(repoRoot, dir);
-
-  const cache = loadIntegrityCache(repoRoot, dir);
-  const nextCache: IntegrityCache = {
-    schema_version: 1,
-    entries: {},
-  };
-
-  const downloadsByListing: D.DownloadsByListing = {};
-  const listingContexts = new Map<string, ListingContext>();
-  const listingMeta = new Map<string, { listingName: string; authorId: string }>();
-  const repoSet = new Set<string>();
+    fetchImpl,
+    warnings,
+    previousDownloads,
+    downloadsByListing,
+    listingContexts,
+    listingMeta,
+    repoSet,
+    transientErrorListings,
+  } = params;
 
   // Pace unauthenticated raw.githubusercontent.com custom-update fetches to
   // avoid GitHub secondary rate limits (429s). 200ms between each fetch.
   const CUSTOM_UPDATE_INTER_FETCH_DELAY_MS = 200;
   let customFetchCount = 0;
-  const transientErrorListings = new Set<string>();
 
   for (const id of ids) {
     downloadsByListing[id] = {};
@@ -337,6 +391,925 @@ export async function generateDownloadsDataFull(
       },
     });
   }
+}
+
+// Stage 2: preserve state for listings that never got a context — either a
+// transient custom-update fetch error (previous integrity + cache preserved) or
+// an unreadable manifest (empty listing entry).
+function preserveMissingContextListing(ctx: FullRunContext, id: string): void {
+  if (ctx.transientErrorListings.has(id)) {
+    const listingCacheEntries = ctx.cache.entries[id] ?? {};
+    const preservedListing = ctx.previousIntegrity?.listings[id];
+    ctx.integrityListings[id] = preservedListing ?? createListingIntegrityEntry({});
+    ctx.nextCache.entries[id] = sortObjectByKeys(listingCacheEntries);
+    const preservedCounts = countIntegrityVersions(preservedListing);
+    ctx.stats.completeVersions += preservedCounts.complete;
+    ctx.stats.incompleteVersions += preservedCounts.incomplete;
+    warnListing(ctx.warnings, id, "preserved previous integrity state (transient custom-update fetch error)");
+  } else {
+    ctx.integrityListings[id] = createListingIntegrityEntry({});
+  }
+}
+
+// Decides whether a github release version may reuse its cached integrity
+// result. Includes asset clobber detection: a matching cache entry is discarded
+// when the release asset's recorded updatedAt (preferred) or byte size (legacy
+// fallback) no longer matches the release index.
+function shouldReuseGithubCacheEntry(
+  ctx: FullRunContext,
+  listingId: string,
+  tag: string,
+  cached: IntegrityCacheEntry,
+  fingerprint: string,
+  currentZipSizes: Record<string, number>,
+  currentZipUpdatedAt: Record<string, string>,
+): boolean {
+  let shouldReuseCached = (
+    !ctx.forceIntegrityRecheck
+    && shouldUseCachedIntegrity(
+      cached,
+      fingerprint,
+      ctx.now,
+      ctx.strictFingerprintCacheForMods,
+    )
+    && !isLegacyMapCacheMissingFileSizes(ctx.listingType, cached)
+    && !isLegacyModCacheMissingSecurityCheck(ctx.listingType, cached)
+  );
+  if (shouldReuseCached && cached != null) {
+    // Prefer updatedAt timestamps (catches same-size replacements, e.g. config.json version bump).
+    // Fall back to byte-size check for entries written before updatedAt was recorded.
+    const storedUpdatedAt = cached.asset_updated_at;
+    const storedSizes = cached.asset_sizes;
+    const updatedAtMismatch = storedUpdatedAt != null && (
+      Object.keys(currentZipUpdatedAt).some((name) => currentZipUpdatedAt[name] !== storedUpdatedAt[name])
+      || Object.keys(storedUpdatedAt).some((name) => !(name in currentZipUpdatedAt))
+    );
+    const sizeMismatch = storedSizes != null && storedUpdatedAt == null && (
+      Object.keys(currentZipSizes).some((name) => currentZipSizes[name] !== storedSizes[name])
+      || Object.keys(storedSizes).some((name) => !(name in currentZipSizes))
+    );
+    if (updatedAtMismatch || sizeMismatch) {
+      warnListing(ctx.warnings, listingId, "zip asset replaced since last inspection; forcing re-check", tag);
+      shouldReuseCached = false;
+    }
+  }
+  return shouldReuseCached;
+}
+
+// Fresh inspection of a github release's ZIP assets: fetches/inspects each .zip
+// (memoized per listing), records attribution for real fetches, and synthesizes
+// the version's integrity entry (first complete asset wins; otherwise the last
+// failed result carries the accumulated errors).
+async function inspectGithubReleaseZips(
+  ctx: FullRunContext,
+  state: ListingEvaluationState,
+  listingId: string,
+  repo: string,
+  tag: string,
+  releaseData: D.RepoReleaseTagData,
+  zipAssets: Array<[string, GithubReleaseAsset]>,
+  sourceBase: IntegritySource,
+  fingerprint: string,
+): Promise<IntegrityVersionEntry> {
+  const hasReleaseManifestAsset = releaseData.assets.has("manifest.json");
+  // Parse game_version/deps from the release's manifest.json asset once
+  // per fresh check (github only). Cached entries gain it on recheck.
+  const gameMeta = await resolveReleaseGameMeta(
+    hasReleaseManifestAsset ? releaseData.assets.get("manifest.json")?.downloadUrl ?? null : null,
+    ctx.fetchImpl,
+  );
+  let selectedResult: IntegrityVersionEntry | null = null;
+  let lastFailedResult: IntegrityVersionEntry | null = null;
+  const attemptedErrors: string[] = [];
+  let attemptedReleaseSizeMiB: number | undefined;
+
+  for (const [assetName, asset] of zipAssets.sort(([a], [b]) => a.localeCompare(b))) {
+    if (!asset.downloadUrl) {
+      attemptedErrors.push(`zip asset '${assetName}' is missing download URL`);
+      continue;
+    }
+    const inspected = await state.inspectZipWithMemo({
+      version: tag,
+      assetName,
+      downloadUrl: asset.downloadUrl,
+      releaseHasManifestAsset: hasReleaseManifestAsset,
+    });
+    if (!inspected.ok) {
+      attemptedErrors.push(`asset '${assetName}': ${inspected.error}`);
+      continue;
+    }
+    if (!inspected.value.fromMemo) {
+      const key = toDownloadAttributionAssetKey(repo, tag, assetName, asset.assetNodeId);
+      recordDownloadAttributionFetchByAssetKey(ctx.attributionDelta, key);
+    }
+    const { check, releaseSizeMiB } = inspected.value;
+    attemptedReleaseSizeMiB = releaseSizeMiB;
+    for (const warning of check.warnings) {
+      warnListing(ctx.warnings, listingId, `integrity warning (${warning})`, tag);
+    }
+    selectedResult = withCheckResult(
+      check,
+      { ...sourceBase, asset_name: assetName, download_url: asset.downloadUrl },
+      fingerprint,
+      ctx.nowIso,
+      releaseSizeMiB,
+      gameMeta,
+    );
+    if (check.isComplete) {
+      break;
+    }
+    attemptedErrors.push(...check.errors.map((error) => `asset '${assetName}': ${error}`));
+    lastFailedResult = selectedResult;
+    selectedResult = null;
+  }
+
+  return selectedResult
+    ?? (
+      lastFailedResult
+        ? {
+          ...lastFailedResult,
+          is_complete: false,
+          errors: attemptedErrors.length > 0
+            ? attemptedErrors
+            : lastFailedResult.errors,
+        }
+        : buildIncompleteVersionEntry(
+          sourceBase,
+          fingerprint,
+          ctx.nowIso,
+          attemptedErrors.length > 0 ? attemptedErrors : ["all zip assets failed integrity checks"],
+          {},
+          {},
+          attemptedReleaseSizeMiB,
+        )
+    );
+}
+
+// Stores a fresh github inspection result, unless doing so would downgrade a
+// previously-complete version purely on grandfathered checks — in that case the
+// previous passing entry is preserved (never-downgrade guard).
+function storeGithubInspectionResult(
+  ctx: FullRunContext,
+  state: ListingEvaluationState,
+  listingId: string,
+  tag: string,
+  result: IntegrityVersionEntry,
+  fingerprint: string,
+  currentZipSizes: Record<string, number>,
+  currentZipUpdatedAt: Record<string, string>,
+): void {
+  const previousVersionEntry = ctx.previousIntegrity?.listings[listingId]?.versions?.[tag];
+  const zipSizesEntry = Object.keys(currentZipSizes).length > 0 ? currentZipSizes : undefined;
+  const zipUpdatedAtEntry = Object.keys(currentZipUpdatedAt).length > 0 ? currentZipUpdatedAt : undefined;
+  if (isGrandfatheredDowngrade(previousVersionEntry, result)) {
+    state.versionEntries[tag] = previousVersionEntry!;
+    state.nextListingCacheEntries[tag] = {
+      fingerprint,
+      last_checked_at: ctx.nowIso,
+      result: previousVersionEntry!,
+      asset_sizes: zipSizesEntry,
+      asset_updated_at: zipUpdatedAtEntry,
+    };
+    const failingKeys = Object.entries(result.required_checks)
+      .filter(([, v]) => !v).map(([k]) => k).join(", ");
+    warnListing(ctx.warnings, listingId, `preserved previous is_complete=true (grandfathered checks: ${failingKeys})`, tag);
+  } else {
+    state.versionEntries[tag] = result;
+    state.nextListingCacheEntries[tag] = {
+      fingerprint,
+      last_checked_at: ctx.nowIso,
+      result,
+      asset_sizes: zipSizesEntry,
+      asset_updated_at: zipUpdatedAtEntry,
+    };
+  }
+}
+
+// Applies the (attribution-adjusted) download count for a supported github
+// release version, filtering versions that fail integrity.
+function applyGithubDownloadCount(
+  ctx: FullRunContext,
+  state: ListingEvaluationState,
+  listingId: string,
+  repo: string,
+  tag: string,
+  releaseData: D.RepoReleaseTagData,
+): void {
+  const result = state.versionEntries[tag];
+  const adjusted = getAdjustedGithubZipTotal({
+    listingId,
+    version: tag,
+    repo,
+    assets: releaseData.assets,
+    attributionLedger: ctx.attributionLedger,
+    attributionDelta: ctx.attributionDelta,
+    warnings: ctx.warnings,
+  });
+  ctx.stats.adjustedDeltaTotal += adjusted.subtractedTotal;
+  if (adjusted.clamped) {
+    ctx.stats.clampedVersions += 1;
+  }
+  const included = applyDownloadCountForVersion({
+    warnings: ctx.warnings,
+    listingId,
+    version: tag,
+    result,
+    downloadCount: adjusted.adjustedCount,
+    downloadsByListing: ctx.downloadsByListing,
+  });
+  if (!included) {
+    ctx.stats.filteredVersions += 1;
+  } else {
+    ctx.versionBucketInputs[listingId][tag] = adjusted.bucketInputs;
+  }
+}
+
+// Stage 3a: evaluate a github-sourced listing — per-release-tag integrity
+// (cache reuse with clobber detection, fresh inspection with grandfathering)
+// and download-count application. Returns handled=true when the listing was
+// fully resolved here (repo unavailable / not found) and per-listing
+// finalization must be skipped; otherwise the listing's lastUpdated epoch.
+async function evaluateGithubListing(
+  ctx: FullRunContext,
+  id: string,
+  repo: string,
+  state: ListingEvaluationState,
+): Promise<{ handled: true } | { handled: false; lastUpdated: number | undefined }> {
+  if (ctx.unavailableRepos.has(repo)) {
+    const preservedListing = ctx.previousIntegrity?.listings[id];
+    ctx.downloadsByListing[id] = sortObjectByKeys(ctx.previousDownloads[id] ?? {});
+    ctx.integrityListings[id] = preservedListing ?? createListingIntegrityEntry({});
+    ctx.nextCache.entries[id] = sortObjectByKeys(state.listingCacheEntries);
+    const preservedCounts = countIntegrityVersions(preservedListing);
+    ctx.stats.completeVersions += preservedCounts.complete;
+    ctx.stats.incompleteVersions += preservedCounts.incomplete;
+    warnListing(ctx.warnings, id, "preserved previous integrity and download state (repo unavailable)");
+    return { handled: true };
+  }
+  const repoIndex = ctx.repoIndexes.get(repo);
+  if (!repoIndex) {
+    warnListing(ctx.warnings, id, "skipped all github-release versions (repository not found or inaccessible)");
+    ctx.integrityListings[id] = createListingIntegrityEntry(state.versionEntries);
+    ctx.nextCache.entries[id] = state.nextListingCacheEntries;
+    return { handled: true };
+  }
+  const lastUpdated = maxReleaseEpoch(
+    [...repoIndex.byTag.values()].map((release) => release.publishedAt),
+  );
+  for (const [releaseTag, release] of repoIndex.byTag) {
+    const ms = Date.parse(release.publishedAt ?? "");
+    state.publishEpochByVersion.set(releaseTag, Number.isFinite(ms) ? Math.floor(ms / 1000) : undefined);
+  }
+
+  for (const tag of [...repoIndex.byTag.keys()].sort()) {
+    const releaseData = repoIndex.byTag.get(tag);
+    if (!releaseData) continue;
+    ctx.stats.versionsChecked += 1;
+
+    const zipAssets = Array.from(releaseData.assets.entries())
+      .filter(([assetName]) => assetName.toLowerCase().endsWith(".zip"))
+      .sort(([a], [b]) => a.localeCompare(b));
+    const zipAssetNames = zipAssets.map(([name]) => name);
+    const securityFingerprintPart = getSecurityFingerprintPart(
+      ctx.listingType,
+      ctx.modSecurityRules,
+    );
+    const fingerprintBase = zipAssets.length > 0
+      ? `github:${repo}:${tag}:${zipAssetNames.join("|")}${securityFingerprintPart}`
+      : `github:${repo}:${tag}:no-zip${securityFingerprintPart}`;
+    const fingerprint = versionedFingerprint(fingerprintBase);
+    const cached = state.listingCacheEntries[tag];
+    const sourceBase: IntegritySource = {
+      update_type: "github",
+      repo,
+      tag,
+    };
+    const currentZipSizes: Record<string, number> = Object.fromEntries(
+      zipAssets.flatMap(([name, a]) => a.sizeBytes != null ? [[name, a.sizeBytes]] : []),
+    );
+    const currentZipUpdatedAt: Record<string, string> = Object.fromEntries(
+      zipAssets.flatMap(([name, a]) => a.assetUpdatedAt != null ? [[name, a.assetUpdatedAt]] : []),
+    );
+    const shouldReuseCached = shouldReuseGithubCacheEntry(
+      ctx,
+      id,
+      tag,
+      cached,
+      fingerprint,
+      currentZipSizes,
+      currentZipUpdatedAt,
+    );
+
+    if (shouldReuseCached) {
+      ctx.stats.cacheHits += 1;
+      const cachedAssetName = cached.result.source.asset_name;
+      const matchedAsset = (
+        typeof cachedAssetName === "string"
+          ? releaseData.assets.get(cachedAssetName)
+          : undefined
+      );
+      const representativeAsset = matchedAsset ?? (zipAssets.length === 1 ? zipAssets[0][1] : undefined);
+      const result = withBuildingsIndexPresenceIfMissing(
+        withReleaseSizeIfMissing(
+          cached.result,
+          releaseSizeFromBytes(representativeAsset?.sizeBytes),
+        ),
+      );
+      state.versionEntries[tag] = result;
+      state.nextListingCacheEntries[tag] = {
+        ...cached,
+        result,
+      };
+    } else if (!isSupportedReleaseTag(tag)) {
+      const result = buildIncompleteVersionEntry(
+        sourceBase,
+        fingerprint,
+        ctx.nowIso,
+        [`non-semver release tag '${tag}'`],
+      );
+      state.versionEntries[tag] = result;
+      state.nextListingCacheEntries[tag] = {
+        fingerprint,
+        last_checked_at: ctx.nowIso,
+        result,
+      };
+    } else if (zipAssets.length === 0) {
+      const result = buildIncompleteVersionEntry(
+        sourceBase,
+        fingerprint,
+        ctx.nowIso,
+        ["release has no .zip asset"],
+      );
+      state.versionEntries[tag] = result;
+      state.nextListingCacheEntries[tag] = {
+        fingerprint,
+        last_checked_at: ctx.nowIso,
+        result,
+      };
+    } else {
+      const result = await inspectGithubReleaseZips(
+        ctx,
+        state,
+        id,
+        repo,
+        tag,
+        releaseData,
+        zipAssets,
+        sourceBase,
+        fingerprint,
+      );
+      storeGithubInspectionResult(
+        ctx,
+        state,
+        id,
+        tag,
+        result,
+        fingerprint,
+        currentZipSizes,
+        currentZipUpdatedAt,
+      );
+    }
+
+    if (isSupportedReleaseTag(tag)) {
+      applyGithubDownloadCount(ctx, state, id, repo, tag, releaseData);
+    }
+  }
+  return { handled: false, lastUpdated };
+}
+
+// Evaluates a custom version whose download URL parses to a github release .zip
+// asset: resolves the release/asset (preserving previous state when the repo is
+// transiently unavailable), performs the memoized inspection, and stores the
+// result with the never-downgrade grandfathering guard.
+async function evaluateCustomParsedZipVersion(
+  ctx: FullRunContext,
+  state: ListingEvaluationState,
+  listingId: string,
+  candidate: CustomVersionCandidate,
+  parsed: D.ParsedReleaseAssetUrl,
+  versionKey: string,
+  cached: IntegrityCacheEntry,
+  fingerprint: string,
+  sourceBase: IntegritySource,
+  expectedReleaseManifestAssetName: string,
+): Promise<void> {
+  const previousVersionEntry = ctx.previousIntegrity?.listings[listingId]?.versions?.[versionKey];
+  const repoIndex = ctx.repoIndexes.get(parsed.repo);
+  if (ctx.unavailableRepos.has(parsed.repo)) {
+    if (previousVersionEntry) {
+      state.versionEntries[versionKey] = previousVersionEntry;
+      if (cached) {
+        state.nextListingCacheEntries[versionKey] = cached;
+      }
+      warnListing(
+        ctx.warnings,
+        listingId,
+        "preserved previous integrity state (repo unavailable)",
+        versionKey,
+      );
+    } else {
+      const result = buildIncompleteVersionEntry(
+        sourceBase,
+        fingerprint,
+        ctx.nowIso,
+        ["repository is unavailable via GitHub GraphQL and no previous integrity result exists"],
+      );
+      state.versionEntries[versionKey] = result;
+      state.nextListingCacheEntries[versionKey] = {
+        fingerprint,
+        last_checked_at: ctx.nowIso,
+        result,
+      };
+    }
+  } else if (!repoIndex) {
+    const result = buildIncompleteVersionEntry(
+      sourceBase,
+      fingerprint,
+      ctx.nowIso,
+      ["repository is unavailable via GitHub GraphQL"],
+    );
+    state.versionEntries[versionKey] = result;
+    state.nextListingCacheEntries[versionKey] = {
+      fingerprint,
+      last_checked_at: ctx.nowIso,
+      result,
+    };
+  } else {
+    const release = repoIndex.byTag.get(parsed.tag);
+    if (!release) {
+      const result = buildIncompleteVersionEntry(
+        sourceBase,
+        fingerprint,
+        ctx.nowIso,
+        [`release tag '${parsed.tag}' not found`],
+      );
+      state.versionEntries[versionKey] = result;
+      state.nextListingCacheEntries[versionKey] = {
+        fingerprint,
+        last_checked_at: ctx.nowIso,
+        result,
+      };
+    } else {
+      const asset = release.assets.get(parsed.assetName);
+      if (!asset) {
+        const result = buildIncompleteVersionEntry(
+          sourceBase,
+          fingerprint,
+          ctx.nowIso,
+          [`release asset '${parsed.assetName}' not found`],
+        );
+        state.versionEntries[versionKey] = result;
+        state.nextListingCacheEntries[versionKey] = {
+          fingerprint,
+          last_checked_at: ctx.nowIso,
+          result,
+        };
+      } else if (!asset.downloadUrl) {
+        const result = buildIncompleteVersionEntry(
+          sourceBase,
+          fingerprint,
+          ctx.nowIso,
+          [`release asset '${parsed.assetName}' has no download URL`],
+        );
+        state.versionEntries[versionKey] = result;
+        state.nextListingCacheEntries[versionKey] = {
+          fingerprint,
+          last_checked_at: ctx.nowIso,
+          result,
+        };
+      } else {
+        const inspected = await state.inspectZipWithMemo({
+          version: versionKey,
+          assetName: parsed.assetName,
+          downloadUrl: asset.downloadUrl,
+          releaseHasManifestAsset: release.assets.has(expectedReleaseManifestAssetName),
+          expectedReleaseManifestAssetName,
+        });
+        if (!inspected.ok) {
+          const result = buildIncompleteVersionEntry(
+            sourceBase,
+            fingerprint,
+            ctx.nowIso,
+            [inspected.error],
+          );
+          state.versionEntries[versionKey] = result;
+          state.nextListingCacheEntries[versionKey] = {
+            fingerprint,
+            last_checked_at: ctx.nowIso,
+            result,
+          };
+        } else {
+          if (!inspected.value.fromMemo) {
+            const key = toDownloadAttributionAssetKey(
+              parsed.repo,
+              parsed.tag,
+              parsed.assetName,
+              asset.assetNodeId,
+            );
+            recordDownloadAttributionFetchByAssetKey(ctx.attributionDelta, key);
+          }
+          const { check, releaseSizeMiB } = inspected.value;
+          for (const warning of check.warnings) {
+            warnListing(ctx.warnings, listingId, `integrity warning (${warning})`, versionKey);
+          }
+          const result = withCheckResult(
+            check,
+            {
+              ...sourceBase,
+              asset_name: parsed.assetName,
+              download_url: asset.downloadUrl,
+            },
+            fingerprint,
+            ctx.nowIso,
+            releaseSizeMiB,
+            candidate.gameMeta,
+          );
+          if (isGrandfatheredDowngrade(previousVersionEntry, result)) {
+            state.versionEntries[versionKey] = previousVersionEntry!;
+            state.nextListingCacheEntries[versionKey] = {
+              fingerprint,
+              last_checked_at: ctx.nowIso,
+              result: previousVersionEntry!,
+            };
+            const failingKeys = Object.entries(result.required_checks)
+              .filter(([, v]) => !v).map(([k]) => k).join(", ");
+            warnListing(ctx.warnings, listingId, `preserved previous is_complete=true (grandfathered checks: ${failingKeys})`, versionKey);
+          } else {
+            state.versionEntries[versionKey] = result;
+            state.nextListingCacheEntries[versionKey] = {
+              fingerprint,
+              last_checked_at: ctx.nowIso,
+              result,
+            };
+          }
+        }
+      }
+    }
+  }
+}
+
+// Applies the download count for a semver custom version: preserves previous
+// counts when the backing repo is unavailable, otherwise adjusts the raw GitHub
+// asset count by registry-attributed fetches.
+function applyCustomDownloadCount(
+  ctx: FullRunContext,
+  state: ListingEvaluationState,
+  listingId: string,
+  candidate: CustomVersionCandidate,
+  versionKey: string,
+): void {
+  const result = state.versionEntries[versionKey];
+  let downloadCount: number | undefined;
+  let versionBucketsForVersion: D.DownloadVersionBucketInput[] = [];
+  if (candidate.parsed && ctx.unavailableRepos.has(candidate.parsed.repo)) {
+    const previousCount = ctx.previousDownloads[listingId]?.[versionKey];
+    if (typeof previousCount === "number") {
+      downloadCount = previousCount;
+      warnListing(
+        ctx.warnings,
+        listingId,
+        "preserved previous GitHub release download count (repo unavailable)",
+        versionKey,
+      );
+    }
+  } else if (candidate.parsed) {
+    const asset = ctx.repoIndexes
+      .get(candidate.parsed.repo)
+      ?.byTag
+      .get(candidate.parsed.tag)
+      ?.assets
+      .get(candidate.parsed.assetName);
+    const rawCount = asset?.downloadCount;
+    if (typeof rawCount === "number") {
+      const adjusted = getAdjustedSingleAssetCount({
+        listingId,
+        version: versionKey,
+        repo: candidate.parsed.repo,
+        tag: candidate.parsed.tag,
+        assetName: candidate.parsed.assetName,
+        rawCount,
+        assetNodeId: asset?.assetNodeId ?? null,
+        attributionLedger: ctx.attributionLedger,
+        attributionDelta: ctx.attributionDelta,
+        warnings: ctx.warnings,
+      });
+      ctx.stats.adjustedDeltaTotal += adjusted.subtractedTotal;
+      if (adjusted.clamped) {
+        ctx.stats.clampedVersions += 1;
+      }
+      downloadCount = adjusted.adjustedCount;
+      versionBucketsForVersion = adjusted.bucketInputs;
+    }
+  }
+  const included = applyDownloadCountForVersion({
+    warnings: ctx.warnings,
+    listingId,
+    version: versionKey,
+    result,
+    downloadCount,
+    downloadsByListing: ctx.downloadsByListing,
+  });
+  if (!included) {
+    ctx.stats.filteredVersions += 1;
+  } else {
+    ctx.versionBucketInputs[listingId][versionKey] = versionBucketsForVersion;
+  }
+}
+
+// Stage 3b: evaluate a custom-update-sourced listing — per-declared-version
+// integrity (cache reuse, candidate validation, fresh inspection with
+// grandfathering) and download-count application. Returns the listing's
+// lastUpdated epoch.
+async function evaluateCustomListing(
+  ctx: FullRunContext,
+  id: string,
+  versions: CustomVersionCandidate[],
+  state: ListingEvaluationState,
+): Promise<number | undefined> {
+  const lastUpdated = maxReleaseEpoch(versions.map((candidate) => candidate.date));
+  for (const candidate of versions) {
+    const versionKey = candidate.version;
+    const candidateMs = Date.parse(candidate.date ?? "");
+    state.publishEpochByVersion.set(versionKey, Number.isFinite(candidateMs) ? Math.floor(candidateMs / 1000) : undefined);
+    ctx.stats.versionsChecked += 1;
+    const expectedReleaseManifestAssetName = resolveExpectedCustomReleaseManifestAssetName(
+      candidate,
+      ctx.warnings,
+      id,
+    );
+
+    const fallbackFingerprintBase = candidate.sha256
+      ? `sha256:${candidate.sha256}`
+      : `custom:${versionKey}:${candidate.downloadUrl ?? "missing-download"}:${expectedReleaseManifestAssetName}`;
+    const securityFingerprintPart = getSecurityFingerprintPart(
+      ctx.listingType,
+      ctx.modSecurityRules,
+    );
+    const fingerprintBase = candidate.sha256
+      ? `sha256:${candidate.sha256}${securityFingerprintPart}`
+      : (
+        candidate.parsed
+          ? `custom:${candidate.parsed.repo}:${candidate.parsed.tag}:${candidate.parsed.assetName}:${expectedReleaseManifestAssetName}:${candidate.downloadUrl ?? "missing-download"}${securityFingerprintPart}`
+          : `${fallbackFingerprintBase}${securityFingerprintPart}`
+      );
+    const fingerprint = versionedFingerprint(fingerprintBase);
+    const sourceBase: IntegritySource = {
+      update_type: "custom",
+      repo: candidate.parsed?.repo,
+      tag: candidate.parsed?.tag,
+      asset_name: candidate.parsed?.assetName,
+      download_url: candidate.downloadUrl ?? undefined,
+    };
+    const cached = state.listingCacheEntries[versionKey];
+    const shouldReuseCached = (
+      !ctx.forceIntegrityRecheck
+      && shouldUseCachedIntegrity(
+        cached,
+        fingerprint,
+        ctx.now,
+        ctx.strictFingerprintCacheForMods,
+      )
+      && !isLegacyMapCacheMissingFileSizes(ctx.listingType, cached)
+      && !isLegacyModCacheMissingSecurityCheck(ctx.listingType, cached)
+    );
+
+    if (shouldReuseCached) {
+      ctx.stats.cacheHits += 1;
+      const sizeFromMetadata = (
+        candidate.parsed
+          ? releaseSizeFromBytes(
+            ctx.repoIndexes
+              .get(candidate.parsed.repo)
+              ?.byTag
+              .get(candidate.parsed.tag)
+              ?.assets
+              .get(candidate.parsed.assetName)
+              ?.sizeBytes,
+          )
+          : undefined
+      );
+      const result = withBuildingsIndexPresenceIfMissing(
+        withReleaseSizeIfMissing(cached.result, sizeFromMetadata),
+      );
+      state.versionEntries[versionKey] = result;
+      state.nextListingCacheEntries[versionKey] = {
+        ...cached,
+        result,
+      };
+    } else if (candidate.errors.length > 0) {
+      const result = buildIncompleteVersionEntry(
+        sourceBase,
+        fingerprint,
+        ctx.nowIso,
+        candidate.errors,
+      );
+      state.versionEntries[versionKey] = result;
+      state.nextListingCacheEntries[versionKey] = {
+        fingerprint,
+        last_checked_at: ctx.nowIso,
+        result,
+      };
+    } else if (!candidate.parsed) {
+      const result = buildIncompleteVersionEntry(
+        sourceBase,
+        fingerprint,
+        ctx.nowIso,
+        ["download URL could not be parsed as a GitHub release asset URL"],
+      );
+      state.versionEntries[versionKey] = result;
+      state.nextListingCacheEntries[versionKey] = {
+        fingerprint,
+        last_checked_at: ctx.nowIso,
+        result,
+      };
+    } else if (!candidate.parsed.assetName.toLowerCase().endsWith(".zip")) {
+      const result = buildIncompleteVersionEntry(
+        sourceBase,
+        fingerprint,
+        ctx.nowIso,
+        [`download asset '${candidate.parsed.assetName}' is not a .zip`],
+      );
+      state.versionEntries[versionKey] = result;
+      state.nextListingCacheEntries[versionKey] = {
+        fingerprint,
+        last_checked_at: ctx.nowIso,
+        result,
+      };
+    } else {
+      await evaluateCustomParsedZipVersion(
+        ctx,
+        state,
+        id,
+        candidate,
+        candidate.parsed,
+        versionKey,
+        cached,
+        fingerprint,
+        sourceBase,
+        expectedReleaseManifestAssetName,
+      );
+    }
+
+    if (candidate.semver) {
+      applyCustomDownloadCount(ctx, state, id, candidate, versionKey);
+    }
+  }
+  return lastUpdated;
+}
+
+// Stage 4: per-listing finalization — game_version enforcement, released_at
+// stamping, integrity-alert assembly, complete/incomplete tallies, and the
+// listing's integrity + cache outputs.
+function finalizeListingEntries(
+  ctx: FullRunContext,
+  id: string,
+  state: ListingEvaluationState,
+  lastUpdated: number | undefined,
+): void {
+  const { versionEntries, publishEpochByVersion, nextListingCacheEntries } = state;
+
+  for (const violation of enforceGameVersionRequirement(
+    versionEntries,
+    publishEpochByVersion,
+    GAME_VERSION_REQUIRED_SINCE_EPOCH,
+  )) {
+    warnListing(ctx.warnings, id, `game_version required [${ctx.listingType}]: ${violation.reason}`, violation.version);
+  }
+
+  // Stamp released_at (immutable publish date) onto every version — fresh, reused,
+  // and legacy cache entries alike. The output entry and its cache entry share a
+  // reference, so re-point both to the stamped copy.
+  for (const version of Object.keys(versionEntries)) {
+    const stamped = withReleasedAtIfMissing(versionEntries[version], publishEpochByVersion.get(version));
+    if (stamped === versionEntries[version]) continue;
+    versionEntries[version] = stamped;
+    const cacheEntry = nextListingCacheEntries[version];
+    if (cacheEntry) nextListingCacheEntries[version] = { ...cacheEntry, result: stamped };
+  }
+
+  for (const [version, entry] of Object.entries(versionEntries)) {
+    if (!entry.is_complete && Object.values(entry.required_checks).some((v) => v === false)) {
+      const prevEntry = ctx.previousIntegrity?.listings[id]?.versions?.[version];
+      if (prevEntry === undefined || prevEntry.is_complete === true) {
+        const meta = ctx.listingMeta.get(id);
+        ctx.integrityAlerts.push({
+          listingId: id,
+          listingName: meta?.listingName ?? id,
+          listingType: ctx.listingType,
+          authorId: meta?.authorId ?? "",
+          version,
+          isRegression: prevEntry?.is_complete === true,
+          failingChecks: Object.entries(entry.required_checks)
+            .filter(([, v]) => v === false)
+            .map(([k]) => k),
+          errors: entry.errors,
+          sourceRepo: entry.source.repo,
+          sourceTag: entry.source.tag,
+        });
+      }
+    }
+  }
+
+  for (const result of Object.values(versionEntries)) {
+    if (result.is_complete) {
+      ctx.stats.completeVersions += 1;
+    } else {
+      ctx.stats.incompleteVersions += 1;
+    }
+  }
+
+  ctx.integrityListings[id] = createListingIntegrityEntry(versionEntries, lastUpdated);
+  ctx.nextCache.entries[id] = sortObjectByKeys(nextListingCacheEntries);
+}
+
+// Stage 3: evaluate one listing with a resolved context — build its per-listing
+// working state, dispatch to the github/custom evaluator, then finalize.
+async function evaluateListing(
+  ctx: FullRunContext,
+  id: string,
+  context: ListingContext,
+): Promise<void> {
+  const state: ListingEvaluationState = {
+    versionEntries: {},
+    publishEpochByVersion: new Map<string, number | undefined>(),
+    listingCacheEntries: ctx.cache.entries[id] ?? {},
+    nextListingCacheEntries: {},
+    inspectZipWithMemo: createInspectZipWithMemo({
+      listingId: id,
+      listingType: ctx.listingType,
+      cityCode: context.cityCode,
+      nowIso: ctx.nowIso,
+      warnings: ctx.warnings,
+      fetchImpl: ctx.fetchImpl,
+      modSecurityRules: ctx.modSecurityRules,
+      securityFingerprint: getSecurityFingerprintValue(ctx.modSecurityRules),
+    }),
+  };
+
+  // Newest release date for this listing (epoch seconds), synced to last_updated.
+  let lastUpdated: number | undefined;
+  if (context.update.type === "github") {
+    const outcome = await evaluateGithubListing(ctx, id, context.update.repo, state);
+    if (outcome.handled) return;
+    lastUpdated = outcome.lastUpdated;
+  } else {
+    lastUpdated = await evaluateCustomListing(ctx, id, context.update.versions, state);
+  }
+
+  finalizeListingEntries(ctx, id, state, lastUpdated);
+}
+
+export async function generateDownloadsDataFull(
+  options: D.GenerateDownloadsOptions,
+): Promise<D.GenerateDownloadsResult> {
+  const repoRoot = options.repoRoot;
+  const listingType = options.listingType;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const token = options.token;
+  const strictFingerprintCache = options.strictFingerprintCache === true;
+  const forceIntegrityRecheck = options.forceIntegrityRecheck === true;
+  const strictFingerprintCacheForMods = getStrictFingerprintCacheForListingType(
+    listingType,
+    strictFingerprintCache,
+  );
+  const warnings: string[] = [];
+  const dir = getDirectoryForType(listingType);
+  const ids = getIndexIds(repoRoot, dir);
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const attributionLedger = options.attribution?.ledger ?? createEmptyDownloadAttributionLedger(nowIso);
+  const attributionDelta = options.attribution?.delta
+    ?? createDownloadAttributionDelta(`runtime:${listingType}:full`, undefined, nowIso);
+  const modSecurityRules = resolveModSecurityRules(listingType, repoRoot);
+  const previousIntegrity = loadIntegritySnapshot(repoRoot, dir);
+  const previousDownloads = loadDownloadsSnapshot(repoRoot, dir);
+
+  const cache = loadIntegrityCache(repoRoot, dir);
+  const nextCache: IntegrityCache = {
+    schema_version: 1,
+    entries: {},
+  };
+
+  const downloadsByListing: D.DownloadsByListing = {};
+  const listingContexts = new Map<string, ListingContext>();
+  const listingMeta = new Map<string, { listingName: string; authorId: string }>();
+  const repoSet = new Set<string>();
+  const transientErrorListings = new Set<string>();
+
+  await resolveListingContexts({
+    ids,
+    repoRoot,
+    dir,
+    listingType,
+    fetchImpl,
+    warnings,
+    previousDownloads,
+    downloadsByListing,
+    listingContexts,
+    listingMeta,
+    repoSet,
+    transientErrorListings,
+  });
 
   const usageState = createGraphqlUsageState();
   const { repoIndexes, unavailableRepos } = await fetchRepoReleaseIndexes(repoSet, {
@@ -346,697 +1319,49 @@ export async function generateDownloadsDataFull(
     usageState,
   });
 
-  const integrityListings: Record<string, ListingIntegrityEntry> = {};
-  const versionBucketInputs: D.VersionBucketInputsByListing = {};
-  const integrityAlerts: D.IntegrityAlert[] = [];
-  let versionsChecked = 0;
-  let completeVersions = 0;
-  let incompleteVersions = 0;
-  let filteredVersions = 0;
-  let cacheHits = 0;
-  let adjustedDeltaTotal = 0;
-  let clampedVersions = 0;
+  const ctx: FullRunContext = {
+    listingType,
+    fetchImpl,
+    now,
+    nowIso,
+    warnings,
+    stats: {
+      versionsChecked: 0,
+      completeVersions: 0,
+      incompleteVersions: 0,
+      filteredVersions: 0,
+      cacheHits: 0,
+      adjustedDeltaTotal: 0,
+      clampedVersions: 0,
+    },
+    strictFingerprintCacheForMods,
+    forceIntegrityRecheck,
+    modSecurityRules,
+    attributionLedger,
+    attributionDelta,
+    previousIntegrity,
+    previousDownloads,
+    cache,
+    nextCache,
+    downloadsByListing,
+    versionBucketInputs: {},
+    integrityListings: {},
+    integrityAlerts: [],
+    listingMeta,
+    transientErrorListings,
+    repoIndexes,
+    unavailableRepos,
+  };
 
   for (const id of [...ids].sort()) {
     console.log(`[downloads] heartbeat:listing mode=full listing=${id}`);
-    versionBucketInputs[id] = {};
+    ctx.versionBucketInputs[id] = {};
     const context = listingContexts.get(id);
     if (!context) {
-      if (transientErrorListings.has(id)) {
-        const listingCacheEntries = cache.entries[id] ?? {};
-        const preservedListing = previousIntegrity?.listings[id];
-        integrityListings[id] = preservedListing ?? createListingIntegrityEntry({});
-        nextCache.entries[id] = sortObjectByKeys(listingCacheEntries);
-        const preservedCounts = countIntegrityVersions(preservedListing);
-        completeVersions += preservedCounts.complete;
-        incompleteVersions += preservedCounts.incomplete;
-        warnListing(warnings, id, "preserved previous integrity state (transient custom-update fetch error)");
-      } else {
-        integrityListings[id] = createListingIntegrityEntry({});
-      }
+      preserveMissingContextListing(ctx, id);
       continue;
     }
-
-    const versionEntries: Record<string, IntegrityVersionEntry> = {};
-    // Per-version publish epoch (seconds); date-gates the game_version requirement.
-    const publishEpochByVersion = new Map<string, number | undefined>();
-    // Newest release date for this listing (epoch seconds), synced to last_updated.
-    let lastUpdated: number | undefined;
-    const listingCacheEntries = cache.entries[id] ?? {};
-    const nextListingCacheEntries: Record<string, IntegrityCacheEntry> = {};
-    const inspectZipWithMemo = createInspectZipWithMemo({
-      listingId: id,
-      listingType,
-      cityCode: context.cityCode,
-      nowIso,
-      warnings,
-      fetchImpl,
-      modSecurityRules,
-      securityFingerprint: getSecurityFingerprintValue(modSecurityRules),
-    });
-
-    if (context.update.type === "github") {
-      const repo = context.update.repo;
-      if (unavailableRepos.has(repo)) {
-        const preservedListing = previousIntegrity?.listings[id];
-        downloadsByListing[id] = sortObjectByKeys(previousDownloads[id] ?? {});
-        integrityListings[id] = preservedListing ?? createListingIntegrityEntry({});
-        nextCache.entries[id] = sortObjectByKeys(listingCacheEntries);
-        const preservedCounts = countIntegrityVersions(preservedListing);
-        completeVersions += preservedCounts.complete;
-        incompleteVersions += preservedCounts.incomplete;
-        warnListing(warnings, id, "preserved previous integrity and download state (repo unavailable)");
-        continue;
-      }
-      const repoIndex = repoIndexes.get(repo);
-      if (!repoIndex) {
-        warnListing(warnings, id, "skipped all github-release versions (repository not found or inaccessible)");
-        integrityListings[id] = createListingIntegrityEntry(versionEntries);
-        nextCache.entries[id] = nextListingCacheEntries;
-        continue;
-      }
-      lastUpdated = maxReleaseEpoch(
-        [...repoIndex.byTag.values()].map((release) => release.publishedAt),
-      );
-      for (const [releaseTag, release] of repoIndex.byTag) {
-        const ms = Date.parse(release.publishedAt ?? "");
-        publishEpochByVersion.set(releaseTag, Number.isFinite(ms) ? Math.floor(ms / 1000) : undefined);
-      }
-
-      for (const tag of [...repoIndex.byTag.keys()].sort()) {
-        const releaseData = repoIndex.byTag.get(tag);
-        if (!releaseData) continue;
-        versionsChecked += 1;
-
-        const zipAssets = Array.from(releaseData.assets.entries())
-          .filter(([assetName]) => assetName.toLowerCase().endsWith(".zip"))
-          .sort(([a], [b]) => a.localeCompare(b));
-        const zipAssetNames = zipAssets.map(([name]) => name);
-        const securityFingerprintPart = getSecurityFingerprintPart(
-          listingType,
-          modSecurityRules,
-        );
-        const fingerprintBase = zipAssets.length > 0
-          ? `github:${repo}:${tag}:${zipAssetNames.join("|")}${securityFingerprintPart}`
-          : `github:${repo}:${tag}:no-zip${securityFingerprintPart}`;
-        const fingerprint = versionedFingerprint(fingerprintBase);
-        const cached = listingCacheEntries[tag];
-        const sourceBase: IntegritySource = {
-          update_type: "github",
-          repo,
-          tag,
-        };
-        const currentZipSizes: Record<string, number> = Object.fromEntries(
-          zipAssets.flatMap(([name, a]) => a.sizeBytes != null ? [[name, a.sizeBytes]] : []),
-        );
-        const currentZipUpdatedAt: Record<string, string> = Object.fromEntries(
-          zipAssets.flatMap(([name, a]) => a.assetUpdatedAt != null ? [[name, a.assetUpdatedAt]] : []),
-        );
-        let shouldReuseCached = (
-          !forceIntegrityRecheck
-          && shouldUseCachedIntegrity(
-            cached,
-            fingerprint,
-            now,
-            strictFingerprintCacheForMods,
-          )
-          && !isLegacyMapCacheMissingFileSizes(listingType, cached)
-          && !isLegacyModCacheMissingSecurityCheck(listingType, cached)
-        );
-        if (shouldReuseCached && cached != null) {
-          // Prefer updatedAt timestamps (catches same-size replacements, e.g. config.json version bump).
-          // Fall back to byte-size check for entries written before updatedAt was recorded.
-          const storedUpdatedAt = cached.asset_updated_at;
-          const storedSizes = cached.asset_sizes;
-          const updatedAtMismatch = storedUpdatedAt != null && (
-            Object.keys(currentZipUpdatedAt).some((name) => currentZipUpdatedAt[name] !== storedUpdatedAt[name])
-            || Object.keys(storedUpdatedAt).some((name) => !(name in currentZipUpdatedAt))
-          );
-          const sizeMismatch = storedSizes != null && storedUpdatedAt == null && (
-            Object.keys(currentZipSizes).some((name) => currentZipSizes[name] !== storedSizes[name])
-            || Object.keys(storedSizes).some((name) => !(name in currentZipSizes))
-          );
-          if (updatedAtMismatch || sizeMismatch) {
-            warnListing(warnings, id, "zip asset replaced since last inspection; forcing re-check", tag);
-            shouldReuseCached = false;
-          }
-        }
-
-        if (shouldReuseCached) {
-          cacheHits += 1;
-          const cachedAssetName = cached.result.source.asset_name;
-          const matchedAsset = (
-            typeof cachedAssetName === "string"
-              ? releaseData.assets.get(cachedAssetName)
-              : undefined
-          );
-          const representativeAsset = matchedAsset ?? (zipAssets.length === 1 ? zipAssets[0][1] : undefined);
-          const result = withBuildingsIndexPresenceIfMissing(
-            withReleaseSizeIfMissing(
-              cached.result,
-              releaseSizeFromBytes(representativeAsset?.sizeBytes),
-            ),
-          );
-          versionEntries[tag] = result;
-          nextListingCacheEntries[tag] = {
-            ...cached,
-            result,
-          };
-        } else if (!isSupportedReleaseTag(tag)) {
-          const result = buildIncompleteVersionEntry(
-            sourceBase,
-            fingerprint,
-            nowIso,
-            [`non-semver release tag '${tag}'`],
-          );
-          versionEntries[tag] = result;
-          nextListingCacheEntries[tag] = {
-            fingerprint,
-            last_checked_at: nowIso,
-            result,
-          };
-        } else if (zipAssets.length === 0) {
-          const result = buildIncompleteVersionEntry(
-            sourceBase,
-            fingerprint,
-            nowIso,
-            ["release has no .zip asset"],
-          );
-          versionEntries[tag] = result;
-          nextListingCacheEntries[tag] = {
-            fingerprint,
-            last_checked_at: nowIso,
-            result,
-          };
-        } else {
-          const hasReleaseManifestAsset = releaseData.assets.has("manifest.json");
-          // Parse game_version/deps from the release's manifest.json asset once
-          // per fresh check (github only). Cached entries gain it on recheck.
-          const gameMeta = await resolveReleaseGameMeta(
-            hasReleaseManifestAsset ? releaseData.assets.get("manifest.json")?.downloadUrl ?? null : null,
-            fetchImpl,
-          );
-          let selectedResult: IntegrityVersionEntry | null = null;
-          let lastFailedResult: IntegrityVersionEntry | null = null;
-          const attemptedErrors: string[] = [];
-          let attemptedReleaseSizeMiB: number | undefined;
-
-          for (const [assetName, asset] of zipAssets.sort(([a], [b]) => a.localeCompare(b))) {
-            if (!asset.downloadUrl) {
-              attemptedErrors.push(`zip asset '${assetName}' is missing download URL`);
-              continue;
-            }
-            const inspected = await inspectZipWithMemo({
-              version: tag,
-              assetName,
-              downloadUrl: asset.downloadUrl,
-              releaseHasManifestAsset: hasReleaseManifestAsset,
-            });
-            if (!inspected.ok) {
-              attemptedErrors.push(`asset '${assetName}': ${inspected.error}`);
-              continue;
-            }
-                  if (!inspected.value.fromMemo) {
-                    const key = toDownloadAttributionAssetKey(repo, tag, assetName, asset.assetNodeId);
-                    recordDownloadAttributionFetchByAssetKey(attributionDelta, key);
-                  }
-            const { check, releaseSizeMiB } = inspected.value;
-            attemptedReleaseSizeMiB = releaseSizeMiB;
-            for (const warning of check.warnings) {
-              warnListing(warnings, id, `integrity warning (${warning})`, tag);
-            }
-            selectedResult = withCheckResult(
-              check,
-              { ...sourceBase, asset_name: assetName, download_url: asset.downloadUrl },
-              fingerprint,
-              nowIso,
-              releaseSizeMiB,
-              gameMeta,
-            );
-            if (check.isComplete) {
-              break;
-            }
-            attemptedErrors.push(...check.errors.map((error) => `asset '${assetName}': ${error}`));
-            lastFailedResult = selectedResult;
-            selectedResult = null;
-          }
-
-          const result = selectedResult
-            ?? (
-              lastFailedResult
-                ? {
-                  ...lastFailedResult,
-                  is_complete: false,
-                  errors: attemptedErrors.length > 0
-                    ? attemptedErrors
-                    : lastFailedResult.errors,
-                }
-                : buildIncompleteVersionEntry(
-                  sourceBase,
-                  fingerprint,
-                  nowIso,
-                  attemptedErrors.length > 0 ? attemptedErrors : ["all zip assets failed integrity checks"],
-                  {},
-                  {},
-                  attemptedReleaseSizeMiB,
-                )
-            );
-          const previousVersionEntry = previousIntegrity?.listings[id]?.versions?.[tag];
-          const zipSizesEntry = Object.keys(currentZipSizes).length > 0 ? currentZipSizes : undefined;
-          const zipUpdatedAtEntry = Object.keys(currentZipUpdatedAt).length > 0 ? currentZipUpdatedAt : undefined;
-          if (isGrandfatheredDowngrade(previousVersionEntry, result)) {
-            versionEntries[tag] = previousVersionEntry!;
-            nextListingCacheEntries[tag] = {
-              fingerprint,
-              last_checked_at: nowIso,
-              result: previousVersionEntry!,
-              asset_sizes: zipSizesEntry,
-              asset_updated_at: zipUpdatedAtEntry,
-            };
-            const failingKeys = Object.entries(result.required_checks)
-              .filter(([, v]) => !v).map(([k]) => k).join(", ");
-            warnListing(warnings, id, `preserved previous is_complete=true (grandfathered checks: ${failingKeys})`, tag);
-          } else {
-            versionEntries[tag] = result;
-            nextListingCacheEntries[tag] = {
-              fingerprint,
-              last_checked_at: nowIso,
-              result,
-              asset_sizes: zipSizesEntry,
-              asset_updated_at: zipUpdatedAtEntry,
-            };
-          }
-        }
-
-        if (isSupportedReleaseTag(tag)) {
-          const result = versionEntries[tag];
-          const adjusted = getAdjustedGithubZipTotal({
-            listingId: id,
-            version: tag,
-            repo,
-            assets: releaseData.assets,
-            attributionLedger,
-            attributionDelta,
-            warnings,
-          });
-          adjustedDeltaTotal += adjusted.subtractedTotal;
-          if (adjusted.clamped) {
-            clampedVersions += 1;
-          }
-          const included = applyDownloadCountForVersion({
-            warnings,
-            listingId: id,
-            version: tag,
-            result,
-            downloadCount: adjusted.adjustedCount,
-            downloadsByListing,
-          });
-          if (!included) {
-            filteredVersions += 1;
-          } else {
-            versionBucketInputs[id][tag] = adjusted.bucketInputs;
-          }
-        }
-      }
-    } else {
-      lastUpdated = maxReleaseEpoch(context.update.versions.map((candidate) => candidate.date));
-      for (const candidate of context.update.versions) {
-        const versionKey = candidate.version;
-        const candidateMs = Date.parse(candidate.date ?? "");
-        publishEpochByVersion.set(versionKey, Number.isFinite(candidateMs) ? Math.floor(candidateMs / 1000) : undefined);
-        versionsChecked += 1;
-        const expectedReleaseManifestAssetName = resolveExpectedCustomReleaseManifestAssetName(
-          candidate,
-          warnings,
-          id,
-        );
-
-        const fallbackFingerprintBase = candidate.sha256
-          ? `sha256:${candidate.sha256}`
-          : `custom:${versionKey}:${candidate.downloadUrl ?? "missing-download"}:${expectedReleaseManifestAssetName}`;
-        const securityFingerprintPart = getSecurityFingerprintPart(
-          listingType,
-          modSecurityRules,
-        );
-        const fingerprintBase = candidate.sha256
-          ? `sha256:${candidate.sha256}${securityFingerprintPart}`
-          : (
-            candidate.parsed
-              ? `custom:${candidate.parsed.repo}:${candidate.parsed.tag}:${candidate.parsed.assetName}:${expectedReleaseManifestAssetName}:${candidate.downloadUrl ?? "missing-download"}${securityFingerprintPart}`
-              : `${fallbackFingerprintBase}${securityFingerprintPart}`
-          );
-        const fingerprint = versionedFingerprint(fingerprintBase);
-        const sourceBase: IntegritySource = {
-          update_type: "custom",
-          repo: candidate.parsed?.repo,
-          tag: candidate.parsed?.tag,
-          asset_name: candidate.parsed?.assetName,
-          download_url: candidate.downloadUrl ?? undefined,
-        };
-        const cached = listingCacheEntries[versionKey];
-        const shouldReuseCached = (
-          !forceIntegrityRecheck
-          && shouldUseCachedIntegrity(
-            cached,
-            fingerprint,
-            now,
-            strictFingerprintCacheForMods,
-          )
-          && !isLegacyMapCacheMissingFileSizes(listingType, cached)
-          && !isLegacyModCacheMissingSecurityCheck(listingType, cached)
-        );
-
-        if (shouldReuseCached) {
-          cacheHits += 1;
-          const sizeFromMetadata = (
-            candidate.parsed
-              ? releaseSizeFromBytes(
-                repoIndexes
-                  .get(candidate.parsed.repo)
-                  ?.byTag
-                  .get(candidate.parsed.tag)
-                  ?.assets
-                  .get(candidate.parsed.assetName)
-                  ?.sizeBytes,
-              )
-              : undefined
-          );
-          const result = withBuildingsIndexPresenceIfMissing(
-            withReleaseSizeIfMissing(cached.result, sizeFromMetadata),
-          );
-          versionEntries[versionKey] = result;
-          nextListingCacheEntries[versionKey] = {
-            ...cached,
-            result,
-          };
-        } else if (candidate.errors.length > 0) {
-          const result = buildIncompleteVersionEntry(
-            sourceBase,
-            fingerprint,
-            nowIso,
-            candidate.errors,
-          );
-          versionEntries[versionKey] = result;
-          nextListingCacheEntries[versionKey] = {
-            fingerprint,
-            last_checked_at: nowIso,
-            result,
-          };
-        } else if (!candidate.parsed) {
-          const result = buildIncompleteVersionEntry(
-            sourceBase,
-            fingerprint,
-            nowIso,
-            ["download URL could not be parsed as a GitHub release asset URL"],
-          );
-          versionEntries[versionKey] = result;
-          nextListingCacheEntries[versionKey] = {
-            fingerprint,
-            last_checked_at: nowIso,
-            result,
-          };
-        } else if (!candidate.parsed.assetName.toLowerCase().endsWith(".zip")) {
-          const result = buildIncompleteVersionEntry(
-            sourceBase,
-            fingerprint,
-            nowIso,
-            [`download asset '${candidate.parsed.assetName}' is not a .zip`],
-          );
-          versionEntries[versionKey] = result;
-          nextListingCacheEntries[versionKey] = {
-            fingerprint,
-            last_checked_at: nowIso,
-            result,
-          };
-        } else {
-          const previousVersionEntry = previousIntegrity?.listings[id]?.versions?.[versionKey];
-          const repoIndex = repoIndexes.get(candidate.parsed.repo);
-          if (unavailableRepos.has(candidate.parsed.repo)) {
-            if (previousVersionEntry) {
-              versionEntries[versionKey] = previousVersionEntry;
-              if (cached) {
-                nextListingCacheEntries[versionKey] = cached;
-              }
-              warnListing(
-                warnings,
-                id,
-                "preserved previous integrity state (repo unavailable)",
-                versionKey,
-              );
-            } else {
-              const result = buildIncompleteVersionEntry(
-                sourceBase,
-                fingerprint,
-                nowIso,
-                ["repository is unavailable via GitHub GraphQL and no previous integrity result exists"],
-              );
-              versionEntries[versionKey] = result;
-              nextListingCacheEntries[versionKey] = {
-                fingerprint,
-                last_checked_at: nowIso,
-                result,
-              };
-            }
-          } else if (!repoIndex) {
-            const result = buildIncompleteVersionEntry(
-              sourceBase,
-              fingerprint,
-              nowIso,
-              ["repository is unavailable via GitHub GraphQL"],
-            );
-            versionEntries[versionKey] = result;
-            nextListingCacheEntries[versionKey] = {
-              fingerprint,
-              last_checked_at: nowIso,
-              result,
-            };
-          } else {
-            const release = repoIndex.byTag.get(candidate.parsed.tag);
-            if (!release) {
-              const result = buildIncompleteVersionEntry(
-                sourceBase,
-                fingerprint,
-                nowIso,
-                [`release tag '${candidate.parsed.tag}' not found`],
-              );
-              versionEntries[versionKey] = result;
-              nextListingCacheEntries[versionKey] = {
-                fingerprint,
-                last_checked_at: nowIso,
-                result,
-              };
-            } else {
-              const asset = release.assets.get(candidate.parsed.assetName);
-              if (!asset) {
-                const result = buildIncompleteVersionEntry(
-                  sourceBase,
-                  fingerprint,
-                  nowIso,
-                  [`release asset '${candidate.parsed.assetName}' not found`],
-                );
-                versionEntries[versionKey] = result;
-                nextListingCacheEntries[versionKey] = {
-                  fingerprint,
-                  last_checked_at: nowIso,
-                  result,
-                };
-              } else if (!asset.downloadUrl) {
-                const result = buildIncompleteVersionEntry(
-                  sourceBase,
-                  fingerprint,
-                  nowIso,
-                  [`release asset '${candidate.parsed.assetName}' has no download URL`],
-                );
-                versionEntries[versionKey] = result;
-                nextListingCacheEntries[versionKey] = {
-                  fingerprint,
-                  last_checked_at: nowIso,
-                  result,
-                };
-              } else {
-                const inspected = await inspectZipWithMemo({
-                  version: versionKey,
-                  assetName: candidate.parsed.assetName,
-                  downloadUrl: asset.downloadUrl,
-                  releaseHasManifestAsset: release.assets.has(expectedReleaseManifestAssetName),
-                  expectedReleaseManifestAssetName,
-                });
-                if (!inspected.ok) {
-                  const result = buildIncompleteVersionEntry(
-                    sourceBase,
-                    fingerprint,
-                    nowIso,
-                    [inspected.error],
-                  );
-                  versionEntries[versionKey] = result;
-                  nextListingCacheEntries[versionKey] = {
-                    fingerprint,
-                    last_checked_at: nowIso,
-                    result,
-                  };
-                } else {
-                  if (!inspected.value.fromMemo) {
-                    const key = toDownloadAttributionAssetKey(
-                      candidate.parsed.repo,
-                      candidate.parsed.tag,
-                      candidate.parsed.assetName,
-                      asset.assetNodeId,
-                    );
-                    recordDownloadAttributionFetchByAssetKey(attributionDelta, key);
-                  }
-                  const { check, releaseSizeMiB } = inspected.value;
-                  for (const warning of check.warnings) {
-                    warnListing(warnings, id, `integrity warning (${warning})`, versionKey);
-                  }
-                  const result = withCheckResult(
-                    check,
-                    {
-                      ...sourceBase,
-                      asset_name: candidate.parsed.assetName,
-                      download_url: asset.downloadUrl,
-                    },
-                    fingerprint,
-                    nowIso,
-                    releaseSizeMiB,
-                    candidate.gameMeta,
-                  );
-                  if (isGrandfatheredDowngrade(previousVersionEntry, result)) {
-                    versionEntries[versionKey] = previousVersionEntry!;
-                    nextListingCacheEntries[versionKey] = {
-                      fingerprint,
-                      last_checked_at: nowIso,
-                      result: previousVersionEntry!,
-                    };
-                    const failingKeys = Object.entries(result.required_checks)
-                      .filter(([, v]) => !v).map(([k]) => k).join(", ");
-                    warnListing(warnings, id, `preserved previous is_complete=true (grandfathered checks: ${failingKeys})`, versionKey);
-                  } else {
-                    versionEntries[versionKey] = result;
-                    nextListingCacheEntries[versionKey] = {
-                      fingerprint,
-                      last_checked_at: nowIso,
-                      result,
-                    };
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        if (candidate.semver) {
-          const result = versionEntries[versionKey];
-          let downloadCount: number | undefined;
-          let versionBucketsForVersion: D.DownloadVersionBucketInput[] = [];
-          if (candidate.parsed && unavailableRepos.has(candidate.parsed.repo)) {
-            const previousCount = previousDownloads[id]?.[versionKey];
-            if (typeof previousCount === "number") {
-              downloadCount = previousCount;
-              warnListing(
-                warnings,
-                id,
-                "preserved previous GitHub release download count (repo unavailable)",
-                versionKey,
-              );
-            }
-          } else if (candidate.parsed) {
-            const asset = repoIndexes
-              .get(candidate.parsed.repo)
-              ?.byTag
-              .get(candidate.parsed.tag)
-              ?.assets
-              .get(candidate.parsed.assetName);
-            const rawCount = asset?.downloadCount;
-            if (typeof rawCount === "number") {
-              const adjusted = getAdjustedSingleAssetCount({
-                listingId: id,
-                version: versionKey,
-                repo: candidate.parsed.repo,
-                tag: candidate.parsed.tag,
-                assetName: candidate.parsed.assetName,
-                rawCount,
-                assetNodeId: asset?.assetNodeId ?? null,
-                attributionLedger,
-                attributionDelta,
-                warnings,
-              });
-              adjustedDeltaTotal += adjusted.subtractedTotal;
-              if (adjusted.clamped) {
-                clampedVersions += 1;
-              }
-              downloadCount = adjusted.adjustedCount;
-              versionBucketsForVersion = adjusted.bucketInputs;
-            }
-          }
-          const included = applyDownloadCountForVersion({
-            warnings,
-            listingId: id,
-            version: versionKey,
-            result,
-            downloadCount,
-            downloadsByListing,
-          });
-          if (!included) {
-            filteredVersions += 1;
-          } else {
-            versionBucketInputs[id][versionKey] = versionBucketsForVersion;
-          }
-        }
-      }
-    }
-
-    for (const violation of enforceGameVersionRequirement(
-      versionEntries,
-      publishEpochByVersion,
-      GAME_VERSION_REQUIRED_SINCE_EPOCH,
-    )) {
-      warnListing(warnings, id, `game_version required [${listingType}]: ${violation.reason}`, violation.version);
-    }
-
-    // Stamp released_at (immutable publish date) onto every version — fresh, reused,
-    // and legacy cache entries alike. The output entry and its cache entry share a
-    // reference, so re-point both to the stamped copy.
-    for (const version of Object.keys(versionEntries)) {
-      const stamped = withReleasedAtIfMissing(versionEntries[version], publishEpochByVersion.get(version));
-      if (stamped === versionEntries[version]) continue;
-      versionEntries[version] = stamped;
-      const cacheEntry = nextListingCacheEntries[version];
-      if (cacheEntry) nextListingCacheEntries[version] = { ...cacheEntry, result: stamped };
-    }
-
-    for (const [version, entry] of Object.entries(versionEntries)) {
-      if (!entry.is_complete && Object.values(entry.required_checks).some((v) => v === false)) {
-        const prevEntry = previousIntegrity?.listings[id]?.versions?.[version];
-        if (prevEntry === undefined || prevEntry.is_complete === true) {
-          const meta = listingMeta.get(id);
-          integrityAlerts.push({
-            listingId: id,
-            listingName: meta?.listingName ?? id,
-            listingType,
-            authorId: meta?.authorId ?? "",
-            version,
-            isRegression: prevEntry?.is_complete === true,
-            failingChecks: Object.entries(entry.required_checks)
-              .filter(([, v]) => v === false)
-              .map(([k]) => k),
-            errors: entry.errors,
-            sourceRepo: entry.source.repo,
-            sourceTag: entry.source.tag,
-          });
-        }
-      }
-    }
-
-    for (const result of Object.values(versionEntries)) {
-      if (result.is_complete) {
-        completeVersions += 1;
-      } else {
-        incompleteVersions += 1;
-      }
-    }
-
-    integrityListings[id] = createListingIntegrityEntry(versionEntries, lastUpdated);
-    nextCache.entries[id] = sortObjectByKeys(nextListingCacheEntries);
+    await evaluateListing(ctx, id, context);
   }
 
   const sortedDownloads: D.DownloadsByListing = {};
@@ -1046,27 +1371,27 @@ export async function generateDownloadsDataFull(
 
   return {
     downloads: sortedDownloads,
-    versionBucketInputs,
+    versionBucketInputs: ctx.versionBucketInputs,
     integrity: {
       schema_version: 1,
       generated_at: nowIso,
-      listings: sortObjectByKeys(integrityListings),
+      listings: sortObjectByKeys(ctx.integrityListings),
     },
     integrityCache: {
       schema_version: 1,
       entries: sortObjectByKeys(nextCache.entries),
     },
-    integrityAlerts,
+    integrityAlerts: ctx.integrityAlerts,
     stats: {
       listings: ids.length,
-      versions_checked: versionsChecked,
-      complete_versions: completeVersions,
-      incomplete_versions: incompleteVersions,
-      filtered_versions: filteredVersions,
-      cache_hits: cacheHits,
+      versions_checked: ctx.stats.versionsChecked,
+      complete_versions: ctx.stats.completeVersions,
+      incomplete_versions: ctx.stats.incompleteVersions,
+      filtered_versions: ctx.stats.filteredVersions,
+      cache_hits: ctx.stats.cacheHits,
       registry_fetches_added: Object.values(attributionDelta.assets).reduce((sum, count) => sum + count, 0),
-      adjusted_delta_total: adjustedDeltaTotal,
-      clamped_versions: clampedVersions,
+      adjusted_delta_total: ctx.stats.adjustedDeltaTotal,
+      clamped_versions: ctx.stats.clampedVersions,
     },
     warnings,
     rateLimit: graphqlUsageSnapshot(usageState),

--- a/scripts/ops/backfill-charleston-snapshot-clamp.ts
+++ b/scripts/ops/backfill-charleston-snapshot-clamp.ts
@@ -68,5 +68,5 @@ function run(): void {
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  runAndExitOnError(() => run());
+  runAndExitOnError(async () => run());
 }

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -106,6 +106,32 @@ async function makeMapZip(cityCode: string, version = "1.0.0"): Promise<Buffer> 
   return zip.generateAsync({ type: "nodebuffer" });
 }
 
+// Like makeMapZip, but adds one phantom demand point (neither residents nor jobs)
+// close to the populated point. This fails ONLY the grandfathered
+// demand_phantom_points check: spacing passes (points ~1.5km apart) and resident
+// totals still match (the phantom contributes 0 residents on both sides).
+async function makeMapZipWithPhantomPoint(cityCode: string, version = "1.0.0"): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file("config.json", JSON.stringify({ code: cityCode, version }));
+  zip.file("demand_data.json", JSON.stringify({
+    points: [
+      { id: "pt1", location: [0, 0], jobs: 1, residents: 1 },
+      { id: "pt-phantom", location: [0.01, 0.01], jobs: 0, residents: 0 },
+    ],
+    pops_map: [
+      { id: "pop1", size: 1 },
+    ],
+    pops: [
+      { residenceId: "pt1", jobId: "pt1", drivingDistance: 1 },
+    ],
+  }));
+  zip.file("buildings_index.json", "{}");
+  zip.file("roads.geojson", "{}");
+  zip.file("runways_taxiways.geojson", "{}");
+  zip.file(`${cityCode}.pmtiles`, "stub");
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
 async function makeMapZipWithPointLocations(
   cityCode: string,
   locations: Array<{ id: string; location: [number, number] }>,
@@ -1503,5 +1529,448 @@ test("mod security WARNING findings are recorded but do not block completeness",
       result.integrity.listings["warning-mod"]?.versions["v1.0.0"]?.security_issue?.findings[0]?.severity,
       "WARNING",
     );
+  });
+});
+
+// --- Behavior locks for the 429-cascade incident class ---------------------
+// These tests pin the exact preservation semantics of generateDownloadsDataFull
+// so that refactors cannot silently change them.
+
+test("full mode preserves previous integrity, cache, and downloads when a custom update JSON returns HTTP 429", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["custom-429-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "custom-429-mod", {
+      ...makeBaseModManifest("custom-429-mod"),
+      update: { type: "custom", url: "https://example.com/custom-429-update.json" },
+    });
+
+    const previousVersionEntry = {
+      is_complete: true,
+      errors: [],
+      required_checks: { release_manifest_asset: true, zip_manifest_json: true, security_scan_passed: true },
+      matched_files: { release_manifest_asset: "manifest.json", zip_manifest_json: "manifest.json", security_scan_passed: "passed" },
+      source: {
+        update_type: "custom",
+        repo: "owner/four29",
+        tag: "v1.0.0",
+        asset_name: "four29.zip",
+        download_url: "https://github.com/owner/four29/releases/download/v1.0.0/four29.zip",
+      },
+      fingerprint: "fp-custom-429",
+      checked_at: "2026-03-31T00:00:00.000Z",
+    };
+    const previousListingEntry = {
+      has_complete_version: true,
+      latest_semver_version: "1.0.0",
+      latest_semver_complete: true,
+      complete_versions: ["1.0.0"],
+      incomplete_versions: [],
+      versions: { "1.0.0": previousVersionEntry },
+    };
+    writeJson(join(repoRoot, "mods", "downloads.json"), {
+      "custom-429-mod": { "1.0.0": 42 },
+    });
+    writeJson(join(repoRoot, "mods", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-03-31T00:00:00.000Z",
+      listings: { "custom-429-mod": previousListingEntry },
+    });
+    // Note: the seeded cache entry includes asset_updated_at, but
+    // loadIntegrityCache only round-trips fingerprint/last_checked_at/result,
+    // so the preserved cache output is expected in the three-field shape.
+    writeJson(join(repoRoot, "mods", "integrity-cache.json"), {
+      schema_version: 1,
+      entries: {
+        "custom-429-mod": {
+          "1.0.0": {
+            fingerprint: "fp-custom-429",
+            last_checked_at: "2026-03-31T00:00:00.000Z",
+            result: previousVersionEntry,
+            asset_updated_at: { "four29.zip": "2026-03-30T00:00:00Z" },
+          },
+        },
+      },
+    });
+
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://example.com/custom-429-update.json",
+        handle: () => new Response("rate limited", { status: 429 }),
+      },
+    ]);
+
+    const result = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    assert.ok(result.warnings.includes(
+      "listing=custom-429-mod: custom update JSON returned HTTP 429 (transient; previous counts preserved)",
+    ));
+    assert.ok(result.warnings.includes(
+      "listing=custom-429-mod: preserved previous custom-update downloads (transient fetch error)",
+    ));
+    assert.ok(result.warnings.includes(
+      "listing=custom-429-mod: preserved previous integrity state (transient custom-update fetch error)",
+    ));
+
+    assert.deepEqual(result.downloads, {
+      "custom-429-mod": { "1.0.0": 42 },
+    });
+    assert.deepEqual(result.integrity.listings["custom-429-mod"], previousListingEntry);
+    assert.deepEqual(result.integrityCache.entries["custom-429-mod"], {
+      "1.0.0": {
+        fingerprint: "fp-custom-429",
+        last_checked_at: "2026-03-31T00:00:00.000Z",
+        result: previousVersionEntry,
+      },
+    });
+    assert.equal(result.stats.versions_checked, 0);
+    assert.equal(result.stats.complete_versions, 1);
+    assert.equal(result.stats.incomplete_versions, 0);
+    assert.deepEqual(result.integrityAlerts, []);
+  });
+});
+
+test("full mode grandfathers a previously-complete github version when fresh inspection fails only grandfathered checks", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("maps", ["grandfather-map"]);
+    writeIndex("mods", []);
+    writeManifest("maps", "grandfather-map", {
+      ...makeBaseMapManifest("grandfather-map"),
+      update: { type: "github", repo: "owner/gfmap" },
+    });
+
+    const previousVersionEntry = {
+      is_complete: true,
+      errors: [],
+      required_checks: {
+        config_json: true,
+        demand_data: true,
+        buildings_index: true,
+        roads_geojson: true,
+        runways_taxiways_geojson: true,
+        city_pmtiles: true,
+        config_version_matches_tag: true,
+      },
+      matched_files: {},
+      source: { update_type: "github", repo: "owner/gfmap", tag: "v1.0.0" },
+      fingerprint: "fp-old",
+      checked_at: "2026-03-31T00:00:00.000Z",
+    };
+    writeJson(join(repoRoot, "maps", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-03-31T00:00:00.000Z",
+      listings: {
+        "grandfather-map": {
+          has_complete_version: true,
+          latest_semver_version: "v1.0.0",
+          latest_semver_complete: true,
+          complete_versions: ["v1.0.0"],
+          incomplete_versions: [],
+          versions: { "v1.0.0": previousVersionEntry },
+        },
+      },
+    });
+    // No integrity-cache.json: forces the fresh-inspection path.
+
+    const phantomZip = await makeMapZipWithPhantomPoint("ABC");
+    let zipFetchCount = 0;
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://downloads.example.com/gfmap.zip",
+        handle: () => {
+          zipFetchCount += 1;
+          return new Response(new Uint8Array(phantomZip));
+        },
+      },
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: () => jsonResponse({
+          data: {
+            repository: {
+              releases: {
+                nodes: [
+                  {
+                    tagName: "v1.0.0",
+                    releaseAssets: {
+                      nodes: [
+                        {
+                          id: "asset-node-gfmap",
+                          name: "gfmap.zip",
+                          downloadCount: 9,
+                          downloadUrl: "https://downloads.example.com/gfmap.zip",
+                          size: 12345,
+                          updatedAt: "2026-04-01T00:00:00Z",
+                        },
+                      ],
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                    },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        }),
+      },
+    ]);
+
+    const result = await generateDownloadsData({
+      repoRoot,
+      listingType: "map",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    assert.equal(zipFetchCount, 1);
+    assert.ok(result.warnings.includes(
+      "listing=grandfather-map version=v1.0.0: preserved previous is_complete=true (grandfathered checks: demand_phantom_points)",
+    ));
+
+    // The previous complete entry is preserved verbatim (never-downgrade guard).
+    assert.deepEqual(result.integrity.listings["grandfather-map"]?.versions["v1.0.0"], previousVersionEntry);
+    assert.equal(result.integrity.listings["grandfather-map"]?.has_complete_version, true);
+    assert.deepEqual(result.integrity.listings["grandfather-map"]?.complete_versions, ["v1.0.0"]);
+
+    // Downloads stay live: raw 9 minus the 1 registry-attributed inspection fetch.
+    assert.deepEqual(result.downloads, { "grandfather-map": { "v1.0.0": 8 } });
+
+    // The grandfathered cache entry carries the preserved result plus the
+    // current asset clobber metadata from the release index.
+    const cacheEntry = result.integrityCache.entries["grandfather-map"]?.["v1.0.0"];
+    assert.deepEqual(cacheEntry?.result, previousVersionEntry);
+    assert.deepEqual(cacheEntry?.asset_sizes, { "gfmap.zip": 12345 });
+    assert.deepEqual(cacheEntry?.asset_updated_at, { "gfmap.zip": "2026-04-01T00:00:00Z" });
+
+    assert.deepEqual(result.integrityAlerts, []);
+    assert.equal(result.stats.versions_checked, 1);
+    assert.equal(result.stats.cache_hits, 0);
+    assert.equal(result.stats.complete_versions, 1);
+    assert.equal(result.stats.incomplete_versions, 0);
+    assert.equal(result.stats.filtered_versions, 0);
+  });
+});
+
+test("full mode grandfathers a previously-complete custom version when fresh inspection fails only grandfathered checks", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("maps", ["grandfather-custom-map"]);
+    writeIndex("mods", []);
+    writeManifest("maps", "grandfather-custom-map", {
+      ...makeBaseMapManifest("grandfather-custom-map"),
+      update: { type: "custom", url: "https://example.com/grandfather-custom-update.json" },
+    });
+
+    const previousVersionEntry = {
+      is_complete: true,
+      errors: [],
+      required_checks: {
+        config_json: true,
+        demand_data: true,
+        buildings_index: true,
+        roads_geojson: true,
+        runways_taxiways_geojson: true,
+        city_pmtiles: true,
+        config_version_matches_tag: true,
+      },
+      matched_files: {},
+      source: {
+        update_type: "custom",
+        repo: "owner/gfcustom",
+        tag: "v1.0.0",
+        asset_name: "gfcustom.zip",
+        download_url: "https://github.com/Owner/GfCustom/releases/download/v1.0.0/gfcustom.zip",
+      },
+      fingerprint: "fp-old-custom",
+      checked_at: "2026-03-31T00:00:00.000Z",
+    };
+    writeJson(join(repoRoot, "maps", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-03-31T00:00:00.000Z",
+      listings: {
+        "grandfather-custom-map": {
+          has_complete_version: true,
+          latest_semver_version: "1.0.0",
+          latest_semver_complete: true,
+          complete_versions: ["1.0.0"],
+          incomplete_versions: [],
+          versions: { "1.0.0": previousVersionEntry },
+        },
+      },
+    });
+    // No integrity-cache.json: forces the fresh-inspection path.
+
+    const phantomZip = await makeMapZipWithPhantomPoint("ABC");
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://example.com/grandfather-custom-update.json",
+        handle: () => jsonResponse({
+          schema_version: 1,
+          versions: [
+            {
+              version: "1.0.0",
+              download: "https://github.com/Owner/GfCustom/releases/download/v1.0.0/gfcustom.zip",
+            },
+          ],
+        }),
+      },
+      {
+        match: (url) => url === "https://downloads.example.com/gfcustom.zip",
+        handle: () => new Response(new Uint8Array(phantomZip)),
+      },
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: () => jsonResponse({
+          data: {
+            repository: {
+              releases: {
+                nodes: [
+                  {
+                    tagName: "v1.0.0",
+                    releaseAssets: {
+                      nodes: [
+                        { name: "gfcustom.zip", downloadCount: 6, downloadUrl: "https://downloads.example.com/gfcustom.zip" },
+                      ],
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                    },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        }),
+      },
+    ]);
+
+    const result = await generateDownloadsData({
+      repoRoot,
+      listingType: "map",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    assert.ok(result.warnings.includes(
+      "listing=grandfather-custom-map version=1.0.0: preserved previous is_complete=true (grandfathered checks: demand_phantom_points)",
+    ));
+    assert.deepEqual(
+      result.integrity.listings["grandfather-custom-map"]?.versions["1.0.0"],
+      previousVersionEntry,
+    );
+    assert.equal(result.integrity.listings["grandfather-custom-map"]?.has_complete_version, true);
+
+    // Downloads stay live: raw 6 minus the 1 registry-attributed inspection fetch.
+    assert.deepEqual(result.downloads, { "grandfather-custom-map": { "1.0.0": 5 } });
+
+    const cacheEntry = result.integrityCache.entries["grandfather-custom-map"]?.["1.0.0"];
+    assert.deepEqual(cacheEntry?.result, previousVersionEntry);
+    // The custom grandfather site does not record asset clobber metadata.
+    assert.equal(cacheEntry?.asset_sizes, undefined);
+    assert.equal(cacheEntry?.asset_updated_at, undefined);
+
+    assert.deepEqual(result.integrityAlerts, []);
+    assert.equal(result.stats.complete_versions, 1);
+    assert.equal(result.stats.incomplete_versions, 0);
+    assert.equal(result.stats.cache_hits, 0);
+  });
+});
+
+test("full mode writes asset clobber metadata to the cache, but disk-loaded entries are reused even when updatedAt changes", async () => {
+  // Behavior lock, including a known load-layer gap: fresh inspections write
+  // asset_sizes/asset_updated_at into integrity-cache.json (downloads-full.ts),
+  // and a cached entry whose asset_updated_at/asset_sizes disagree with the
+  // release index would be re-checked ("zip asset replaced since last
+  // inspection; forcing re-check"). However, loadIntegrityCache
+  // (downloads-support.ts) only round-trips fingerprint/last_checked_at/result,
+  // so entries loaded from disk never carry the clobber metadata and the
+  // re-check cannot trigger across runs today. This test pins BOTH facts; if
+  // the loader is fixed to round-trip the metadata, the second half of this
+  // test should be updated to expect a re-fetch.
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["clobber-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "clobber-mod", {
+      ...makeBaseModManifest("clobber-mod"),
+      update: { type: "github", repo: "owner/clobber" },
+    });
+
+    const validZip = await makeModZip(true);
+    let zipFetchCount = 0;
+    let assetUpdatedAt = "2026-01-01T00:00:00Z";
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://downloads.example.com/clobber.zip",
+        handle: () => {
+          zipFetchCount += 1;
+          return new Response(new Uint8Array(validZip));
+        },
+      },
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: () => jsonResponse({
+          data: {
+            repository: {
+              releases: {
+                nodes: [
+                  {
+                    tagName: "v1.0.0",
+                    releaseAssets: {
+                      nodes: [
+                        {
+                          id: "asset-node-clobber",
+                          name: "clobber.zip",
+                          downloadCount: 5,
+                          downloadUrl: "https://downloads.example.com/clobber.zip",
+                          size: 4096,
+                          updatedAt: assetUpdatedAt,
+                        },
+                        { name: "manifest.json", downloadCount: 5, downloadUrl: "https://downloads.example.com/clobber-manifest.json" },
+                      ],
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                    },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        }),
+      },
+    ]);
+
+    const first = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+    assert.equal(zipFetchCount, 1);
+    const firstCacheEntry = first.integrityCache.entries["clobber-mod"]?.["v1.0.0"];
+    assert.deepEqual(firstCacheEntry?.asset_sizes, { "clobber.zip": 4096 });
+    assert.deepEqual(firstCacheEntry?.asset_updated_at, { "clobber.zip": "2026-01-01T00:00:00Z" });
+
+    // Persist the cache exactly as produced (including clobber metadata), then
+    // simulate a same-size asset replacement by changing only updatedAt.
+    writeJson(join(repoRoot, "mods", "integrity-cache.json"), first.integrityCache);
+    assetUpdatedAt = "2026-02-02T00:00:00Z";
+
+    const second = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    // Current behavior: the loader drops asset_updated_at/asset_sizes, so the
+    // stale entry is reused and no re-check is forced.
+    assert.equal(second.stats.cache_hits, 1);
+    assert.equal(zipFetchCount, 1);
+    assert.ok(!second.warnings.some((warning) => (
+      warning.includes("zip asset replaced since last inspection; forcing re-check")
+    )));
+    assert.deepEqual(second.downloads, { "clobber-mod": { "v1.0.0": 5 } });
   });
 });


### PR DESCRIPTION
Part 3 phase C — the 429-cascade-critical megafunction, done tests-first.

## Step 1: behavior-lock tests (committed before any refactor)
Four new integration tests pin the critical paths with exact warning strings, verified green against the *unmodified* code:
- **Custom-update HTTP 429** → previous downloads (42), full integrity listing, and cache entries all preserved; pins `"custom update JSON returned HTTP 429 (transient; previous counts preserved)"` + both preservation warnings; `versions_checked=0`, no alerts.
- **Never-downgrade grandfathering, both sites** (github fresh-inspection and custom): a previously-complete version whose fresh ZIP now fails only grandfathered checks stays complete; pins `"preserved previous is_complete=true (grandfathered checks: demand_phantom_points)"` and each site's differing cache-metadata behavior.
- **Asset-clobber metadata**: pins that fresh inspections write `asset_updated_at`/`asset_sizes`, and pins the current cross-run behavior (see bug below).

## ⚠️ Latent production bug found (not fixed here, by design)
The updatedAt/size **clobber re-check is dead code across runs**: `loadIntegrityCache` (downloads-support.ts) drops `asset_sizes`/`asset_updated_at` when reading `integrity-cache.json` from disk, so the mismatch branch can only ever fire within a single run — never between runs, which is its whole purpose. The on-disk production cache *does* contain the fields; the loader just discards them. Test 4 locks both facts with a comment marking exactly which assertion to flip. Recommend an immediate follow-up PR to round-trip the two fields (small change + test flip).

## Step 2: decomposition
`generateDownloadsDataFull` (~828 lines) → a **138-line orchestrator** over 12 named stage functions (largest 166 LoC): context resolution incl. transient-429 handling, cache-reuse/clobber decision, github + custom evaluation paths with their grandfather guards, count application, and finalization/alerts. Shared accumulators pass through explicit `FullRunContext`/`ListingEvaluationState` objects; statement order, warning strings, and stats semantics verified byte-identical by literal-extraction diff.

Also: one-line chore fixing a pre-existing tsc error in the new `ops/backfill-charleston-snapshot-clamp.ts` (sync fn passed to Promise-expecting `runAndExitOnError`), kept as its own commit so the refactor stays pure.

## Verification
Fresh-build suite **260/260** (256 baseline + 4 locks, zero test edits in the refactor step); `tsc --noEmit` zero diagnostics; independently re-verified after the agent run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)