### PR TITLE
Fix asset-clobber detection: round-trip cache metadata on load

### DIFF
--- a/scripts/lib/downloads-support.ts
+++ b/scripts/lib/downloads-support.ts
@@ -112,6 +112,21 @@ function getEmptyCache(): IntegrityCache {
   };
 }
 
+function readStringKeyedRecord<T>(
+  value: unknown,
+  isValid: (entry: unknown) => entry is T,
+): Record<string, T> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const record: Record<string, T> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (!isValid(entry)) continue;
+    record[key] = entry;
+  }
+  return Object.keys(record).length > 0 ? record : undefined;
+}
+
 export function loadIntegrityCache(repoRoot: string, dir: ManifestDirectory): IntegrityCache {
   const cachePath = getCachePath(repoRoot, dir);
   if (!existsSync(cachePath)) {
@@ -152,10 +167,24 @@ export function loadIntegrityCache(repoRoot: string, dir: ManifestDirectory): In
         ) {
           continue;
         }
+        // Clobber-detection metadata must round-trip: dropping these fields on
+        // load would make same-size asset replacements undetectable across
+        // runs. Invalid shapes are omitted (lazy-migration semantics — the
+        // fields reappear on the next fresh inspection).
+        const assetSizes = readStringKeyedRecord(
+          (versionValue as { asset_sizes?: unknown }).asset_sizes,
+          (value): value is number => typeof value === "number" && Number.isFinite(value),
+        );
+        const assetUpdatedAt = readStringKeyedRecord(
+          (versionValue as { asset_updated_at?: unknown }).asset_updated_at,
+          (value): value is string => typeof value === "string" && value.trim() !== "",
+        );
         versionEntries[version] = {
           fingerprint,
           last_checked_at: lastCheckedAt,
           result: result as IntegrityVersionEntry,
+          ...(assetSizes ? { asset_sizes: assetSizes } : {}),
+          ...(assetUpdatedAt ? { asset_updated_at: assetUpdatedAt } : {}),
         };
       }
       entries[listingId] = versionEntries;

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -1576,9 +1576,8 @@ test("full mode preserves previous integrity, cache, and downloads when a custom
       generated_at: "2026-03-31T00:00:00.000Z",
       listings: { "custom-429-mod": previousListingEntry },
     });
-    // Note: the seeded cache entry includes asset_updated_at, but
-    // loadIntegrityCache only round-trips fingerprint/last_checked_at/result,
-    // so the preserved cache output is expected in the three-field shape.
+    // The seeded cache entry includes asset_updated_at; loadIntegrityCache
+    // round-trips it, so the preserved cache output carries it too.
     writeJson(join(repoRoot, "mods", "integrity-cache.json"), {
       schema_version: 1,
       entries: {
@@ -1626,6 +1625,7 @@ test("full mode preserves previous integrity, cache, and downloads when a custom
         fingerprint: "fp-custom-429",
         last_checked_at: "2026-03-31T00:00:00.000Z",
         result: previousVersionEntry,
+        asset_updated_at: { "four29.zip": "2026-03-30T00:00:00Z" },
       },
     });
     assert.equal(result.stats.versions_checked, 0);
@@ -1878,17 +1878,12 @@ test("full mode grandfathers a previously-complete custom version when fresh ins
   });
 });
 
-test("full mode writes asset clobber metadata to the cache, but disk-loaded entries are reused even when updatedAt changes", async () => {
-  // Behavior lock, including a known load-layer gap: fresh inspections write
-  // asset_sizes/asset_updated_at into integrity-cache.json (downloads-full.ts),
-  // and a cached entry whose asset_updated_at/asset_sizes disagree with the
-  // release index would be re-checked ("zip asset replaced since last
-  // inspection; forcing re-check"). However, loadIntegrityCache
-  // (downloads-support.ts) only round-trips fingerprint/last_checked_at/result,
-  // so entries loaded from disk never carry the clobber metadata and the
-  // re-check cannot trigger across runs today. This test pins BOTH facts; if
-  // the loader is fixed to round-trip the metadata, the second half of this
-  // test should be updated to expect a re-fetch.
+test("full mode detects a same-size asset replacement across runs and forces a re-check", async () => {
+  // Fresh inspections write asset_sizes/asset_updated_at into
+  // integrity-cache.json (downloads-full.ts); loadIntegrityCache round-trips
+  // them so a cached entry whose asset_updated_at disagrees with the release
+  // index is re-checked across runs — the clobber-detection scenario (e.g. a
+  // config.json version bump replacing a ZIP without changing its size).
   await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
     writeIndex("mods", ["clobber-mod"]);
     writeIndex("maps", []);
@@ -1964,13 +1959,18 @@ test("full mode writes asset clobber metadata to the cache, but disk-loaded entr
       token: "test-token",
     });
 
-    // Current behavior: the loader drops asset_updated_at/asset_sizes, so the
-    // stale entry is reused and no re-check is forced.
-    assert.equal(second.stats.cache_hits, 1);
-    assert.equal(zipFetchCount, 1);
-    assert.ok(!second.warnings.some((warning) => (
+    // The stale entry's asset_updated_at disagrees with the release index, so
+    // the cache is bypassed and the ZIP is re-fetched and re-inspected.
+    assert.equal(second.stats.cache_hits, 0);
+    assert.equal(zipFetchCount, 2);
+    assert.ok(second.warnings.some((warning) => (
       warning.includes("zip asset replaced since last inspection; forcing re-check")
     )));
-    assert.deepEqual(second.downloads, { "clobber-mod": { "v1.0.0": 5 } });
+    // Raw count 5 minus this run's own registry-attributed ZIP fetch = 4
+    // (same adjustment every fetching run applies).
+    assert.deepEqual(second.downloads, { "clobber-mod": { "v1.0.0": 4 } });
+    const secondCacheEntry = second.integrityCache.entries["clobber-mod"]?.["v1.0.0"];
+    assert.deepEqual(secondCacheEntry?.asset_updated_at, { "clobber.zip": "2026-02-02T00:00:00Z" });
+    assert.equal(second.integrity.listings["clobber-mod"]?.versions["v1.0.0"]?.is_complete, true);
   });
 });


### PR DESCRIPTION
Follow-up to #6321, whose behavior-lock tests exposed this. Fixes the latent bug that made asset-clobber detection dead code across runs.

## The bug
Fresh inspections write `asset_sizes`/`asset_updated_at` into `integrity-cache.json` (and production's on-disk cache contains them), but `loadIntegrityCache` rebuilt entries with only `fingerprint`/`last_checked_at`/`result` — dropping the clobber metadata on every load. The updatedAt/size-mismatch branch ("zip asset replaced since last inspection; forcing re-check") could therefore only fire within a single run, never against a previous run's state — which is the entire point of the guard (catching same-size ZIP replacements like a config.json version bump). In effect, the April hardening's clobber detection has never worked between runs.

## The fix
The loader now round-trips both fields, with defensive validation matching its existing style: invalid shapes are omitted rather than rejecting the entry, preserving the lazy-migration semantics (pre-fix entries without the fields still skip the check and gain the fields on their next natural re-inspection).

## Behavior activation, verified by the locks
- The clobber test (written in #6321 with a marked flip point) now asserts the intended cross-run behavior: cache bypassed (`cache_hits=0`), ZIP re-fetched and re-inspected, the re-check warning emitted, refreshed `asset_updated_at` in the new cache entry, and the count correctly adjusted by the run's own attributed fetch.
- The 429-preservation test now expects the preserved cache entry to carry its seeded `asset_updated_at` through the transient path — i.e. the fix also stops transient-error preservation from silently stripping clobber metadata.
- All other locks (grandfathering both sites, 429 preservation semantics) pass **unchanged** — the fix activates exactly the intended guard and nothing else.

Fresh-build suite 260/260; tsc zero diagnostics.

Note for rollout: existing production cache entries already have the fields on disk, so detection becomes effective for them immediately on merge; genuinely old entries without fields are unaffected until their next natural re-inspection (as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)