### PR TITLE
Caretaker migrations: devenperez fleet, porto handover, brussels cleanup

### DIFF
--- a/maps/brussels/manifest.json
+++ b/maps/brussels/manifest.json
@@ -6,7 +6,7 @@
   "github_id": 4420305,
   "description": "Full Brussels Capital Region with real Statbel population data for all 19 municipalities and 724 statistical sectors (~1.27M residents). Workplaces derived from ~23k OSM job locations. Includes ~318k OSM building footprints, complete road network, and Brussels Airport (EBBR) runways and taxiways. Build a metro beneath the capital of Europe.",
   "tags": [
-    "europe",
+    "west-europe",
     "airports"
   ],
   "gallery": [
@@ -41,8 +41,7 @@
     "rubric_version": 1,
     "provenance": "reviewed"
   },
-  "location": "europe",
-  "sub_location": "west-europe",
+  "location": "west-europe",
   "special_demand": [
     "airports"
   ],

--- a/maps/calgary/manifest.json
+++ b/maps/calgary/manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "id": "calgary",
   "name": "Calgary",
-  "author": "devenperez",
-  "github_id": 63876261,
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
   "description": "Custom map of Calgary and its surrounding metro area. (Credit to @expedtadam for making original maps)",
   "tags": [
     "north-america",
@@ -151,5 +151,14 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 63876261,
+      "since": "2026-02-21T00:00:00Z"
+    }
+  ],
+  "collaborators": [
+    63876261
+  ]
 }

--- a/maps/edmonton/manifest.json
+++ b/maps/edmonton/manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "id": "edmonton",
   "name": "Edmonton",
-  "author": "devenperez",
-  "github_id": 63876261,
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
   "description": "Custom map of Edmonton and its surrounding metro area. (Credit to @expedtadam for making original maps)",
   "tags": [
     "north-america",
@@ -152,5 +152,14 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 63876261,
+      "since": "2026-02-21T00:00:00Z"
+    }
+  ],
+  "collaborators": [
+    63876261
+  ]
 }

--- a/maps/montreal/manifest.json
+++ b/maps/montreal/manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "id": "montreal",
   "name": "Montreal",
-  "author": "devenperez",
-  "github_id": 63876261,
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
   "description": "Custom map of Montreal and its surrounding metro area. (Credit to @expedtadam for making original maps)",
   "tags": [
     "north-america",
@@ -170,5 +170,14 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 63876261,
+      "since": "2026-02-21T00:00:00Z"
+    }
+  ],
+  "collaborators": [
+    63876261
+  ]
 }

--- a/maps/opo-pt-metropolitan/manifest.json
+++ b/maps/opo-pt-metropolitan/manifest.json
@@ -153,5 +153,11 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 198279488,
+      "since": "2026-06-01T00:00:00Z"
+    }
+  ]
 }

--- a/maps/ottawa/manifest.json
+++ b/maps/ottawa/manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "id": "ottawa",
   "name": "Ottawa",
-  "author": "devenperez",
-  "github_id": 63876261,
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
   "description": "Custom map of Ottawa and its surrounding metro area. (Credit to @expedtadam for making original maps)",
   "tags": [
     "north-america",
@@ -168,5 +168,14 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 63876261,
+      "since": "2026-02-21T00:00:00Z"
+    }
+  ],
+  "collaborators": [
+    63876261
+  ]
 }

--- a/maps/quebec-city/manifest.json
+++ b/maps/quebec-city/manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "id": "quebec-city",
   "name": "Quebec City",
-  "author": "devenperez",
-  "github_id": 63876261,
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
   "description": "Custom map of Quebec City and its surrounding metro area. (Credit to @expedtadam for making original maps)",
   "tags": [
     "north-america",
@@ -159,5 +159,14 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 63876261,
+      "since": "2026-02-21T00:00:00Z"
+    }
+  ],
+  "collaborators": [
+    63876261
+  ]
 }

--- a/maps/toronto/manifest.json
+++ b/maps/toronto/manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "id": "toronto",
   "name": "Toronto",
-  "author": "devenperez",
-  "github_id": 63876261,
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
   "description": "Custom map of Toronto and its surrounding metro area. (Credit to @expedtadam for making original maps)",
   "tags": [
     "north-america",
@@ -148,5 +148,14 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 63876261,
+      "since": "2026-02-21T00:00:00Z"
+    }
+  ],
+  "collaborators": [
+    63876261
+  ]
 }

--- a/maps/vancouver/manifest.json
+++ b/maps/vancouver/manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "id": "vancouver",
   "name": "Vancouver",
-  "author": "devenperez",
-  "github_id": 63876261,
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
   "description": "Custom map of Vancouver and its surrounding metro area. (Credit to @expedtadam for making original maps)",
   "tags": [
     "north-america",
@@ -161,5 +161,14 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 63876261,
+      "since": "2026-02-21T00:00:00Z"
+    }
+  ],
+  "collaborators": [
+    63876261
+  ]
 }

--- a/maps/winnipeg/manifest.json
+++ b/maps/winnipeg/manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "id": "winnipeg",
   "name": "Winnipeg",
-  "author": "devenperez",
-  "github_id": 63876261,
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
   "description": "Custom map of Winnipeg and its surrounding metro area. (Credit to @expedtadam for making original maps)",
   "tags": [
     "north-america",
@@ -165,5 +165,14 @@
   "data_quality": {
     "tier": "unknown",
     "rubric_version": 1
-  }
+  },
+  "caretakers": [
+    {
+      "github_id": 63876261,
+      "since": "2026-02-21T00:00:00Z"
+    }
+  ],
+  "collaborators": [
+    63876261
+  ]
 }


### PR DESCRIPTION
PR D of the caretakers plan - the one-off data migrations (#6608 schema; crediting math in #6612 makes these take effect).

## devenperez's 8 CA maps
calgary, edmonton, montreal, ottawa, quebec-city, toronto, vancouver, winnipeg: `author` -> `subway-builder-modded-admin` (268817724); devenperez (63876261) becomes **active caretaker since 2026-02-21T00:00:00Z** - the day of his earliest CA release (computed from integrity `released_at`) - and is unioned into collaborators. Every version of every map falls inside his window, so his credited download totals are provably unchanged; only the displayed author changes.

## porto (opo-pt-metropolitan)
Author stays **bquelhas**. Existing collaborator 198279488 (Capitao-piolho / Miguel Sousa) becomes **active caretaker since 2026-06-01T00:00:00Z**, chosen between v0.2.1 (2026-05-30) and v0.3.0 (2026-07-06) per Alex's call - so v0.3.0/v0.4.x credit Miguel and v0.1.0-v0.2.1 credit bquelhas.

## brussels cleanup (drive-by, found by the schema sweep)
Brussels merged from a stale pre-location-migration publish branch and still carried `sub_location` + the retired `location: europe`. Normalized exactly as the location migration would have: location `west-europe` (BE), tags rebuilt, sub_location removed.

## Verification
Full-registry schema sweep: **309/309 manifests valid** (was 308/309), 9 carrying caretaker windows (all invariant-checked by the schema). Diff is exactly the 10 data files.

After this + #6612 merge, the next daily analytics run will emit `listing_version_credits.csv` showing the porto split - a good end-to-end sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)