### PR TITLE
Credit downloads to caretakers at the analytics layer

### DIFF
--- a/scripts/lib/analytics-core.ts
+++ b/scripts/lib/analytics-core.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { loadAuthorAliasIndex } from "./author-aliases.js";
@@ -6,6 +6,12 @@ import { getFlagValue } from "./cli.js";
 import { writeCsv } from "./csv.js";
 import { readJsonFile } from "./json-utils.js";
 import { resolveRepoRoot } from "./script-runtime.js";
+import { compareStableSemverAsc } from "./semver.js";
+import { isTestListing } from "./test-listings.js";
+import {
+  buildVersionCreditResolver,
+  type CreditedPersonPresentation,
+} from "./analytics/credited-person.js";
 import {
   buildAssetsByDayRows,
   buildAuthorByDayRows,
@@ -26,12 +32,14 @@ import {
   buildListingIdsBySnapshot,
   buildListingVersionsBySnapshot,
   buildMonotonicSnapshotTotals,
+  buildVersionGrainSnapshotTotals,
   listSnapshots,
   resolveBaselineSnapshot,
   toListingTotals,
 } from "./analytics/snapshots.js";
 import type {
   AssetByDayRow,
+  AuthorCreditEntry,
   DailySeriesRow,
   ListingKey,
   ListingMeta,
@@ -113,6 +121,16 @@ interface AuthorAssetCountRow {
   mod_count: number;
   total_downloads: number;
   adjusted_total_downloads: number;
+  // Number of listings where this person is the ACTIVE caretaker (no `until`).
+  // Appended last so existing positional consumers keep working.
+  caretaken_asset_count: number;
+}
+
+interface ListingVersionCreditRow {
+  listing_type: "map" | "mod";
+  listing_id: string;
+  version: string;
+  credited_author_id: string;
 }
 
 interface AuthorTotalDownloadsRow {
@@ -262,6 +280,118 @@ export function runGenerateAnalyticsCli(
   for (const key of latestAdjustedTotals.keys()) {
     const [listingType, id] = key.split(":") as ["maps" | "mods", string];
     listingMeta.set(key, loadManifestMeta(resolvedRepoRoot, listingType, id, authorAliases));
+  }
+
+  // --- Caretaker download crediting (author aggregations only) ---
+  // Each listing is partitioned into "credit units": groups of versions credited
+  // to the same person per the [since, until)/released_at rule. Listings whose
+  // versions all credit one person (every listing without caretakers, and
+  // caretaker-since-epoch listings) keep listing-grain totals; only listings
+  // split between persons use (listing, version)-grain monotonic/delta math.
+  const creditResolver = buildVersionCreditResolver({
+    repoRoot: resolvedRepoRoot,
+    authorAliases,
+  });
+  const UNKNOWN_PERSON: CreditedPersonPresentation = {
+    author: "UNKNOWN",
+    author_alias: "UNKNOWN",
+    attribution_link: "https://github.com/UNKNOWN",
+  };
+
+  // Union of versions per listing across all history snapshots.
+  const historyVersionsByListing = new Map<ListingKey, Set<string>>();
+  for (const versionSets of listingVersionsBySnapshot.values()) {
+    for (const listingType of ["maps", "mods"] as const) {
+      for (const versionKey of versionSets[listingType]) {
+        const separatorIndex = versionKey.indexOf("@@");
+        if (separatorIndex === -1) continue;
+        const key: ListingKey = `${listingType}:${versionKey.slice(0, separatorIndex)}`;
+        let versions = historyVersionsByListing.get(key);
+        if (!versions) {
+          versions = new Set<string>();
+          historyVersionsByListing.set(key, versions);
+        }
+        versions.add(versionKey.slice(separatorIndex + 2));
+      }
+    }
+  }
+
+  interface ListingCreditUnit {
+    person: CreditedPersonPresentation;
+    // null = all of the listing's versions (use listing-grain totals unchanged).
+    versions: Set<string> | null;
+  }
+  const creditUnitsByListing = new Map<ListingKey, ListingCreditUnit[]>();
+  const splitListingKeys = new Set<ListingKey>();
+  for (const key of latestTotals.keys()) {
+    const [listingType, id] = key.split(":") as ["maps" | "mods", string];
+    const meta = listingMeta.get(key);
+    const authorPerson: CreditedPersonPresentation = meta
+      ? { author: meta.author, author_alias: meta.author_alias, attribution_link: meta.attribution_link }
+      : UNKNOWN_PERSON;
+    let units: ListingCreditUnit[] = [{ person: authorPerson, versions: null }];
+    if (creditResolver.hasCaretakers(listingType, id)) {
+      const versions = [...(historyVersionsByListing.get(key) ?? new Set<string>())]
+        .sort(compareStableSemverAsc);
+      const groups = new Map<string, { person: CreditedPersonPresentation; versions: Set<string> }>();
+      for (const version of versions) {
+        const person = creditResolver.resolvePresentation(listingType, id, version, authorPerson);
+        const group = groups.get(person.author) ?? { person, versions: new Set<string>() };
+        group.versions.add(version);
+        groups.set(person.author, group);
+      }
+      if (groups.size === 1) {
+        units = [{ person: [...groups.values()][0]!.person, versions: null }];
+      } else if (groups.size > 1) {
+        units = [...groups.values()].map((group) => ({ person: group.person, versions: group.versions }));
+        splitListingKeys.add(key);
+      }
+    }
+    creditUnitsByListing.set(key, units);
+  }
+
+  const versionGrain = splitListingKeys.size > 0
+    ? buildVersionGrainSnapshotTotals(snapshots, historyDir, splitListingKeys)
+    : null;
+  const sumOverVersionKeys = (
+    totals: Map<string, number> | undefined,
+    versionKeys: readonly string[],
+  ): number => {
+    if (!totals) return 0;
+    let total = 0;
+    for (const versionKey of versionKeys) {
+      total += totals.get(versionKey) ?? 0;
+    }
+    return total;
+  };
+
+  const authorCreditEntries: AuthorCreditEntry[] = [];
+  for (const [key, currentTotal] of latestTotals.entries()) {
+    const [listingType] = key.split(":") as ["maps" | "mods", string];
+    for (const unit of creditUnitsByListing.get(key) ?? []) {
+      if (unit.versions === null) {
+        authorCreditEntries.push({
+          listingType,
+          person: unit.person,
+          currentTotal,
+          currentAdjusted: latestAdjustedTotals.get(key) ?? 0,
+          monotonicAt: (file) => monotonicTotalsBySnapshot.get(file)?.get(key) ?? 0,
+          adjustedAt: (file) => getAdjustedTotalsForSnapshot(file).get(key) ?? 0,
+          deltaAt: (file) => filteredDailyDeltasBySnapshot.get(file)?.get(key) ?? 0,
+        });
+      } else {
+        const versionKeys = [...unit.versions].map((version) => `${key}@@${version}`);
+        authorCreditEntries.push({
+          listingType,
+          person: unit.person,
+          currentTotal: sumOverVersionKeys(versionGrain?.monotonicBySnapshot.get(latest.file), versionKeys),
+          currentAdjusted: sumOverVersionKeys(versionGrain?.adjustedBySnapshot.get(latest.file), versionKeys),
+          monotonicAt: (file) => sumOverVersionKeys(versionGrain?.monotonicBySnapshot.get(file), versionKeys),
+          adjustedAt: (file) => sumOverVersionKeys(versionGrain?.adjustedBySnapshot.get(file), versionKeys),
+          deltaAt: (file) => sumOverVersionKeys(versionGrain?.dailyDeltasBySnapshot.get(file), versionKeys),
+        });
+      }
+    }
   }
 
   const listingProjectRows: ListingProjectRow[] = [...latestAdjustedTotals.keys()]
@@ -481,6 +611,8 @@ export function runGenerateAnalyticsCli(
     }));
   })();
 
+  // authors_by_asset_count stays AUTHORSHIP-based (assets owned); caretaker
+  // crediting only adds the caretaken_asset_count column.
   const authorStats = new Map<string, Omit<AuthorAssetCountRow, "rank">>();
   for (const [key, total] of latestTotals.entries()) {
     const [listingType] = key.split(":") as ["maps" | "mods", string];
@@ -500,6 +632,7 @@ export function runGenerateAnalyticsCli(
       mod_count: 0,
       total_downloads: 0,
       adjusted_total_downloads: 0,
+      caretaken_asset_count: 0,
     };
     previous.asset_count += 1;
     if (listingType === "maps") previous.map_count += 1;
@@ -509,31 +642,66 @@ export function runGenerateAnalyticsCli(
     authorStats.set(meta.author, previous);
   }
 
+  // caretaken_asset_count: listings whose manifest declares this person as the
+  // ACTIVE caretaker (entry without `until`). Persons who caretake but author
+  // nothing still get a row (zeros in the authorship columns).
+  for (const key of latestTotals.keys()) {
+    const [listingType, id] = key.split(":") as ["maps" | "mods", string];
+    const active = creditResolver.activeCaretaker(listingType, id);
+    if (!active) continue;
+    const existing = authorStats.get(active.author) ?? {
+      author: active.author,
+      author_alias: active.author_alias,
+      attribution_link: active.attribution_link,
+      asset_count: 0,
+      map_count: 0,
+      mod_count: 0,
+      total_downloads: 0,
+      adjusted_total_downloads: 0,
+      caretaken_asset_count: 0,
+    };
+    existing.caretaken_asset_count += 1;
+    authorStats.set(active.author, existing);
+  }
+
+  // authors_by_total_downloads aggregates per CREDITED person (caretaker
+  // crediting); identical to authorStats whenever no listing splits credit.
+  const creditedAuthorStats = new Map<string, Omit<AuthorTotalDownloadsRow, "rank">>();
+  for (const entry of authorCreditEntries) {
+    const previous = creditedAuthorStats.get(entry.person.author) ?? {
+      author: entry.person.author,
+      author_alias: entry.person.author_alias,
+      attribution_link: entry.person.attribution_link,
+      total_downloads: 0,
+      adjusted_total_downloads: 0,
+      asset_count: 0,
+      map_count: 0,
+      mod_count: 0,
+    };
+    previous.asset_count += 1;
+    if (entry.listingType === "maps") previous.map_count += 1;
+    if (entry.listingType === "mods") previous.mod_count += 1;
+    previous.total_downloads += entry.currentTotal;
+    previous.adjusted_total_downloads += entry.currentAdjusted;
+    creditedAuthorStats.set(entry.person.author, previous);
+  }
+
+  // Author windows aggregate per CREDITED person (caretaker crediting) at
+  // credit-unit grain; identical to the old listing-author rollup whenever no
+  // listing splits credit between persons.
   const authorRowsForWindow = (days: number): AuthorWindowRow[] => {
     const baseline = resolveBaselineSnapshot(snapshots, latest.date, days);
-    const baselineAdjustedTotals = getAdjustedTotalsForSnapshot(baseline.file);
-    const baselineTotals = filterOutTestListingTotals(
-      resolvedRepoRoot,
-      monotonicTotalsBySnapshot.get(baseline.file) ?? new Map<ListingKey, number>(),
-    );
     const authorWindowStats = new Map<string, Omit<AuthorWindowRow, "rank">>();
 
-    for (const [key, currentTotal] of latestTotals.entries()) {
-      const [listingType] = key.split(":") as ["maps" | "mods", string];
-      const meta = listingMeta.get(key) ?? {
-        name: "",
-        author: "UNKNOWN",
-        author_alias: "UNKNOWN",
-        attribution_link: "https://github.com/UNKNOWN",
-        github_id: null,
-      };
-      const baselineTotal = baselineTotals.get(key) ?? 0;
-      const currentAdjustedTotal = latestAdjustedTotals.get(key) ?? 0;
-      const baselineAdjustedTotal = baselineAdjustedTotals.get(key) ?? 0;
-      const existing = authorWindowStats.get(meta.author) ?? {
-        author: meta.author,
-        author_alias: meta.author_alias,
-        attribution_link: meta.attribution_link,
+    for (const entry of authorCreditEntries) {
+      const currentTotal = entry.currentTotal;
+      const baselineTotal = entry.monotonicAt(baseline.file);
+      const currentAdjustedTotal = entry.currentAdjusted;
+      const baselineAdjustedTotal = entry.adjustedAt(baseline.file);
+      const existing = authorWindowStats.get(entry.person.author) ?? {
+        author: entry.person.author,
+        author_alias: entry.person.author_alias,
+        attribution_link: entry.person.attribution_link,
         asset_count: 0,
         map_count: 0,
         mod_count: 0,
@@ -547,15 +715,15 @@ export function runGenerateAnalyticsCli(
         baseline_snapshot: baseline.file,
       };
       existing.asset_count += 1;
-      if (listingType === "maps") existing.map_count += 1;
-      if (listingType === "mods") existing.mod_count += 1;
+      if (entry.listingType === "maps") existing.map_count += 1;
+      if (entry.listingType === "mods") existing.mod_count += 1;
       existing.download_change += currentTotal - baselineTotal;
       existing.adjusted_download_change += currentAdjustedTotal - baselineAdjustedTotal;
       existing.current_total += currentTotal;
       existing.adjusted_current_total += currentAdjustedTotal;
       existing.baseline_total += baselineTotal;
       existing.adjusted_baseline_total += baselineAdjustedTotal;
-      authorWindowStats.set(meta.author, existing);
+      authorWindowStats.set(entry.person.author, existing);
     }
 
     const rows = [...authorWindowStats.values()]
@@ -577,12 +745,12 @@ export function runGenerateAnalyticsCli(
     .slice(0, topAuthors ?? authorStats.size)
     .map((row, index) => ({ rank: index + 1, ...row }));
 
-  const authorRowsByTotalDownloads: AuthorTotalDownloadsRow[] = [...authorStats.values()]
+  const authorRowsByTotalDownloads: AuthorTotalDownloadsRow[] = [...creditedAuthorStats.values()]
     .sort((a, b) =>
       b.total_downloads - a.total_downloads
       || b.asset_count - a.asset_count
       || a.author.localeCompare(b.author))
-    .slice(0, topAuthors ?? authorStats.size)
+    .slice(0, topAuthors ?? creditedAuthorStats.size)
     .map((row, index) => ({
       rank: index + 1,
       author: row.author,
@@ -609,12 +777,42 @@ export function runGenerateAnalyticsCli(
     listingMeta,
     listingProjectByKey,
   );
-  const authorByDayRows = buildAuthorByDayRows(
-    snapshotDates,
-    latestTotals,
-    filteredDailyDeltasBySnapshot,
-    listingMeta,
-  );
+  const authorByDayRows = buildAuthorByDayRows(snapshotDates, authorCreditEntries);
+
+  // Per-version credited person for every version in the current downloads.json
+  // data (test listings excluded, like every other analytics artifact). Lets
+  // consumers (website author pages) derive credited per-author totals without
+  // recomputing caretaker windows.
+  const listingVersionCreditRows: ListingVersionCreditRow[] = [];
+  for (const listingType of ["maps", "mods"] as const) {
+    const downloadsPath = join(resolvedRepoRoot, listingType, "downloads.json");
+    if (!existsSync(downloadsPath)) continue;
+    let downloadsByListing: Record<string, Record<string, unknown>>;
+    try {
+      downloadsByListing = readJsonFile<Record<string, Record<string, unknown>>>(downloadsPath);
+    } catch {
+      continue;
+    }
+    for (const [id, versions] of Object.entries(downloadsByListing)) {
+      if (!versions || typeof versions !== "object") continue;
+      if (isTestListing(resolvedRepoRoot, listingType, id)) continue;
+      const key: ListingKey = `${listingType}:${id}`;
+      const authorId = (listingMeta.get(key)
+        ?? loadManifestMeta(resolvedRepoRoot, listingType, id, authorAliases)).author;
+      for (const version of Object.keys(versions)) {
+        listingVersionCreditRows.push({
+          listing_type: toListingLabel(listingType),
+          listing_id: id,
+          version,
+          credited_author_id: creditResolver.resolveAuthorId(listingType, id, version, authorId),
+        });
+      }
+    }
+  }
+  listingVersionCreditRows.sort((a, b) =>
+    a.listing_type.localeCompare(b.listing_type)
+    || a.listing_id.localeCompare(b.listing_id)
+    || compareStableSemverAsc(a.version, b.version));
   const assetsByDayRows = buildAssetsByDayRows(
     snapshotDates,
     filteredDailyDeltasBySnapshot,
@@ -745,6 +943,7 @@ export function runGenerateAnalyticsCli(
       "mod_count",
       "total_downloads",
       "adjusted_total_downloads",
+      "caretaken_asset_count",
     ],
     authorRowsByAssetCount,
   );
@@ -816,6 +1015,17 @@ export function runGenerateAnalyticsCli(
       "project_name",
     ],
     listingProjectRows,
+  );
+
+  writeCsv<ListingVersionCreditRow>(
+    join(analyticsDir, "listing_version_credits.csv"),
+    [
+      "listing_type",
+      "listing_id",
+      "version",
+      "credited_author_id",
+    ],
+    listingVersionCreditRows,
   );
 
   writeCsv<DailySeriesRow>(

--- a/scripts/lib/analytics/by-day.ts
+++ b/scripts/lib/analytics/by-day.ts
@@ -1,6 +1,7 @@
 import { toListingLabel } from "./listing-meta.js";
 import type {
   AssetByDayRow,
+  AuthorCreditEntry,
   DailySeriesRow,
   ListingKey,
   ListingMeta,
@@ -160,41 +161,34 @@ export function buildProjectByDayRows(
     || String(a.project_key).localeCompare(String(b.project_key)));
 }
 
+// Author-by-day rolls up per CREDITED person (caretaker crediting): each credit
+// entry contributes its totals/deltas to the person it is credited to. For
+// listings without caretakers this is exactly the old listing-author rollup.
 export function buildAuthorByDayRows(
   snapshotDates: string[],
-  latestTotals: ListingTotals,
-  dailyDeltasBySnapshot: Map<string, ListingTotals>,
-  listingMeta: Map<ListingKey, ListingMeta>,
+  creditEntries: readonly AuthorCreditEntry[],
 ): DailySeriesRow[] {
   const authorRows = new Map<string, DailySeriesRow>();
 
-  for (const [key, totalDownloads] of latestTotals.entries()) {
-    const [listingType] = key.split(":") as ["maps" | "mods", string];
-    const meta = listingMeta.get(key) ?? {
-      name: "",
-      author: "UNKNOWN",
-      author_alias: "UNKNOWN",
-      attribution_link: "https://github.com/UNKNOWN",
-      github_id: null,
-    };
-    const existing = authorRows.get(meta.author) ?? {
-      author: meta.author,
-      author_alias: meta.author_alias,
-      attribution_link: meta.attribution_link,
+  for (const entry of creditEntries) {
+    const existing = authorRows.get(entry.person.author) ?? {
+      author: entry.person.author,
+      author_alias: entry.person.author_alias,
+      attribution_link: entry.person.attribution_link,
       asset_count: 0,
       map_count: 0,
       mod_count: 0,
       total_downloads: 0,
     };
     existing.asset_count = Number(existing.asset_count) + 1;
-    if (listingType === "maps") existing.map_count = Number(existing.map_count) + 1;
-    if (listingType === "mods") existing.mod_count = Number(existing.mod_count) + 1;
-    existing.total_downloads = Number(existing.total_downloads) + totalDownloads;
+    if (entry.listingType === "maps") existing.map_count = Number(existing.map_count) + 1;
+    if (entry.listingType === "mods") existing.mod_count = Number(existing.mod_count) + 1;
+    existing.total_downloads = Number(existing.total_downloads) + entry.currentTotal;
     for (const snapshotDate of snapshotDates) {
       existing[snapshotDate] = Number(existing[snapshotDate] ?? 0)
-        + (dailyDeltasBySnapshot.get(`snapshot_${snapshotDate}.json`)?.get(key) ?? 0);
+        + entry.deltaAt(`snapshot_${snapshotDate}.json`);
     }
-    authorRows.set(meta.author, existing);
+    authorRows.set(entry.person.author, existing);
   }
 
   return [...authorRows.values()].sort((a, b) =>

--- a/scripts/lib/analytics/credited-person.ts
+++ b/scripts/lib/analytics/credited-person.ts
@@ -1,0 +1,250 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { readJsonFile, isObject } from "../json-utils.js";
+import { resolveAuthorPresentation, type AuthorAliasIndex } from "../author-aliases.js";
+
+// Download CREDITING (analytics layer only): a version's downloads are credited
+// to the caretaker whose [since, until) window contains the version's
+// released_at (ISO 8601, from the current <type>/integrity.json:
+// listings[id].versions[version].released_at). `since` is inclusive, `until`
+// exclusive. No covering window, no released_at, or an unresolvable caretaker
+// github_id -> credited to the listing AUTHOR. Manifests, downloads.json and
+// the attribution ledger are untouched; only the authors_* CSVs and the
+// listing_version_credits.csv artifact apply this rule.
+
+export interface CaretakerWindowLike {
+  github_id: number;
+  since: string;
+  until?: string;
+}
+
+export interface CreditedPersonPresentation {
+  author: string;
+  author_alias: string;
+  attribution_link: string;
+}
+
+/**
+ * Finds the caretaker window covering `releasedAt` and returns its github_id,
+ * or null when no window covers it. `since` is inclusive, `until` exclusive;
+ * a missing `until` means the window is still open. Windows with unparseable
+ * dates never match. When windows overlap (validation prevents this), the last
+ * matching entry wins, mirroring getActiveCaretaker's last-entry-is-active rule.
+ */
+export function findCoveringCaretakerGithubId(
+  caretakers: readonly CaretakerWindowLike[] | undefined,
+  releasedAt: string | undefined,
+): number | null {
+  if (!caretakers || caretakers.length === 0) return null;
+  if (typeof releasedAt !== "string") return null;
+  const releasedMs = Date.parse(releasedAt);
+  if (!Number.isFinite(releasedMs)) return null;
+
+  for (let index = caretakers.length - 1; index >= 0; index -= 1) {
+    const window = caretakers[index]!;
+    const sinceMs = Date.parse(window.since);
+    if (!Number.isFinite(sinceMs) || releasedMs < sinceMs) continue;
+    if (window.until !== undefined) {
+      const untilMs = Date.parse(window.until);
+      if (!Number.isFinite(untilMs) || releasedMs >= untilMs) continue;
+    }
+    return window.github_id;
+  }
+  return null;
+}
+
+/**
+ * Pure crediting rule: resolves the person credited with a version's downloads.
+ * Returns the caretaker's author_id when a [since, until) window covers
+ * `releasedAt` and `resolveGithubId` can map the caretaker's github_id to an
+ * author_id; in every other case (no caretakers, no covering window, missing
+ * released_at, unresolvable github_id) returns `authorId` unchanged.
+ */
+export function resolveCreditedPerson(
+  caretakers: readonly CaretakerWindowLike[] | undefined,
+  releasedAt: string | undefined,
+  authorId: string,
+  resolveGithubId: (githubId: number) => string | null,
+): string {
+  const githubId = findCoveringCaretakerGithubId(caretakers, releasedAt);
+  if (githubId === null) return authorId;
+  return resolveGithubId(githubId) ?? authorId;
+}
+
+export interface VersionCreditResolver {
+  /** Caretaker windows declared on the listing's manifest ([] when none). */
+  getCaretakers(listingType: "maps" | "mods", listingId: string): readonly CaretakerWindowLike[];
+  /** True when the listing's manifest carries at least one caretaker window. */
+  hasCaretakers(listingType: "maps" | "mods", listingId: string): boolean;
+  /**
+   * Credited person's presentation for one version. Falls back to
+   * `authorFallback` (the listing author's presentation) per the crediting rule.
+   */
+  resolvePresentation(
+    listingType: "maps" | "mods",
+    listingId: string,
+    version: string,
+    authorFallback: CreditedPersonPresentation,
+  ): CreditedPersonPresentation;
+  /** Credited author_id for one version (author fallback = `authorId`). */
+  resolveAuthorId(
+    listingType: "maps" | "mods",
+    listingId: string,
+    version: string,
+    authorId: string,
+  ): string;
+  /**
+   * Presentation of the ACTIVE caretaker (entry without `until`), or null when
+   * the listing has none or the github_id does not resolve via authors/index.json.
+   */
+  activeCaretaker(
+    listingType: "maps" | "mods",
+    listingId: string,
+  ): CreditedPersonPresentation | null;
+}
+
+function parseCaretakerWindows(value: unknown): CaretakerWindowLike[] {
+  if (!Array.isArray(value)) return [];
+  const windows: CaretakerWindowLike[] = [];
+  for (const entry of value) {
+    if (!isObject(entry)) continue;
+    if (typeof entry.github_id !== "number" || !Number.isFinite(entry.github_id)) continue;
+    if (typeof entry.since !== "string") continue;
+    windows.push({
+      github_id: entry.github_id,
+      since: entry.since,
+      ...(typeof entry.until === "string" ? { until: entry.until } : {}),
+    });
+  }
+  return windows;
+}
+
+interface IntegrityFileShape {
+  listings?: Record<string, { versions?: Record<string, { released_at?: unknown }> }>;
+}
+
+function loadReleasedAtByListing(
+  repoRoot: string,
+  listingType: "maps" | "mods",
+): Map<string, Map<string, string>> {
+  const byListing = new Map<string, Map<string, string>>();
+  const integrityPath = join(repoRoot, listingType, "integrity.json");
+  if (!existsSync(integrityPath)) return byListing;
+  let integrity: IntegrityFileShape;
+  try {
+    integrity = readJsonFile<IntegrityFileShape>(integrityPath);
+  } catch {
+    return byListing;
+  }
+  if (!isObject(integrity.listings)) return byListing;
+  for (const [listingId, listing] of Object.entries(integrity.listings)) {
+    if (!isObject(listing) || !isObject(listing.versions)) continue;
+    const byVersion = new Map<string, string>();
+    for (const [version, entry] of Object.entries(listing.versions)) {
+      if (!isObject(entry)) continue;
+      if (typeof entry.released_at === "string") {
+        byVersion.set(version, entry.released_at);
+      }
+    }
+    byListing.set(listingId, byVersion);
+  }
+  return byListing;
+}
+
+/**
+ * Loader wrapper around resolveCreditedPerson: reads caretaker windows from
+ * each listing's manifest, released_at timestamps from the current
+ * <type>/integrity.json, and resolves caretaker github_ids to people via
+ * authors/index.json (entry.github_id -> author_id).
+ */
+export function buildVersionCreditResolver(options: {
+  repoRoot: string;
+  authorAliases: AuthorAliasIndex;
+}): VersionCreditResolver {
+  const { repoRoot, authorAliases } = options;
+  const caretakersCache = new Map<string, CaretakerWindowLike[]>();
+  const releasedAtCache = new Map<"maps" | "mods", Map<string, Map<string, string>>>();
+  const authorIdByGithubId = new Map<number, string | null>();
+  const presentationByGithubId = new Map<number, CreditedPersonPresentation | null>();
+
+  const getCaretakers = (
+    listingType: "maps" | "mods",
+    listingId: string,
+  ): CaretakerWindowLike[] => {
+    const cacheKey = `${listingType}:${listingId}`;
+    const cached = caretakersCache.get(cacheKey);
+    if (cached) return cached;
+    let windows: CaretakerWindowLike[] = [];
+    try {
+      const manifest = readJsonFile<Record<string, unknown>>(
+        join(repoRoot, listingType, listingId, "manifest.json"),
+      );
+      windows = parseCaretakerWindows(manifest.caretakers);
+    } catch {
+      // Missing/unreadable manifest -> no caretakers; credit stays with the author.
+    }
+    caretakersCache.set(cacheKey, windows);
+    return windows;
+  };
+
+  const getReleasedAt = (
+    listingType: "maps" | "mods",
+    listingId: string,
+    version: string,
+  ): string | undefined => {
+    let byListing = releasedAtCache.get(listingType);
+    if (!byListing) {
+      byListing = loadReleasedAtByListing(repoRoot, listingType);
+      releasedAtCache.set(listingType, byListing);
+    }
+    return byListing.get(listingId)?.get(version);
+  };
+
+  const resolveGithubId = (githubId: number): string | null => {
+    const cached = authorIdByGithubId.get(githubId);
+    if (cached !== undefined) return cached;
+    const entry = authorAliases.authors.find((candidate) => candidate.github_id === githubId);
+    const authorId = entry?.author_id ?? null;
+    authorIdByGithubId.set(githubId, authorId);
+    return authorId;
+  };
+
+  const presentationForGithubId = (githubId: number): CreditedPersonPresentation | null => {
+    const cached = presentationByGithubId.get(githubId);
+    if (cached !== undefined) return cached;
+    const authorId = resolveGithubId(githubId);
+    const presentation = authorId === null
+      ? null
+      : resolveAuthorPresentation(authorId, githubId, authorAliases);
+    presentationByGithubId.set(githubId, presentation);
+    return presentation;
+  };
+
+  return {
+    getCaretakers,
+    hasCaretakers: (listingType, listingId) => getCaretakers(listingType, listingId).length > 0,
+    resolvePresentation: (listingType, listingId, version, authorFallback) => {
+      const caretakers = getCaretakers(listingType, listingId);
+      if (caretakers.length === 0) return authorFallback;
+      const githubId = findCoveringCaretakerGithubId(
+        caretakers,
+        getReleasedAt(listingType, listingId, version),
+      );
+      if (githubId === null) return authorFallback;
+      return presentationForGithubId(githubId) ?? authorFallback;
+    },
+    resolveAuthorId: (listingType, listingId, version, authorId) => resolveCreditedPerson(
+      getCaretakers(listingType, listingId),
+      getReleasedAt(listingType, listingId, version),
+      authorId,
+      resolveGithubId,
+    ),
+    activeCaretaker: (listingType, listingId) => {
+      const caretakers = getCaretakers(listingType, listingId);
+      if (caretakers.length === 0) return null;
+      const last = caretakers[caretakers.length - 1]!;
+      if (last.until !== undefined) return null;
+      return presentationForGithubId(last.github_id);
+    },
+  };
+}

--- a/scripts/lib/analytics/snapshots.ts
+++ b/scripts/lib/analytics/snapshots.ts
@@ -105,6 +105,86 @@ export function buildListingVersionsBySnapshot(
   return bySnapshot;
 }
 
+// Per-(listing, version) totals for the given listing keys, keyed
+// `${listingKey}@@${version}`. Mirrors toListingTotals at version grain; used to
+// split a listing's downloads between credited persons (caretaker crediting).
+export function toListingVersionTotals(
+  snapshot: SnapshotData,
+  listingKeys: ReadonlySet<ListingKey>,
+): Map<string, number> {
+  const totals = new Map<string, number>();
+  for (const listingType of ["maps", "mods"] as const) {
+    const downloads = snapshot?.[listingType]?.downloads;
+    if (!downloads || typeof downloads !== "object") continue;
+    for (const [id, versions] of Object.entries(downloads)) {
+      const listingKey: ListingKey = `${listingType}:${id}`;
+      if (!listingKeys.has(listingKey)) continue;
+      if (!versions || typeof versions !== "object") continue;
+      for (const [version, count] of Object.entries(versions)) {
+        totals.set(`${listingKey}@@${version}`, isFiniteNumber(count) ? count : 0);
+      }
+    }
+  }
+  return totals;
+}
+
+export interface VersionGrainSnapshotTotals {
+  // Raw per-version counts straight from each snapshot (the "adjusted" series).
+  adjustedBySnapshot: Map<string, Map<string, number>>;
+  // Running-max per version key; same clamping rule as buildMonotonicSnapshotTotals.
+  monotonicBySnapshot: Map<string, Map<string, number>>;
+  // Clamped day-over-day deltas of the monotonic series; same rule as
+  // buildDailyDeltaSnapshotTotals.
+  dailyDeltasBySnapshot: Map<string, Map<string, number>>;
+}
+
+// Applies the listing-grain monotonic/delta machinery at (listing, version)
+// grain, but only for the given listing keys (those whose versions are credited
+// to different persons). Skipped entirely when no listing has caretakers.
+export function buildVersionGrainSnapshotTotals(
+  snapshots: SnapshotEntry[],
+  historyDir: string,
+  listingKeys: ReadonlySet<ListingKey>,
+): VersionGrainSnapshotTotals {
+  const adjustedBySnapshot = new Map<string, Map<string, number>>();
+  const monotonicBySnapshot = new Map<string, Map<string, number>>();
+  const dailyDeltasBySnapshot = new Map<string, Map<string, number>>();
+  const runningMax = new Map<string, number>();
+  let previousMonotonic = new Map<string, number>();
+
+  for (const snapshot of snapshots) {
+    const snapshotData = readJsonFile<SnapshotData>(join(historyDir, snapshot.file));
+    const adjustedTotals = toListingVersionTotals(snapshotData, listingKeys);
+    adjustedBySnapshot.set(snapshot.file, adjustedTotals);
+
+    const snapshotMonotonic = new Map<string, number>();
+    const keys = new Set<string>([...runningMax.keys(), ...adjustedTotals.keys()]);
+    for (const key of keys) {
+      const previousMax = runningMax.get(key) ?? 0;
+      const adjustedTotal = adjustedTotals.get(key) ?? 0;
+      const nextMax = Math.max(previousMax, adjustedTotal);
+      if (nextMax > 0 || adjustedTotals.has(key) || runningMax.has(key)) {
+        runningMax.set(key, nextMax);
+        snapshotMonotonic.set(key, nextMax);
+      }
+    }
+    monotonicBySnapshot.set(snapshot.file, snapshotMonotonic);
+
+    const deltaKeys = new Set<string>([...previousMonotonic.keys(), ...snapshotMonotonic.keys()]);
+    const deltaTotals = new Map<string, number>();
+    for (const key of deltaKeys) {
+      const delta = Math.max(0, (snapshotMonotonic.get(key) ?? 0) - (previousMonotonic.get(key) ?? 0));
+      if (delta > 0 || snapshotMonotonic.has(key) || previousMonotonic.has(key)) {
+        deltaTotals.set(key, delta);
+      }
+    }
+    dailyDeltasBySnapshot.set(snapshot.file, deltaTotals);
+    previousMonotonic = snapshotMonotonic;
+  }
+
+  return { adjustedBySnapshot, monotonicBySnapshot, dailyDeltasBySnapshot };
+}
+
 export function buildMonotonicSnapshotTotals(
   snapshots: SnapshotEntry[],
   historyDir: string,

--- a/scripts/lib/analytics/types.ts
+++ b/scripts/lib/analytics/types.ts
@@ -96,3 +96,24 @@ export interface AssetByDayRow {
 
 export type DailySeriesRow = Record<string, string | number>;
 export type ListingKey = `${"maps" | "mods"}:${string}`;
+
+// One unit of download credit for the author aggregations: a listing's totals
+// credited to a single person. Listings without caretakers produce exactly one
+// entry (the author, listing-grain totals, today's behavior); listings whose
+// versions are credited to different persons produce one entry per person, with
+// totals rolled up from (listing, version) grain.
+export interface AuthorCreditEntry {
+  listingType: "maps" | "mods";
+  person: {
+    author: string;
+    author_alias: string;
+    attribution_link: string;
+  };
+  // Monotonic total at the latest snapshot.
+  currentTotal: number;
+  // Adjusted (raw snapshot) total at the latest snapshot.
+  currentAdjusted: number;
+  monotonicAt(snapshotFile: string): number;
+  adjustedAt(snapshotFile: string): number;
+  deltaAt(snapshotFile: string): number;
+}

--- a/scripts/tests/analytics-credits.unit.test.ts
+++ b/scripts/tests/analytics-credits.unit.test.ts
@@ -1,0 +1,250 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runGenerateAnalyticsCli } from "../lib/analytics-core.js";
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+function readAnalyticsCsv(repoRoot: string, fileName: string): string {
+  return readFileSync(join(repoRoot, "analytics", fileName), "utf-8");
+}
+
+const AUTHORS_INDEX = {
+  schema_version: 1,
+  authors: [
+    { github_id: 100, author_id: "bquelhas", author_alias: "bquelhas", attribution_method: "github" },
+    { github_id: 200, author_id: "capitao", author_alias: "Miguel Sousa", attribution_method: "github" },
+  ],
+};
+
+function writePortoManifest(repoRoot: string, caretakers: unknown): void {
+  writeJson(join(repoRoot, "maps", "porto", "manifest.json"), {
+    schema_version: 1,
+    id: "porto",
+    name: "Porto",
+    author: "bquelhas",
+    github_id: 100,
+    source: "https://github.com/example/porto",
+    city_code: "OPO",
+    country: "PT",
+    population: 0,
+    population_count: 0,
+    points_count: 0,
+    collaborators: [200],
+    ...(caretakers === undefined ? {} : { caretakers }),
+  });
+}
+
+function writePortoFixture(repoRoot: string, caretakers: unknown): void {
+  mkdirSync(join(repoRoot, "history"), { recursive: true });
+  mkdirSync(join(repoRoot, "maps", "porto"), { recursive: true });
+  mkdirSync(join(repoRoot, "mods", "test-mod"), { recursive: true });
+  mkdirSync(join(repoRoot, "authors"), { recursive: true });
+
+  writeJson(join(repoRoot, "maps", "index.json"), { schema_version: 1, maps: ["porto"] });
+  writePortoManifest(repoRoot, caretakers);
+  writeJson(join(repoRoot, "maps", "integrity.json"), {
+    schema_version: 1,
+    generated_at: "2026-07-31T00:00:00Z",
+    listings: {
+      porto: {
+        versions: {
+          "v1.0.0": { released_at: "2026-05-01T00:00:00Z" },
+          "v2.0.0": { released_at: "2026-07-01T00:00:00Z" },
+        },
+      },
+    },
+  });
+  writeJson(join(repoRoot, "maps", "downloads.json"), {
+    porto: { "v1.0.0": 30, "v2.0.0": 25 },
+  });
+  // Test listings must not appear in listing_version_credits.csv.
+  writeJson(join(repoRoot, "mods", "test-mod", "manifest.json"), {
+    schema_version: 1,
+    id: "test-mod",
+    name: "Test Mod",
+    author: "tester",
+    github_id: 3,
+    is_test: true,
+  });
+  writeJson(join(repoRoot, "mods", "downloads.json"), {
+    "test-mod": { "v1.0.0": 5 },
+  });
+  writeJson(join(repoRoot, "authors", "index.json"), AUTHORS_INDEX);
+
+  writeJson(join(repoRoot, "history", "snapshot_2026_07_30.json"), {
+    schema_version: 2,
+    snapshot_date: "2026_07_30",
+    generated_at: "2026-07-30T00:00:00.000Z",
+    maps: { downloads: { porto: { "v1.0.0": 28, "v2.0.0": 20 } } },
+    mods: { downloads: {} },
+  });
+  writeJson(join(repoRoot, "history", "snapshot_2026_07_31.json"), {
+    schema_version: 2,
+    snapshot_date: "2026_07_31",
+    generated_at: "2026-07-31T00:00:00.000Z",
+    maps: { downloads: { porto: { "v1.0.0": 30, "v2.0.0": 25 } } },
+    mods: { downloads: {} },
+  });
+}
+
+test("analytics splits a listing's credit at the caretaker window (porto invariant)", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "railyard-credits-porto-"));
+  try {
+    // v1 released before the caretaker's `since`, v2 after it.
+    writePortoFixture(repoRoot, [{ github_id: 200, since: "2026-06-01T00:00:00Z" }]);
+
+    runGenerateAnalyticsCli([], repoRoot);
+
+    assert.equal(
+      readAnalyticsCsv(repoRoot, "listing_version_credits.csv"),
+      [
+        "listing_type,listing_id,version,credited_author_id",
+        "map,porto,v1.0.0,bquelhas",
+        "map,porto,v2.0.0,capitao",
+        "",
+      ].join("\n"),
+    );
+
+    assert.equal(
+      readAnalyticsCsv(repoRoot, "authors_by_total_downloads.csv"),
+      [
+        "rank,author,author_alias,attribution_link,total_downloads,adjusted_total_downloads,asset_count,map_count,mod_count",
+        "1,bquelhas,bquelhas,https://github.com/bquelhas,30,30,1,1,0",
+        "2,capitao,Miguel Sousa,https://github.com/capitao,25,25,1,1,0",
+        "",
+      ].join("\n"),
+    );
+
+    // Authorship-based columns keep the FULL listing totals for the author;
+    // the caretaker only appears through the appended caretaken_asset_count.
+    assert.equal(
+      readAnalyticsCsv(repoRoot, "authors_by_asset_count.csv"),
+      [
+        "rank,author,author_alias,attribution_link,asset_count,map_count,mod_count,total_downloads,adjusted_total_downloads,caretaken_asset_count",
+        "1,bquelhas,bquelhas,https://github.com/bquelhas,1,1,0,55,55,0",
+        "2,capitao,Miguel Sousa,https://github.com/capitao,0,0,0,0,0,1",
+        "",
+      ].join("\n"),
+    );
+
+    assert.equal(
+      readAnalyticsCsv(repoRoot, "authors_by_day.csv"),
+      [
+        "author,author_alias,attribution_link,asset_count,map_count,mod_count,total_downloads,2026_07_30,2026_07_31",
+        "bquelhas,bquelhas,https://github.com/bquelhas,1,1,0,30,28,2",
+        "capitao,Miguel Sousa,https://github.com/capitao,1,1,0,25,20,5",
+        "",
+      ].join("\n"),
+    );
+
+    assert.equal(
+      readAnalyticsCsv(repoRoot, "authors_last_1d.csv"),
+      [
+        "rank,author,author_alias,attribution_link,asset_count,map_count,mod_count,download_change,adjusted_download_change,current_total,adjusted_current_total,baseline_total,adjusted_baseline_total,latest_snapshot,baseline_snapshot",
+        "1,capitao,Miguel Sousa,https://github.com/capitao,1,1,0,5,5,25,25,20,20,snapshot_2026_07_31.json,snapshot_2026_07_30.json",
+        "2,bquelhas,bquelhas,https://github.com/bquelhas,1,1,0,2,2,30,30,28,28,snapshot_2026_07_31.json,snapshot_2026_07_30.json",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("analytics credits every version to a caretaker-since-epoch (devenperez invariant)", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "railyard-credits-deven-"));
+  try {
+    writePortoFixture(repoRoot, [{ github_id: 200, since: "1970-01-01T00:00:00Z" }]);
+
+    runGenerateAnalyticsCli([], repoRoot);
+
+    assert.equal(
+      readAnalyticsCsv(repoRoot, "listing_version_credits.csv"),
+      [
+        "listing_type,listing_id,version,credited_author_id",
+        "map,porto,v1.0.0,capitao",
+        "map,porto,v2.0.0,capitao",
+        "",
+      ].join("\n"),
+    );
+
+    // All download credit moves to the caretaker (listing-grain totals intact);
+    // authorship (asset counts) stays with the author.
+    assert.equal(
+      readAnalyticsCsv(repoRoot, "authors_by_total_downloads.csv"),
+      [
+        "rank,author,author_alias,attribution_link,total_downloads,adjusted_total_downloads,asset_count,map_count,mod_count",
+        "1,capitao,Miguel Sousa,https://github.com/capitao,55,55,1,1,0",
+        "",
+      ].join("\n"),
+    );
+    assert.equal(
+      readAnalyticsCsv(repoRoot, "authors_by_asset_count.csv"),
+      [
+        "rank,author,author_alias,attribution_link,asset_count,map_count,mod_count,total_downloads,adjusted_total_downloads,caretaken_asset_count",
+        "1,bquelhas,bquelhas,https://github.com/bquelhas,1,1,0,55,55,0",
+        "2,capitao,Miguel Sousa,https://github.com/capitao,0,0,0,0,0,1",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("analytics output is unchanged for listings without caretakers", () => {
+  const withoutCaretakers = mkdtempSync(join(tmpdir(), "railyard-credits-none-"));
+  const withClosedWindow = mkdtempSync(join(tmpdir(), "railyard-credits-closed-"));
+  try {
+    writePortoFixture(withoutCaretakers, undefined);
+    runGenerateAnalyticsCli([], withoutCaretakers);
+
+    // A fully closed caretaker window that never covers a release behaves
+    // identically to no caretakers at all (credit-wise), and the active
+    // caretaker count stays zero.
+    writePortoFixture(withClosedWindow, [
+      { github_id: 200, since: "2020-01-01T00:00:00Z", until: "2020-02-01T00:00:00Z" },
+    ]);
+    runGenerateAnalyticsCli([], withClosedWindow);
+
+    for (const fileName of [
+      "authors_by_total_downloads.csv",
+      "authors_by_asset_count.csv",
+      "authors_by_day.csv",
+      "authors_last_1d.csv",
+      "authors_last_30d.csv",
+    ]) {
+      assert.equal(
+        readAnalyticsCsv(withClosedWindow, fileName),
+        readAnalyticsCsv(withoutCaretakers, fileName),
+        `expected ${fileName} to match the no-caretakers output`,
+      );
+    }
+
+    assert.equal(
+      readAnalyticsCsv(withoutCaretakers, "authors_by_total_downloads.csv"),
+      [
+        "rank,author,author_alias,attribution_link,total_downloads,adjusted_total_downloads,asset_count,map_count,mod_count",
+        "1,bquelhas,bquelhas,https://github.com/bquelhas,55,55,1,1,0",
+        "",
+      ].join("\n"),
+    );
+    assert.equal(
+      readAnalyticsCsv(withoutCaretakers, "listing_version_credits.csv"),
+      [
+        "listing_type,listing_id,version,credited_author_id",
+        "map,porto,v1.0.0,bquelhas",
+        "map,porto,v2.0.0,bquelhas",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    rmSync(withoutCaretakers, { recursive: true, force: true });
+    rmSync(withClosedWindow, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/credited-person.unit.test.ts
+++ b/scripts/tests/credited-person.unit.test.ts
@@ -1,0 +1,220 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadAuthorAliasIndex } from "../lib/author-aliases.js";
+import {
+  buildVersionCreditResolver,
+  findCoveringCaretakerGithubId,
+  resolveCreditedPerson,
+  type CaretakerWindowLike,
+} from "../lib/analytics/credited-person.js";
+
+const AUTHOR = "listing-author";
+const CARETAKER_ID = 200;
+const resolveGithubId = (githubId: number): string | null =>
+  (githubId === CARETAKER_ID ? "caretaker" : null);
+
+const WINDOW: CaretakerWindowLike = {
+  github_id: CARETAKER_ID,
+  since: "2026-06-01T00:00:00Z",
+  until: "2026-07-01T00:00:00Z",
+};
+
+test("resolveCreditedPerson credits the author when there are no caretakers", () => {
+  assert.equal(resolveCreditedPerson(undefined, "2026-06-15T00:00:00Z", AUTHOR, resolveGithubId), AUTHOR);
+  assert.equal(resolveCreditedPerson([], "2026-06-15T00:00:00Z", AUTHOR, resolveGithubId), AUTHOR);
+});
+
+test("resolveCreditedPerson credits the caretaker whose window covers released_at", () => {
+  assert.equal(
+    resolveCreditedPerson([WINDOW], "2026-06-15T00:00:00Z", AUTHOR, resolveGithubId),
+    "caretaker",
+  );
+});
+
+test("resolveCreditedPerson credits the author when released_at is before since", () => {
+  assert.equal(
+    resolveCreditedPerson([WINDOW], "2026-05-31T23:59:59Z", AUTHOR, resolveGithubId),
+    AUTHOR,
+  );
+});
+
+test("resolveCreditedPerson credits the author when released_at is after until", () => {
+  assert.equal(
+    resolveCreditedPerson([WINDOW], "2026-07-02T00:00:00Z", AUTHOR, resolveGithubId),
+    AUTHOR,
+  );
+});
+
+test("resolveCreditedPerson treats since as inclusive", () => {
+  assert.equal(
+    resolveCreditedPerson([WINDOW], "2026-06-01T00:00:00Z", AUTHOR, resolveGithubId),
+    "caretaker",
+  );
+});
+
+test("resolveCreditedPerson treats until as exclusive", () => {
+  assert.equal(
+    resolveCreditedPerson([WINDOW], "2026-07-01T00:00:00Z", AUTHOR, resolveGithubId),
+    AUTHOR,
+  );
+});
+
+test("resolveCreditedPerson: caretaker-since-epoch covers every version (devenperez invariant)", () => {
+  const sinceEpoch: CaretakerWindowLike = { github_id: CARETAKER_ID, since: "1970-01-01T00:00:00Z" };
+  for (const releasedAt of ["1970-01-01T00:00:00Z", "2020-01-01T00:00:00Z", "2026-07-31T23:59:59Z"]) {
+    assert.equal(resolveCreditedPerson([sinceEpoch], releasedAt, AUTHOR, resolveGithubId), "caretaker");
+  }
+});
+
+test("resolveCreditedPerson falls back to the author for an unresolvable github_id", () => {
+  const unknownCaretaker: CaretakerWindowLike = { github_id: 999, since: "1970-01-01T00:00:00Z" };
+  assert.equal(
+    resolveCreditedPerson([unknownCaretaker], "2026-06-15T00:00:00Z", AUTHOR, resolveGithubId),
+    AUTHOR,
+  );
+});
+
+test("resolveCreditedPerson credits the author when released_at is missing or unparseable", () => {
+  const active: CaretakerWindowLike = { github_id: CARETAKER_ID, since: "1970-01-01T00:00:00Z" };
+  assert.equal(resolveCreditedPerson([active], undefined, AUTHOR, resolveGithubId), AUTHOR);
+  assert.equal(resolveCreditedPerson([active], "not-a-date", AUTHOR, resolveGithubId), AUTHOR);
+});
+
+test("resolveCreditedPerson picks the window matching each version across a caretaker history", () => {
+  const history: CaretakerWindowLike[] = [
+    { github_id: 300, since: "2025-01-01T00:00:00Z", until: "2026-01-01T00:00:00Z" },
+    { github_id: CARETAKER_ID, since: "2026-01-01T00:00:00Z" },
+  ];
+  const resolveBoth = (githubId: number): string | null => (
+    githubId === CARETAKER_ID ? "caretaker" : githubId === 300 ? "predecessor" : null
+  );
+  assert.equal(resolveCreditedPerson(history, "2024-06-01T00:00:00Z", AUTHOR, resolveBoth), AUTHOR);
+  assert.equal(resolveCreditedPerson(history, "2025-06-01T00:00:00Z", AUTHOR, resolveBoth), "predecessor");
+  assert.equal(resolveCreditedPerson(history, "2026-06-01T00:00:00Z", AUTHOR, resolveBoth), "caretaker");
+});
+
+test("findCoveringCaretakerGithubId skips windows with unparseable dates", () => {
+  assert.equal(
+    findCoveringCaretakerGithubId(
+      [{ github_id: CARETAKER_ID, since: "garbage" }],
+      "2026-06-15T00:00:00Z",
+    ),
+    null,
+  );
+});
+
+// --- Loader wrapper (buildVersionCreditResolver) over a temp repo fixture ---
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+test("buildVersionCreditResolver resolves credits from manifests, integrity and authors index", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "railyard-credit-resolver-"));
+  try {
+    mkdirSync(join(repoRoot, "maps", "porto"), { recursive: true });
+    mkdirSync(join(repoRoot, "authors"), { recursive: true });
+    writeJson(join(repoRoot, "maps", "porto", "manifest.json"), {
+      schema_version: 1,
+      id: "porto",
+      name: "Porto",
+      author: "bquelhas",
+      github_id: 100,
+      collaborators: [200],
+      caretakers: [{ github_id: 200, since: "2026-06-01T00:00:00Z" }],
+    });
+    writeJson(join(repoRoot, "maps", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-07-31T00:00:00Z",
+      listings: {
+        porto: {
+          versions: {
+            "v1.0.0": { released_at: "2026-05-01T00:00:00Z" },
+            "v2.0.0": { released_at: "2026-07-01T00:00:00Z" },
+          },
+        },
+      },
+    });
+    writeJson(join(repoRoot, "authors", "index.json"), {
+      schema_version: 1,
+      authors: [
+        { github_id: 100, author_id: "bquelhas", author_alias: "bquelhas", attribution_method: "github" },
+        { github_id: 200, author_id: "capitao", author_alias: "Miguel Sousa", attribution_method: "github" },
+      ],
+    });
+
+    const resolver = buildVersionCreditResolver({
+      repoRoot,
+      authorAliases: loadAuthorAliasIndex(repoRoot),
+    });
+
+    assert.equal(resolver.hasCaretakers("maps", "porto"), true);
+    assert.equal(resolver.hasCaretakers("maps", "missing-listing"), false);
+    // v1 predates the caretaker window; v2 falls inside it (porto invariant).
+    assert.equal(resolver.resolveAuthorId("maps", "porto", "v1.0.0", "bquelhas"), "bquelhas");
+    assert.equal(resolver.resolveAuthorId("maps", "porto", "v2.0.0", "bquelhas"), "capitao");
+    // Version absent from integrity (no released_at) falls back to the author.
+    assert.equal(resolver.resolveAuthorId("maps", "porto", "v9.9.9", "bquelhas"), "bquelhas");
+    assert.deepEqual(
+      resolver.resolvePresentation("maps", "porto", "v2.0.0", {
+        author: "bquelhas",
+        author_alias: "bquelhas",
+        attribution_link: "https://github.com/bquelhas",
+      }),
+      {
+        author: "capitao",
+        author_alias: "Miguel Sousa",
+        attribution_link: "https://github.com/capitao",
+      },
+    );
+    assert.deepEqual(resolver.activeCaretaker("maps", "porto"), {
+      author: "capitao",
+      author_alias: "Miguel Sousa",
+      attribution_link: "https://github.com/capitao",
+    });
+    assert.equal(resolver.activeCaretaker("mods", "porto"), null);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildVersionCreditResolver falls back to the author for an unresolvable caretaker and closed windows", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "railyard-credit-resolver-fallback-"));
+  try {
+    mkdirSync(join(repoRoot, "mods", "sample-mod"), { recursive: true });
+    writeJson(join(repoRoot, "mods", "sample-mod", "manifest.json"), {
+      schema_version: 1,
+      id: "sample-mod",
+      name: "Sample Mod",
+      author: "modder",
+      github_id: 2,
+      caretakers: [
+        { github_id: 999, since: "1970-01-01T00:00:00Z", until: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    writeJson(join(repoRoot, "mods", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-07-31T00:00:00Z",
+      listings: {
+        "sample-mod": {
+          versions: { "v1.0.0": { released_at: "2025-06-01T00:00:00Z" } },
+        },
+      },
+    });
+
+    const resolver = buildVersionCreditResolver({
+      repoRoot,
+      authorAliases: { schema_version: 1, authors: [] },
+    });
+
+    // github_id 999 is not in authors/index.json -> author keeps the credit.
+    assert.equal(resolver.resolveAuthorId("mods", "sample-mod", "v1.0.0", "modder"), "modder");
+    // The only window is closed -> no active caretaker.
+    assert.equal(resolver.activeCaretaker("mods", "sample-mod"), null);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
PR C of the caretakers plan (#6608 schema, #6611 commands).

## The crediting rule
A version's downloads credit the caretaker whose `[since, until)` window contains the version's `released_at` (since-inclusive, until-exclusive; ISO strings straight from integrity.json); no covering window, missing released_at, or unresolvable caretaker github_id → the author. Implemented once as a pure `resolveCreditedPerson` + a caching loader (`lib/analytics/credited-person.ts`).

## Where credit changes (and where it provably doesn't)
- `authors_last_{1,3,7,14,30}d`, `authors_by_total_downloads`, `authors_by_day` now aggregate per credited person. **Hybrid seam**: listings whose versions all credit one person (every current listing, plus future caretaker-since-epoch ones — the deven invariant) keep today's listing-grain monotonic/delta arithmetic bit-for-bit; only genuinely split listings replay the same monotonic machinery at (listing, version) grain. This choice is what makes the regression bar provable — version-grain monotonic sums are NOT guaranteed to equal listing-grain totals under historical count drops (429 cascades).
- **Byte-identical regression check passed**: full analytics run before vs after — every CSV hash-identical except `authors_by_asset_count.csv`, which gains exactly one appended column, `caretaken_asset_count` (active windows only; author-grain columns untouched per Alex's call).
- New artifact `analytics/listing_version_credits.csv` (`listing_type,listing_id,version,credited_author_id`, test listings excluded, stable-semver ordering) for the website's author surfaces — picked up automatically by the existing `analytics/*.csv` workflow globs, so zero workflow edits.
- downloads.json / manifests / attribution ledger untouched — existing clients unaffected.

## Verification
16 new tests: 13 resolver boundary locks (incl. since-inclusive/until-exclusive edges, epoch window, unresolvable id) + 3 CLI-level fixture tests asserting the **porto invariant** (mid-history caretaker splits credit across all four outputs) and the **deven invariant** (credit moves fully, authorship counts stay). Fresh-build suite 299/299 (283 branch baseline + 16); tsc zero diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)