### PR TITLE
Add caretaker comment commands and caretaker-aware alert routing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,12 @@ jobs:
          (github.event.comment.user.id == github.event.issue.user.id ||
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'COLLABORATOR'))
+          github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'issue_comment' &&
+         (contains(github.event.comment.body, '/admin-author') ||
+          contains(github.event.comment.body, '/quality-exempt')) &&
+         (github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER'))
       )
     runs-on: ubuntu-latest
     steps:
@@ -82,6 +87,36 @@ jobs:
               content: 'eyes'
             });
 
+      - name: Detect maintainer overrides
+        id: overrides
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Maintainer comment commands persist across revalidations: scan
+            // ALL comments on the issue, honoring a command only when its
+            // author's association is OWNER or MEMBER. A command matches when
+            // the trimmed comment body equals it, or starts with it followed
+            // by whitespace.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100
+            });
+            const hasCommand = (command) => comments.some((comment) => {
+              if (comment.author_association !== 'OWNER' && comment.author_association !== 'MEMBER') {
+                return false;
+              }
+              const body = (comment.body ?? '').trim();
+              if (body === command) return true;
+              return body.startsWith(command) && /\s/.test(body.charAt(command.length));
+            });
+            const adminAuthor = hasCommand('/admin-author');
+            const qualityExempt = hasCommand('/quality-exempt');
+            core.setOutput('admin_author', adminAuthor ? 'true' : 'false');
+            core.setOutput('quality_exempt', qualityExempt ? 'true' : 'false');
+            console.log(`Maintainer overrides: admin_author=${adminAuthor} quality_exempt=${qualityExempt}`);
+
       - name: Parse issue body
         id: parser
         uses: stefanbuck/github-issue-parser@v3
@@ -104,6 +139,7 @@ jobs:
           ISSUE_AUTHOR_ID: ${{ github.event.issue.user.id }}
           ISSUE_AUTHOR_LOGIN: ${{ github.event.issue.user.login }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ADMIN_AUTHOR_OVERRIDE: ${{ steps.overrides.outputs.admin_author }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --dir scripts run create-listing
 
@@ -216,7 +252,12 @@ jobs:
          (github.event.comment.user.id == github.event.issue.user.id ||
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'COLLABORATOR'))
+          github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'issue_comment' &&
+         (contains(github.event.comment.body, '/admin-author') ||
+          contains(github.event.comment.body, '/quality-exempt')) &&
+         (github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER'))
       )
     runs-on: ubuntu-latest
     steps:
@@ -272,6 +313,36 @@ jobs:
               content: 'eyes'
             });
 
+      - name: Detect maintainer overrides
+        id: overrides
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Maintainer comment commands persist across revalidations: scan
+            // ALL comments on the issue, honoring a command only when its
+            // author's association is OWNER or MEMBER. A command matches when
+            // the trimmed comment body equals it, or starts with it followed
+            // by whitespace.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100
+            });
+            const hasCommand = (command) => comments.some((comment) => {
+              if (comment.author_association !== 'OWNER' && comment.author_association !== 'MEMBER') {
+                return false;
+              }
+              const body = (comment.body ?? '').trim();
+              if (body === command) return true;
+              return body.startsWith(command) && /\s/.test(body.charAt(command.length));
+            });
+            const adminAuthor = hasCommand('/admin-author');
+            const qualityExempt = hasCommand('/quality-exempt');
+            core.setOutput('admin_author', adminAuthor ? 'true' : 'false');
+            core.setOutput('quality_exempt', qualityExempt ? 'true' : 'false');
+            console.log(`Maintainer overrides: admin_author=${adminAuthor} quality_exempt=${qualityExempt}`);
+
       - name: Parse issue body
         id: parser
         uses: stefanbuck/github-issue-parser@v3
@@ -294,6 +365,7 @@ jobs:
           ISSUE_AUTHOR_ID: ${{ github.event.issue.user.id }}
           ISSUE_AUTHOR_LOGIN: ${{ github.event.issue.user.login }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ADMIN_AUTHOR_OVERRIDE: ${{ steps.overrides.outputs.admin_author }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --dir scripts run create-listing
 
@@ -345,7 +417,10 @@ jobs:
             // merge a draft, which is the hard publish gate. rescore_data
             // marks it ready after confirming the answers; a maintainer can
             // mark it ready manually to grandfather (add dq-grandfathered so
-            // CI's publish gate is exempted too).
+            // CI's publish gate is exempted too), or waive the gate up front
+            // by commenting /quality-exempt on the submission issue — then
+            // the PR is created ready with dq-grandfathered already applied.
+            const qualityExempt = '${{ steps.overrides.outputs.quality_exempt }}' === 'true';
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -357,17 +432,19 @@ jobs:
                 '',
                 'Submitted by @${{ github.event.issue.user.login }}',
                 '',
-                '**Draft until data quality is confirmed** — the author answers the data-quality questions (invite on the submission issue), then a maintainer reviews and comments `rescore_data` here, which marks this PR ready to merge.'
+                qualityExempt
+                  ? '**Data-quality requirement exempted by a maintainer** (`/quality-exempt` on the submission issue) — this PR is ready to merge at unconfirmed quality.'
+                  : '**Draft until data quality is confirmed** — the author answers the data-quality questions (invite on the submission issue), then a maintainer reviews and comments `rescore_data` here, which marks this PR ready to merge.'
               ].join('\n'),
               head: branch,
               base: 'main',
-              draft: true
+              draft: !qualityExempt
             });
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['automated-pr']
+              labels: qualityExempt ? ['automated-pr', 'dq-grandfathered'] : ['automated-pr']
             });
 
       - name: Handle success
@@ -428,12 +505,20 @@ jobs:
               ? `\n\nIf this map was generated with the same methodology as your other scored ${country} maps (${sampleIds.map((id) => `[\`${id}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/tree/main/maps/${id})`).join(', ')}), select **Yes** on the first question to inherit their answers automatically.`
               : '';
 
+            // /quality-exempt flips the required-next-step wording: the PR is
+            // created ready to merge, so the comment must not claim the
+            // submission is blocked on data-quality confirmation.
+            const qualityExempt = '${{ steps.overrides.outputs.quality_exempt }}' === 'true';
+            const dataQualityNote = qualityExempt
+              ? `**Data quality:** the data-quality requirement was exempted by a maintainer (\`/quality-exempt\`), so the publish PR is ready to merge without a confirmed tier. You can still [answer the data-quality questions](${inviteUrl}) at any time to earn a tier — the [Submission Questions guide](https://subwaybuildermodded.com/registry/docs/data-quality/questions) explains every question in plain language.`
+              : `**Required next step — data quality:** [answer the data-quality questions](${inviteUrl}) so your map can receive its data-quality tier. **Your submission cannot merge until a maintainer confirms your answers**; the publish PR stays in draft until then. The [Submission Questions guide](https://subwaybuildermodded.com/registry/docs/data-quality/questions) explains every question in plain language, and new submissions are subject to the [quality floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for countries with existing maps.`;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: 'A pull request has been created for your map submission. A maintainer will review it shortly.\n\n' +
-                `**Required next step — data quality:** [answer the data-quality questions](${inviteUrl}) so your map can receive its data-quality tier. **Your submission cannot merge until a maintainer confirms your answers**; the publish PR stays in draft until then. The [Submission Questions guide](https://subwaybuildermodded.com/registry/docs/data-quality/questions) explains every question in plain language, and new submissions are subject to the [quality floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for countries with existing maps.` +
+                dataQualityNote +
                 sampleNote
             });
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ All submissions are handled through GitHub Issues. Pick a template to get starte
 
 `registry` stores metadata only - manifests, gallery images, and pointers to where your mod or map is actually hosted (GitHub Releases, CDNs, etc.). When you submit through an issue template, CI validates your submission and opens a PR automatically. Once merged, your listing goes live.
 
+## Issue Comment Commands
+
+Automation reacts to specific comments on submission issues and their automated
+PRs. Who can use each command is enforced by the workflows:
+
+| Command | Where | Who | Effect |
+| --- | --- | --- | --- |
+| `revalidate` | Any submission/update issue (publish-mod/map, update-mod/map, update-author, data-quality) | Issue author or org OWNER/MEMBER/COLLABORATOR | Re-runs validation after the issue was edited (e.g. after a `failed-validation` result). |
+| `rescore_data [flags]` | Automated data-quality / publish **PRs** | OWNER/MEMBER/COLLABORATOR | Confirms the submitter's data-quality answers, applies the tier, and marks the publish PR ready to merge. Optional flags on the same line are passed through (e.g. `--admin` to bypass-merge). |
+| `/admin-author` | Publish issues | OWNER/MEMBER only | Creates the listing with author `subway-builder-modded-admin`; the issue submitter is recorded as active **caretaker** (credited for downloads of versions released during their tenure) and added as a collaborator. Use for assets whose true author has no GitHub account. |
+| `/quality-exempt` | Publish-map issues | OWNER/MEMBER only | Waives the data-quality merge gate for this submission: the publish PR is created ready (non-draft) with the `dq-grandfathered` label and merges at `unknown-quality`. |
+
+`/admin-author` and `/quality-exempt` may be commented before or after
+validation runs — the workflow scans all issue comments, so follow up with
+`revalidate` (or comment the command itself, which also triggers a run) to
+apply them.
+
 ## Map Issue Templates
 
 `publish-map.yml` and `update-map.yml` are generated from a shared script:

--- a/scripts/downloads/generate-downloads.ts
+++ b/scripts/downloads/generate-downloads.ts
@@ -38,6 +38,8 @@ import {
   buildIntegrityAlertEmbed,
   buildIntegrityAlertIssueBody,
   buildIntegrityAlertIssueTitle,
+  resolveAlertNotifyTarget,
+  type AlertNotifyTarget,
 } from "../lib/downloads-full/integrity-alerts.js";
 import { sendDiscordPayload } from "../lib/discord-webhook.js";
 
@@ -288,43 +290,50 @@ async function run(): Promise<void> {
     );
     if (discordIntegrityWebhookUrl && integrityAlerts.length > 0) {
       const authorIndex = loadAuthorAliasIndex(repoRoot);
-      const alertsByAuthorId = new Map<string, typeof integrityAlerts>();
+      // Group by notify TARGET (active caretaker when set, else the author):
+      // for admin-authored/caretaken listings the caretaker owns the release
+      // pipeline, so the ping routes to them. The embed keeps showing the
+      // listing author's alias — only the mention target changes.
+      const alertsByTarget = new Map<string, { target: AlertNotifyTarget; alerts: typeof integrityAlerts }>();
       for (const alert of integrityAlerts) {
-        if (!alertsByAuthorId.has(alert.authorId)) {
-          alertsByAuthorId.set(alert.authorId, []);
+        const target = resolveAlertNotifyTarget(alert, authorIndex);
+        const group = alertsByTarget.get(target.authorId);
+        if (group) {
+          group.alerts.push(alert);
+        } else {
+          alertsByTarget.set(target.authorId, { target, alerts: [alert] });
         }
-        alertsByAuthorId.get(alert.authorId)!.push(alert);
       }
-      for (const [authorId, authorAlerts] of alertsByAuthorId) {
-        const authorEntry = authorIndex.authors.find((a) => a.author_id === authorId);
-        const discordId = authorEntry?.discord_id;
-        const authorAlias = authorEntry?.author_alias ?? authorEntry?.author_id ?? authorId;
+      for (const { target, alerts: targetAlerts } of alertsByTarget.values()) {
+        const discordId = target.discordId;
         const content = discordId ? `<@${discordId}>` : undefined;
-        const noDiscordIdNote = discordId ? undefined : `No Discord ID on file for ${authorAlias}`;
-        const embeds = authorAlerts.slice(0, 10).map((alert) =>
-          buildIntegrityAlertEmbed(alert, authorAlias, noDiscordIdNote),
-        );
+        const noDiscordIdNote = discordId ? undefined : `No Discord ID on file for ${target.alias}`;
+        const embeds = targetAlerts.slice(0, 10).map((alert) => {
+          const authorEntry = authorIndex.authors.find((a) => a.author_id === alert.authorId);
+          const authorAlias = authorEntry?.author_alias ?? authorEntry?.author_id ?? alert.authorId;
+          return buildIntegrityAlertEmbed(alert, authorAlias, noDiscordIdNote);
+        });
         try {
           await sendDiscordPayload(discordIntegrityWebhookUrl, content, embeds);
-          console.log(`[downloads][integrity-alert] Sent Discord alert for author=${authorId} (${authorAlerts.length} version(s))`);
+          console.log(`[downloads][integrity-alert] Sent Discord alert for target=${target.authorId} (${targetAlerts.length} version(s))`);
         } catch (error) {
-          console.warn(`[downloads][integrity-alert] Failed to send Discord alert for author=${authorId}: ${(error as Error).message}`);
+          console.warn(`[downloads][integrity-alert] Failed to send Discord alert for target=${target.authorId}: ${(error as Error).message}`);
         }
       }
     }
-    // GitHub-issue notifications for authors with no Discord ID on file: the
-    // channel embed alone never reaches them, so an @mention issue triggers
-    // GitHub's native notification instead. Issue titles are the dedup key
-    // against open integrity-alert issues (alerts fire on state transitions,
-    // so this only guards reruns/backfills).
+    // GitHub-issue notifications for notify targets (caretaker when set, else
+    // author) with no Discord ID on file: the channel embed alone never
+    // reaches them, so an @mention issue triggers GitHub's native
+    // notification instead. Issue titles are the dedup key against open
+    // integrity-alert issues (alerts fire on state transitions, so this only
+    // guards reruns/backfills).
     const githubToken = process.env.GITHUB_TOKEN?.trim() || undefined;
     const githubRepository = process.env.GITHUB_REPOSITORY?.trim() || undefined;
     if (githubToken && githubRepository && integrityAlerts.length > 0) {
       const authorIndex = loadAuthorAliasIndex(repoRoot);
-      const githubOnlyAlerts = integrityAlerts.filter((alert) => {
-        const entry = authorIndex.authors.find((a) => a.author_id === alert.authorId);
-        return entry !== undefined && !entry.discord_id && entry.github_id !== undefined;
-      });
+      const githubOnlyAlerts = integrityAlerts
+        .map((alert) => ({ alert, target: resolveAlertNotifyTarget(alert, authorIndex) }))
+        .filter(({ target }) => !target.discordId && target.githubId !== undefined);
       if (githubOnlyAlerts.length > 0) {
         const apiHeaders = {
           Authorization: `Bearer ${githubToken}`,
@@ -347,7 +356,7 @@ async function run(): Promise<void> {
         } catch (error) {
           console.warn(`[downloads][integrity-alert] Failed to list open alert issues: ${(error as Error).message}`);
         }
-        for (const alert of githubOnlyAlerts) {
+        for (const { alert, target } of githubOnlyAlerts) {
           const title = buildIntegrityAlertIssueTitle(alert);
           if (openAlertTitles.has(title)) {
             console.log(`[downloads][integrity-alert] Open issue already exists for ${alert.listingId} ${alert.version}; skipping`);
@@ -361,13 +370,13 @@ async function run(): Promise<void> {
                 headers: apiHeaders,
                 body: JSON.stringify({
                   title,
-                  body: buildIntegrityAlertIssueBody(alert),
+                  body: buildIntegrityAlertIssueBody(alert, target.authorId),
                   labels: ["integrity-alert"],
                 }),
               },
             );
             if (createResponse.ok) {
-              console.log(`[downloads][integrity-alert] Opened GitHub issue for author=${alert.authorId} listing=${alert.listingId} version=${alert.version}`);
+              console.log(`[downloads][integrity-alert] Opened GitHub issue for target=${target.authorId} listing=${alert.listingId} version=${alert.version}`);
             } else {
               console.warn(`[downloads][integrity-alert] Failed to open GitHub issue for ${alert.listingId} ${alert.version}: HTTP ${createResponse.status}`);
             }

--- a/scripts/intake/create-listing.ts
+++ b/scripts/intake/create-listing.ts
@@ -22,7 +22,11 @@ import {
   ensureCollaboratorAuthorAliasPrefills,
   resolvePublishCollaborators,
 } from "../lib/collaborators.js";
-import { resolvePublishCaretaker } from "../lib/caretakers.js";
+import {
+  ADMIN_AUTHOR_ID,
+  applyAdminAuthorOverride,
+  resolvePublishCaretaker,
+} from "../lib/caretakers.js";
 import {
   type MapManifest,
   type ModManifest,
@@ -202,6 +206,20 @@ async function main() {
     update: buildUpdate(data),
     ...(mapData ? mapData.mapFields : {}),
   };
+
+  // /admin-author maintainer override (publish-issue comment command): the
+  // listing is authored by the org admin account; the submitter stays on as
+  // collaborator and — unless the form named a caretaker — active caretaker,
+  // so they keep edit rights and download credit from v1.
+  if (process.env.ADMIN_AUTHOR_OVERRIDE === "true") {
+    applyAdminAuthorOverride(manifest, issueAuthorGithubId, new Date().toISOString());
+    console.log(
+      `[create-listing] /admin-author override: author=${ADMIN_AUTHOR_ID}; `
+      + `submitter '${issueAuthorLogin}' recorded as ${
+        caretakerGithubId !== null ? "collaborator (form caretaker kept)" : "active caretaker"
+      }`,
+    );
+  }
 
   const authorPrefillResult = ensureAuthorAliasPrefill(
     REPO_ROOT,

--- a/scripts/lib/caretakers.ts
+++ b/scripts/lib/caretakers.ts
@@ -4,11 +4,20 @@ import { fetchGitHubUserById, type GitHubUser } from "./github.js";
 const EMPTY_UPDATE_VALUES = new Set(["", "_No response_", "No change"]);
 const CLEAR_CARETAKER_VALUE = "None";
 
+/** Listing author identity used by the /admin-author maintainer override. */
+export const ADMIN_AUTHOR_ID = "subway-builder-modded-admin";
+export const ADMIN_AUTHOR_GITHUB_ID = 268817724;
+
 export type { CaretakerWindow };
 
 export type ManifestWithCaretakers = {
   collaborators?: number[];
   caretakers?: CaretakerWindow[];
+};
+
+export type ManifestWithAuthor = ManifestWithCaretakers & {
+  author: string;
+  github_id: number;
 };
 
 export type CaretakerUpdate =
@@ -107,6 +116,30 @@ export function applyCaretakerUpdate(
   manifest.caretakers = caretakers;
   unionCollaborator(manifest, update.githubId);
   return update;
+}
+
+/**
+ * Applies the /admin-author maintainer override to a freshly built publish
+ * manifest: the listing's author becomes the org admin account, and the issue
+ * submitter keeps edit rights and download credit —
+ * - `author`/`github_id` → `subway-builder-modded-admin` / its GitHub ID;
+ * - the submitter is unioned into `collaborators` unconditionally;
+ * - unless the form already specified an (active) caretaker — the form value
+ *   wins — the submitter becomes the active caretaker since `nowIso` (which
+ *   also unions them into `collaborators`, already done above).
+ */
+export function applyAdminAuthorOverride(
+  manifest: ManifestWithAuthor,
+  submitterGithubId: number,
+  nowIso: string,
+): void {
+  manifest.author = ADMIN_AUTHOR_ID;
+  manifest.github_id = ADMIN_AUTHOR_GITHUB_ID;
+  unionCollaborator(manifest, submitterGithubId);
+  if (getActiveCaretaker(manifest) !== undefined) return;
+  const caretakers = Array.isArray(manifest.caretakers) ? manifest.caretakers : [];
+  caretakers.push({ github_id: submitterGithubId, since: nowIso });
+  manifest.caretakers = caretakers;
 }
 
 async function validateCaretakerGithubId(

--- a/scripts/lib/download-definitions.ts
+++ b/scripts/lib/download-definitions.ts
@@ -130,6 +130,10 @@ export interface IntegrityAlert {
   listingName: string;
   listingType: "map" | "mod";
   authorId: string;
+  // GitHub ID of the listing's ACTIVE caretaker, when one exists — alert
+  // notifications route to them instead of the author (who may be the org
+  // admin account for admin-authored/caretaken listings).
+  caretakerGithubId?: number;
   version: string;
   isRegression: boolean;
   failingChecks: string[];

--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -59,6 +59,15 @@ import {
   type DownloadAttributionLedger,
 } from "./download-attribution.js";
 import { toDownloadAssetBucketKey } from "./download-version-buckets.js";
+import { getActiveCaretaker } from "./caretakers.js";
+
+// Per-listing display/routing metadata carried from the manifest into
+// integrity-alert assembly.
+interface ListingMetaEntry {
+  listingName: string;
+  authorId: string;
+  caretakerGithubId?: number;
+}
 
 interface AdjustedVersionCount {
   adjustedCount: number;
@@ -284,7 +293,7 @@ interface FullRunContext {
   versionBucketInputs: D.VersionBucketInputsByListing;
   integrityListings: Record<string, ListingIntegrityEntry>;
   integrityAlerts: D.IntegrityAlert[];
-  listingMeta: Map<string, { listingName: string; authorId: string }>;
+  listingMeta: Map<string, ListingMetaEntry>;
   transientErrorListings: Set<string>;
   repoIndexes: Map<string, D.RepoReleaseIndex>;
   unavailableRepos: Set<string>;
@@ -316,7 +325,7 @@ async function resolveListingContexts(params: {
   previousDownloads: D.DownloadsByListing;
   downloadsByListing: D.DownloadsByListing;
   listingContexts: Map<string, ListingContext>;
-  listingMeta: Map<string, { listingName: string; authorId: string }>;
+  listingMeta: Map<string, ListingMetaEntry>;
   repoSet: Set<string>;
   transientErrorListings: Set<string>;
 }): Promise<void> {
@@ -350,7 +359,11 @@ async function resolveListingContexts(params: {
       continue;
     }
 
-    listingMeta.set(id, { listingName: manifest.name, authorId: manifest.author });
+    listingMeta.set(id, {
+      listingName: manifest.name,
+      authorId: manifest.author,
+      caretakerGithubId: getActiveCaretaker(manifest)?.github_id,
+    });
 
     if (manifest.update.type === "github") {
       const repo = manifest.update.repo.toLowerCase();
@@ -1197,6 +1210,9 @@ function finalizeListingEntries(
           listingName: meta?.listingName ?? id,
           listingType: ctx.listingType,
           authorId: meta?.authorId ?? "",
+          ...(meta?.caretakerGithubId !== undefined
+            ? { caretakerGithubId: meta.caretakerGithubId }
+            : {}),
           version,
           isRegression: prevEntry?.is_complete === true,
           failingChecks: Object.entries(entry.required_checks)
@@ -1292,7 +1308,7 @@ export async function generateDownloadsDataFull(
 
   const downloadsByListing: D.DownloadsByListing = {};
   const listingContexts = new Map<string, ListingContext>();
-  const listingMeta = new Map<string, { listingName: string; authorId: string }>();
+  const listingMeta = new Map<string, ListingMetaEntry>();
   const repoSet = new Set<string>();
   const transientErrorListings = new Set<string>();
 

--- a/scripts/lib/downloads-full/integrity-alerts.ts
+++ b/scripts/lib/downloads-full/integrity-alerts.ts
@@ -1,3 +1,4 @@
+import type { AuthorAliasIndex } from "../author-aliases.js";
 import type { DiscordEmbed } from "../discord-webhook.js";
 import type { IntegrityAlert } from "../download-definitions.js";
 
@@ -21,6 +22,54 @@ export const INTEGRITY_CHECK_FIX_HINTS: Record<string, string> = {
   security_scan_passed: "Remove or fix the files flagged by the security scan (listed in the errors above), then publish a new release.",
   release_manifest_asset: "Publish a new release with `manifest.json` uploaded as a separate release asset alongside the ZIP (not only inside it).",
 };
+
+/** Who an integrity alert should notify (ping/mention) — not who authored it. */
+export interface AlertNotifyTarget {
+  authorId: string;
+  alias: string;
+  discordId?: string;
+  githubId?: number;
+}
+
+/**
+ * Resolves the person an alert's notifications route to, in priority order:
+ * 1. the listing's ACTIVE caretaker (alert.caretakerGithubId, looked up in the
+ *    author index by github_id) when set and resolvable — they own the release
+ *    pipeline for admin-authored/caretaken listings;
+ * 2. the listing author's index entry (by author_id);
+ * 3. a bare fallback carrying only the author id (no Discord/GitHub routing).
+ * The embed itself keeps showing the listing author; only the target changes.
+ */
+export function resolveAlertNotifyTarget(
+  alert: IntegrityAlert,
+  authorIndex: AuthorAliasIndex,
+): AlertNotifyTarget {
+  if (alert.caretakerGithubId !== undefined) {
+    const caretakerEntry = authorIndex.authors.find(
+      (entry) => entry.github_id === alert.caretakerGithubId,
+    );
+    if (caretakerEntry?.author_id) {
+      return {
+        authorId: caretakerEntry.author_id,
+        alias: caretakerEntry.author_alias ?? caretakerEntry.author_id,
+        ...(caretakerEntry.discord_id ? { discordId: caretakerEntry.discord_id } : {}),
+        ...(caretakerEntry.github_id !== undefined ? { githubId: caretakerEntry.github_id } : {}),
+      };
+    }
+  }
+  const authorEntry = authorIndex.authors.find(
+    (entry) => entry.author_id === alert.authorId,
+  );
+  if (authorEntry) {
+    return {
+      authorId: authorEntry.author_id ?? alert.authorId,
+      alias: authorEntry.author_alias ?? authorEntry.author_id ?? alert.authorId,
+      ...(authorEntry.discord_id ? { discordId: authorEntry.discord_id } : {}),
+      ...(authorEntry.github_id !== undefined ? { githubId: authorEntry.github_id } : {}),
+    };
+  }
+  return { authorId: alert.authorId, alias: alert.authorId };
+}
 
 export function buildIntegrityAlertEmbed(
   alert: IntegrityAlert,
@@ -78,17 +127,22 @@ export function buildIntegrityAlertIssueTitle(alert: IntegrityAlert): string {
 }
 
 /**
- * GitHub-issue body mirroring the Discord embed, for authors with no
+ * GitHub-issue body mirroring the Discord embed, for notify targets with no
  * discord_id on file. The @mention triggers GitHub's native notification.
+ * `mentionLogin` overrides who is @mentioned (e.g. the active caretaker);
+ * it defaults to the listing author.
  */
-export function buildIntegrityAlertIssueBody(alert: IntegrityAlert): string {
+export function buildIntegrityAlertIssueBody(
+  alert: IntegrityAlert,
+  mentionLogin: string = alert.authorId,
+): string {
   const typeLabel = alert.listingType === "map" ? "Map" : "Mod";
   const regressionLabel = alert.isRegression
     ? "a previously-passing version stopped passing"
     : "a new version failed its first check";
 
   const lines: string[] = [
-    `@${alert.authorId} — your ${typeLabel.toLowerCase()} **${alert.listingName}** \`${alert.version}\` is failing integrity checks (${regressionLabel}). Failing versions are excluded from downloads until fixed.`,
+    `@${mentionLogin} — your ${typeLabel.toLowerCase()} **${alert.listingName}** \`${alert.version}\` is failing integrity checks (${regressionLabel}). Failing versions are excluded from downloads until fixed.`,
     "",
     "**Failing checks:**",
     ...alert.failingChecks.map((key) => {

--- a/scripts/tests/caretakers.unit.test.ts
+++ b/scripts/tests/caretakers.unit.test.ts
@@ -2,11 +2,15 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { ModManifestSchema } from "@subway-builder-modded/registry-schemas";
 import {
+  ADMIN_AUTHOR_GITHUB_ID,
+  ADMIN_AUTHOR_ID,
+  applyAdminAuthorOverride,
   applyCaretakerUpdate,
   getActiveCaretaker,
   parseCaretakerUpdate,
   parsePublishCaretaker,
   resolveCaretakerUpdate,
+  type ManifestWithAuthor,
   type ManifestWithCaretakers,
 } from "../lib/caretakers.js";
 
@@ -240,6 +244,59 @@ test("apply caretaker update does not duplicate an existing collaborator id", ()
   applyCaretakerUpdate(manifest, "200", NOW);
   assert.deepEqual(manifest.collaborators, [200, 300]);
   assert.deepEqual(manifest.caretakers, [{ github_id: 200, since: NOW }]);
+});
+
+// --- applyAdminAuthorOverride (/admin-author comment command) ---
+
+test("admin-author override swaps author identity and defaults the submitter as caretaker", () => {
+  const manifest: ManifestWithAuthor = { author: "submitter", github_id: 555 };
+  applyAdminAuthorOverride(manifest, 555, NOW);
+  assert.equal(manifest.author, ADMIN_AUTHOR_ID);
+  assert.equal(manifest.author, "subway-builder-modded-admin");
+  assert.equal(manifest.github_id, ADMIN_AUTHOR_GITHUB_ID);
+  assert.equal(manifest.github_id, 268817724);
+  assert.deepEqual(manifest.caretakers, [{ github_id: 555, since: NOW }]);
+  assert.deepEqual(manifest.collaborators, [555]);
+});
+
+test("admin-author override keeps a form-specified caretaker and still unions the submitter", () => {
+  const manifest: ManifestWithAuthor = {
+    author: "submitter",
+    github_id: 555,
+    collaborators: [700],
+    caretakers: [{ github_id: 700, since: "2026-07-01T00:00:00Z" }],
+  };
+  applyAdminAuthorOverride(manifest, 555, NOW);
+  assert.equal(manifest.author, ADMIN_AUTHOR_ID);
+  assert.equal(manifest.github_id, ADMIN_AUTHOR_GITHUB_ID);
+  // Form caretaker wins: no new caretaker window is opened.
+  assert.deepEqual(manifest.caretakers, [{ github_id: 700, since: "2026-07-01T00:00:00Z" }]);
+  // The submitter keeps edit rights via collaborators.
+  assert.deepEqual(manifest.collaborators, [700, 555]);
+});
+
+test("admin-author override is idempotent about collaborator membership", () => {
+  const manifest: ManifestWithAuthor = {
+    author: "submitter",
+    github_id: 555,
+    collaborators: [555, 700],
+  };
+  applyAdminAuthorOverride(manifest, 555, NOW);
+  assert.deepEqual(manifest.collaborators, [555, 700]);
+  assert.deepEqual(manifest.caretakers, [{ github_id: 555, since: NOW }]);
+});
+
+test("admin-author override with the submitter as form caretaker leaves a single window", () => {
+  const manifest: ManifestWithAuthor = {
+    author: "submitter",
+    github_id: 555,
+    collaborators: [555],
+    caretakers: [{ github_id: 555, since: "2026-07-01T00:00:00Z" }],
+  };
+  applyAdminAuthorOverride(manifest, 555, NOW);
+  assert.deepEqual(manifest.caretakers, [{ github_id: 555, since: "2026-07-01T00:00:00Z" }]);
+  assert.deepEqual(manifest.collaborators, [555]);
+  assert.equal(getActiveCaretaker(manifest)?.github_id, 555);
 });
 
 // --- Resolution (GitHub account existence, fetch mocked) ---

--- a/scripts/tests/integrity-alerts.unit.test.ts
+++ b/scripts/tests/integrity-alerts.unit.test.ts
@@ -3,7 +3,9 @@ import assert from "node:assert/strict";
 import {
   buildIntegrityAlertIssueBody,
   buildIntegrityAlertIssueTitle,
+  resolveAlertNotifyTarget,
 } from "../lib/downloads-full/integrity-alerts.js";
+import type { AuthorAliasIndex } from "../lib/author-aliases.js";
 import type { IntegrityAlert } from "../lib/download-definitions.js";
 
 function makeAlert(overrides: Partial<IntegrityAlert> = {}): IntegrityAlert {
@@ -67,4 +69,77 @@ test("issue body caps errors at 8 with an overflow line", () => {
   assert.ok(body.includes("- error 8"));
   assert.ok(!body.includes("- error 9"));
   assert.ok(body.includes("...and 3 more"));
+});
+
+test("issue body mention login override renders the caretaker's @mention", () => {
+  const body = buildIntegrityAlertIssueBody(makeAlert(), "caretaker-login");
+  assert.ok(body.startsWith("@caretaker-login "));
+  assert.ok(!body.includes("@some-author"));
+  // Everything but the mention is unchanged.
+  assert.ok(body.includes("**Test Map** `v1.2.0`"));
+});
+
+// --- resolveAlertNotifyTarget ---
+
+function makeAuthorIndex(): AuthorAliasIndex {
+  return {
+    schema_version: 1,
+    authors: [
+      {
+        github_id: 1,
+        author_id: "some-author",
+        author_alias: "Some Author",
+        discord_id: "111",
+      },
+      {
+        github_id: 2,
+        author_id: "caretaker-login",
+        author_alias: "Care Taker",
+        discord_id: "222",
+      },
+      {
+        github_id: 3,
+        author_id: "gh-only-caretaker",
+      },
+    ],
+  };
+}
+
+test("notify target resolves the active caretaker's entry when set and resolvable", () => {
+  const target = resolveAlertNotifyTarget(makeAlert({ caretakerGithubId: 2 }), makeAuthorIndex());
+  assert.deepEqual(target, {
+    authorId: "caretaker-login",
+    alias: "Care Taker",
+    discordId: "222",
+    githubId: 2,
+  });
+});
+
+test("notify target falls back to alias/discord-less caretaker entries gracefully", () => {
+  const target = resolveAlertNotifyTarget(makeAlert({ caretakerGithubId: 3 }), makeAuthorIndex());
+  assert.deepEqual(target, { authorId: "gh-only-caretaker", alias: "gh-only-caretaker", githubId: 3 });
+});
+
+test("notify target falls back to the author when the caretaker id is unresolvable", () => {
+  const target = resolveAlertNotifyTarget(makeAlert({ caretakerGithubId: 999 }), makeAuthorIndex());
+  assert.deepEqual(target, {
+    authorId: "some-author",
+    alias: "Some Author",
+    discordId: "111",
+    githubId: 1,
+  });
+});
+
+test("notify target is the author when no caretaker is set", () => {
+  const target = resolveAlertNotifyTarget(makeAlert(), makeAuthorIndex());
+  assert.equal(target.authorId, "some-author");
+  assert.equal(target.discordId, "111");
+});
+
+test("notify target degrades to a bare fallback when neither resolves", () => {
+  const target = resolveAlertNotifyTarget(
+    makeAlert({ authorId: "unknown-author", caretakerGithubId: 999 }),
+    makeAuthorIndex(),
+  );
+  assert.deepEqual(target, { authorId: "unknown-author", alias: "unknown-author" });
 });


### PR DESCRIPTION
PR B of the caretakers plan (schema + intake landed in #6608).

## Comment commands (publish flow)
Two org-maintainer commands, scanned from ALL issue comments and honored only for OWNER/MEMBER commenters (exact-token match, so `/admin-authorfoo` doesn't count); commenting either also triggers a run, same pattern as `revalidate`:
- **`/admin-author`** — the listing is created with author `subway-builder-modded-admin` (github_id 268817724, already indexed with alias + Discord identity); the issue submitter becomes active caretaker + collaborator (an explicit form caretaker wins if present, submitter still unioned into collaborators for edit rights).
- **`/quality-exempt`** (maps) — the publish PR is created **non-draft** with the existing `dq-grandfathered` label, automating the manual grandfather path; PR body + success comment swap to exempted wording instead of falsely claiming a draft/blocking state.

## Caretaker-aware integrity-alert routing
Alerts now notify the **active caretaker** when one exists, falling back to the author: `IntegrityAlert` carries the active caretaker's github_id (resolved from the manifest at listing-context time), and a pure `resolveAlertNotifyTarget` picks caretaker-index-entry → author-entry → bare fallback. Discord pings + the no-discord GitHub-issue path both use the target (issue @mention = target's login); embeds still display the listing author's alias. This also fixes the admin-authored case where alerts would have pinged the admin Discord instead of the person who can fix the release.

## Verification
10 new tests (admin-override matrix incl. form-caretaker precedence + collaborator idempotency; notify-target resolution order; issue-body mention override — default output byte-identical). Fresh-build suite 293/293; tsc zero diagnostics; workflow YAML parse-checked with CRLF preserved.

BarKuperman's AU/NZ issues (6571–6579) are the intended live test: comment both commands + `revalidate` on each once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)