### PR TITLE
fix: exempt integrity-alert issues from auto-close workflow

### DIFF
--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -17,6 +17,7 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'update-author') &&
       !contains(github.event.issue.labels.*.name, 'data-quality') &&
       !contains(github.event.issue.labels.*.name, 'report') &&
+      !contains(github.event.issue.labels.*.name, 'integrity-alert') &&
       github.event.issue.author_association != 'MEMBER' &&
       github.event.issue.author_association != 'OWNER' &&
       github.event.issue.author_association != 'COLLABORATOR'


### PR DESCRIPTION
## Summary
- Add `integrity-alert` to the label allowlist in the close-invalid workflow

## Problem
`close-invalid.yml` auto-closes any newly opened issue that doesn't carry one of the known template labels (unless the author is a member/owner/collaborator). Integrity-alert issues are opened programmatically by the downloads pipeline (`scripts/downloads/generate-downloads.ts`) with the `integrity-alert` label, which was missing from the allowlist — so every integrity alert was closed as `not_planned` moments after being opened.

## Fix
Add `!contains(github.event.issue.labels.*.name, 'integrity-alert')` to the workflow's `if:` guard. Labels passed at issue-creation time are present in the `opened` event payload, same as the existing template labels, so the exemption is reliable.

## Note
Previously auto-closed integrity-alert issues stay closed; the pipeline's dedup only checks *open* alert issues, so affected alerts will re-fire on the next state transition, but past silently-closed alerts may warrant a manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)