### PR TITLE
feat: deprecate-asset intake — issue form, workflow, author/caretaker-only validation (deprecation PR B)

### DIFF
--- a/.github/ISSUE_TEMPLATE/deprecate-asset.yml
+++ b/.github/ISSUE_TEMPLATE/deprecate-asset.yml
@@ -1,0 +1,47 @@
+name: Deprecate an Asset
+description: Permanently deprecate a mod or map you author or caretake in The Railyard registry.
+title: "[Deprecate]: "
+labels: ["deprecate-asset"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Deprecate an Asset
+
+        Deprecating an asset removes it from downloads and search across the Railyard app and
+        website. Your listing, download history, and author attribution are **kept** — deprecation
+        is not deletion, and your download counts remain credited to you permanently.
+
+        Only the asset's **original publisher or its active caretaker** can deprecate it.
+        Collaborators cannot. This form works for both mods and maps — just enter the asset ID.
+
+        A maintainer reviews and merges the resulting pull request before the deprecation takes
+        effect. If validation fails, you can edit this issue and comment **revalidate** to retry.
+
+  - type: input
+    id: asset-id
+    attributes:
+      label: Asset ID
+      description: The ID of the mod or map you want to deprecate. Must already exist in the registry.
+      placeholder: better-trains
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason (optional)
+      description: >
+        Shown publicly on the listing's detail page — e.g. "Superseded by better-trains-2".
+        Leave blank to omit.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: >
+            I understand this asset will no longer be downloadable or appear in search once a
+            maintainer merges the deprecation, and that undoing this requires contacting a
+            maintainer.
+          required: true

--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -17,6 +17,7 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'update-author') &&
       !contains(github.event.issue.labels.*.name, 'data-quality') &&
       !contains(github.event.issue.labels.*.name, 'report') &&
+      !contains(github.event.issue.labels.*.name, 'deprecate-asset') &&
       !contains(github.event.issue.labels.*.name, 'integrity-alert') &&
       github.event.issue.author_association != 'MEMBER' &&
       github.event.issue.author_association != 'OWNER' &&
@@ -42,6 +43,7 @@ jobs:
                 '- **[Update Author Profile](../../issues/new?template=update-author.yml)** - Update your author alias, attribution, or profile metadata',
                 '- **[Map Data Quality](../../issues/new?template=data-quality.yml)** - Answer the data-quality questions for a map you own',
                 '- **[Report a Mod or Map](../../issues/new?template=report.yml)** - Report an issue with a listing',
+                '- **[Deprecate an Asset](../../issues/new?template=deprecate-asset.yml)** - Deprecate a mod or map you author or caretake',
               ].join('\n')
             });
 

--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -1,0 +1,190 @@
+name: Deprecate Asset
+
+# Author/caretaker-initiated deprecation (asset-type agnostic — the form takes
+# a bare asset ID; listing IDs are unique across maps and mods). Validation is
+# deliberately stricter than metadata updates: only the original publisher or
+# the ACTIVE caretaker may deprecate, never ordinary collaborators. The
+# resulting PR is merged by a maintainer — deprecation never lands unreviewed.
+
+on:
+  issues:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  deprecate-asset:
+    if: >-
+      contains(github.event.issue.labels.*.name, 'deprecate-asset') && (
+        github.event_name == 'issues' ||
+        (github.event_name == 'issue_comment' &&
+         contains(github.event.comment.body, 'revalidate') &&
+         (github.event.comment.user.id == github.event.issue.user.id ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      # Optional CI-triggering bot identity — see publish.yml.
+      - name: Mint bot token
+        id: bot-token
+        if: vars.REGISTRY_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.bot-token.outputs.token || github.token }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: scripts/pnpm-lock.yaml
+
+      - name: Install script dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: scripts
+
+      - name: Acknowledge revalidation
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Parse issue body
+        id: parser
+        uses: stefanbuck/github-issue-parser@v3
+        with:
+          template-path: .github/ISSUE_TEMPLATE/deprecate-asset.yml
+          issue-body: ${{ github.event.issue.body }}
+
+      - name: Validate deprecation request
+        env:
+          ISSUE_JSON: ${{ steps.parser.outputs.jsonString }}
+          ISSUE_AUTHOR_ID: ${{ github.event.issue.user.id }}
+        run: pnpm --dir scripts run validate-deprecate
+
+      - name: Deprecate listing
+        env:
+          ISSUE_JSON: ${{ steps.parser.outputs.jsonString }}
+          ISSUE_AUTHOR_ID: ${{ github.event.issue.user.id }}
+        run: pnpm --dir scripts run deprecate-listing
+
+      - name: Commit and push changes
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "deprecate/${{ fromJson(steps.parser.outputs.jsonString).asset-id }}"
+          git add -A
+          git commit -m "chore: deprecate ${{ fromJson(steps.parser.outputs.jsonString).asset-id }}"
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/deprecate" 2>/dev/null || true
+          git push --force origin "deprecate/${{ fromJson(steps.parser.outputs.jsonString).asset-id }}"
+
+      - name: Create or update pull request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.bot-token.outputs.token || github.token }}
+          script: |
+            const branch = 'deprecate/${{ fromJson(steps.parser.outputs.jsonString).asset-id }}';
+            const { data: existing } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open'
+            });
+            if (existing.length > 0) {
+              console.log(`PR #${existing[0].number} already exists — updated via force push`);
+              return;
+            }
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'chore: deprecate `${{ fromJson(steps.parser.outputs.jsonString).asset-id }}`',
+              body: [
+                'Fixes #${{ github.event.issue.number }}',
+                '',
+                'Automated PR to deprecate `${{ fromJson(steps.parser.outputs.jsonString).asset-id }}`.',
+                'On merge, the next pipeline run removes it from installable versions and search;',
+                'the listing, download history, and author attribution are retained.',
+                '',
+                'Requested by @${{ github.event.issue.user.login }} (verified author or active caretaker).'
+              ].join('\n'),
+              head: branch,
+              base: 'main'
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['automated-pr']
+            });
+
+      - name: Handle success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'failed-validation'
+              });
+            } catch {}
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'A pull request has been created for your deprecation request. A maintainer will review and merge it shortly — the deprecation takes effect once merged.'
+            });
+
+      - name: Handle failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let errorMsg;
+            try {
+              errorMsg = fs.readFileSync('scripts/validation-error.md', 'utf-8');
+            } catch {
+              errorMsg = 'Something went wrong while processing your deprecation request. Please check the [workflow logs](' +
+                `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['failed-validation']
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: errorMsg + '\n\n---\nEdit your issue to fix the problems above, then comment **revalidate** to try again.'
+            });

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ All submissions are handled through GitHub Issues. Pick a template to get starte
 - [Update an Existing Map](https://github.com/Subway-Builder-Modded/registry/issues/new?template=update-map.yml)
 - [Update Your Author Profile](https://github.com/Subway-Builder-Modded/registry/issues/new?template=update-author.yml)
 - [Report an Issue](https://github.com/Subway-Builder-Modded/registry/issues/new?template=report.yml)
+- [Deprecate an Asset](https://github.com/Subway-Builder-Modded/registry/issues/new?template=deprecate-asset.yml)
+
+Deprecation is asset-type agnostic (mods and maps share one form) and is restricted to the
+listing's original publisher or its **active caretaker** — collaborators cannot deprecate.
+A deprecated listing stops being downloadable and drops out of search, but the listing itself,
+its download history, and its author attribution are kept permanently.
 
 ## How It Works
 
@@ -35,7 +41,7 @@ PRs. Who can use each command is enforced by the workflows:
 
 | Command | Where | Who | Effect |
 | --- | --- | --- | --- |
-| `revalidate` | Any submission/update issue (publish-mod/map, update-mod/map, update-author, data-quality) | Issue author or org OWNER/MEMBER/COLLABORATOR | Re-runs validation after the issue was edited (e.g. after a `failed-validation` result). |
+| `revalidate` | Any submission/update issue (publish-mod/map, update-mod/map, update-author, data-quality, deprecate-asset) | Issue author or org OWNER/MEMBER/COLLABORATOR | Re-runs validation after the issue was edited (e.g. after a `failed-validation` result). |
 | `rescore_data [flags]` | Automated data-quality / publish **PRs** | OWNER/MEMBER/COLLABORATOR | Confirms the submitter's data-quality answers, applies the tier, and marks the publish PR ready to merge. Optional flags on the same line are passed through (e.g. `--admin` to bypass-merge). |
 | `admin_author` | Publish issues | Repo admin/maintain | Creates the listing with author `subway-builder-modded-admin`; the issue submitter is recorded as active **caretaker** (credited for downloads of versions released during their tenure) and added as a collaborator. Use for assets whose true author has no GitHub account. |
 | `data_quality_exempt` | Publish-map issues | Repo admin/maintain | Waives the data-quality merge gate for this submission: the publish PR is created (or updated) ready with the `dq-grandfathered` label and merges at `unknown-quality`. |

--- a/scripts/intake/deprecate-listing.ts
+++ b/scripts/intake/deprecate-listing.ts
@@ -1,0 +1,48 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { resolveListingById } from "../lib/manifests.js";
+import { getOptionalIssueValue } from "../lib/map-field-utils.js";
+import { assertValidRegistryManifest } from "../lib/registry-manifest.js";
+
+const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
+  ? resolve(process.env.RAILYARD_REPO_ROOT)
+  : resolve(import.meta.dirname, "..", "..");
+
+function main() {
+  const issueJson = process.env.ISSUE_JSON;
+  const issueAuthorId = process.env.ISSUE_AUTHOR_ID;
+
+  if (!issueJson || !issueAuthorId) {
+    console.error("ISSUE_JSON and ISSUE_AUTHOR_ID environment variables are required");
+    process.exit(1);
+  }
+
+  const data = JSON.parse(issueJson) as Record<string, unknown>;
+  const rawId = data["asset-id"];
+  const id = typeof rawId === "string" ? rawId.trim() : "";
+
+  const resolved = resolveListingById(REPO_ROOT, id);
+  if (!resolved) {
+    throw new Error(`No mod or map with ID "${id}" exists in the registry`);
+  }
+  if (resolved.manifest.deprecation !== undefined) {
+    throw new Error(`The ${resolved.type} "${id}" is already deprecated`);
+  }
+
+  const reason = getOptionalIssueValue(data.reason);
+  resolved.manifest.deprecation = {
+    since: new Date().toISOString(),
+    by_github_id: Number(issueAuthorId),
+    ...(reason ? { reason } : {}),
+  };
+
+  assertValidRegistryManifest(
+    resolved.manifest,
+    `Deprecated ${resolved.dir}/${id}/manifest.json`,
+  );
+
+  writeFileSync(resolved.manifestPath, JSON.stringify(resolved.manifest, null, 2) + "\n");
+  console.log(`Deprecated ${resolved.dir}/${id}/manifest.json`);
+}
+
+main();

--- a/scripts/intake/validate-deprecate.ts
+++ b/scripts/intake/validate-deprecate.ts
@@ -1,0 +1,76 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { getActiveCaretaker, type ManifestWithCaretakers } from "../lib/caretakers.js";
+import { resolveListingById } from "../lib/manifests.js";
+
+const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
+  ? resolve(process.env.RAILYARD_REPO_ROOT)
+  : resolve(import.meta.dirname, "..", "..");
+
+function main() {
+  const issueJson = process.env.ISSUE_JSON;
+  const issueAuthorId = process.env.ISSUE_AUTHOR_ID;
+
+  if (!issueJson || !issueAuthorId) {
+    console.error("ISSUE_JSON and ISSUE_AUTHOR_ID environment variables are required");
+    process.exit(1);
+  }
+
+  const data = JSON.parse(issueJson) as Record<string, unknown>;
+  const rawId = data["asset-id"];
+  const id = typeof rawId === "string" ? rawId.trim() : "";
+  const errors: string[] = [];
+
+  if (!id) {
+    errors.push("**asset-id**: Must provide an asset ID.");
+  } else {
+    const resolved = resolveListingById(REPO_ROOT, id);
+    if (!resolved) {
+      errors.push(`**asset-id**: No mod or map with ID \`${id}\` exists in the registry.`);
+    } else {
+      const manifest = resolved.manifest;
+
+      if (manifest.deprecation !== undefined) {
+        errors.push(`**asset-id**: The ${resolved.type} \`${id}\` is already deprecated.`);
+      }
+
+      if (manifest.is_test === true) {
+        errors.push(
+          `**asset-id**: \`${id}\` is a test listing. Test listings are removed outright rather `
+          + `than deprecated — please contact a maintainer.`,
+        );
+      }
+
+      // Deprecation is deliberately stricter than metadata updates: only the
+      // original publisher or the ACTIVE caretaker may deprecate. Ordinary
+      // collaborators cannot.
+      const requesterId = String(issueAuthorId);
+      const ownerId = String(manifest.github_id);
+      const activeCaretaker = getActiveCaretaker(manifest as unknown as ManifestWithCaretakers);
+      const caretakerId = activeCaretaker ? String(activeCaretaker.github_id) : null;
+
+      if (requesterId !== ownerId && requesterId !== caretakerId) {
+        errors.push(
+          `**Ownership check failed**: Only the original publisher or the active caretaker of `
+          + `\`${id}\` can deprecate it. Collaborators cannot deprecate a listing.`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    const errorMessage = [
+      "Deprecation validation failed:\n",
+      ...errors.map((e) => `- ${e}`),
+      "\nIf you believe this is an error, please contact a maintainer.",
+    ].join("\n");
+
+    writeFileSync(resolve(REPO_ROOT, "scripts", "validation-error.md"), errorMessage);
+    console.error(errorMessage);
+    process.exit(1);
+  }
+
+  console.log("Deprecation validation passed.");
+}
+
+main();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,6 +15,8 @@
     "validate-author-update": "tsx intake/validate-author-update.ts",
     "create-listing": "tsx intake/create-listing.ts",
     "update-listing": "tsx intake/update-listing.ts",
+    "validate-deprecate": "tsx intake/validate-deprecate.ts",
+    "deprecate-listing": "tsx intake/deprecate-listing.ts",
     "update-author": "tsx intake/update-author.ts",
     "apply-data-quality": "tsx quality/apply-data-quality.ts",
     "check-data-quality": "tsx quality/check-data-quality.ts",

--- a/scripts/tests/deprecate-intake.integration.test.ts
+++ b/scripts/tests/deprecate-intake.integration.test.ts
@@ -1,0 +1,223 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+
+const scriptsRoot = resolve(import.meta.dirname, "..", "..");
+
+const AUTHOR_ID = 1000;
+const COLLABORATOR_ID = 2000;
+const ACTIVE_CARETAKER_ID = 3000;
+const PAST_CARETAKER_ID = 4000;
+const STRANGER_ID = 9000;
+
+function baseModManifest(id: string): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    id,
+    name: "Fixture Mod",
+    author: "fixture-author",
+    github_id: AUTHOR_ID,
+    collaborators: [COLLABORATOR_ID, PAST_CARETAKER_ID, ACTIVE_CARETAKER_ID],
+    caretakers: [
+      { github_id: PAST_CARETAKER_ID, since: "2026-01-01T00:00:00Z", until: "2026-03-01T00:00:00Z" },
+      { github_id: ACTIVE_CARETAKER_ID, since: "2026-03-01T00:00:00Z" },
+    ],
+    description: "A fixture mod.",
+    tags: ["qol"],
+    gallery: [],
+    is_test: false,
+    source: "https://example.com/fixture",
+    update: { type: "github", repo: "fixture/fixture" },
+  };
+}
+
+function makeFixtureRepo(manifests: Record<string, Record<string, unknown>>): string {
+  const root = mkdtempSync(join(tmpdir(), "railyard-deprecate-"));
+  mkdirSync(join(root, "maps"), { recursive: true });
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  for (const [id, manifest] of Object.entries(manifests)) {
+    const dir = join(root, "mods", id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+  }
+  return root;
+}
+
+function runScript(
+  scriptName: "validate-deprecate" | "deprecate-listing",
+  fixtureRoot: string,
+  env: Record<string, string>,
+): SpawnSyncReturns<string> {
+  const compiledScriptPath = resolve(scriptsRoot, ".test-dist", "intake", `${scriptName}.js`);
+  return spawnSync(process.execPath, [compiledScriptPath], {
+    cwd: fixtureRoot,
+    env: {
+      ...process.env,
+      RAILYARD_REPO_ROOT: fixtureRoot,
+      ...env,
+    },
+    encoding: "utf-8",
+  });
+}
+
+function readValidationError(fixtureRoot: string): string {
+  const path = join(fixtureRoot, "scripts", "validation-error.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : "";
+}
+
+function issueJson(assetId: string, reason?: string): string {
+  return JSON.stringify({ "asset-id": assetId, reason: reason ?? "_No response_" });
+}
+
+// --- validate-deprecate ---
+
+test("deprecate validation passes for the original publisher", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("deprecate validation passes for the active caretaker", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(ACTIVE_CARETAKER_ID),
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("deprecate validation rejects an ordinary collaborator", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(COLLABORATOR_ID),
+  });
+  assert.notEqual(result.status, 0, "collaborators must not be able to deprecate");
+  assert.match(readValidationError(root), /Only the original publisher or the active caretaker/);
+});
+
+test("deprecate validation rejects a past (closed-window) caretaker", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(PAST_CARETAKER_ID),
+  });
+  assert.notEqual(result.status, 0, "past caretakers must not be able to deprecate");
+});
+
+test("deprecate validation rejects a stranger", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(STRANGER_ID),
+  });
+  assert.notEqual(result.status, 0);
+});
+
+test("deprecate validation rejects an unknown asset ID", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("does-not-exist"),
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(readValidationError(root), /No mod or map with ID `does-not-exist` exists/);
+});
+
+test("deprecate validation rejects an already-deprecated listing", (t) => {
+  const manifest = baseModManifest("fixture-mod");
+  manifest.deprecation = { since: "2026-08-01T00:00:00Z", by_github_id: AUTHOR_ID };
+  const root = makeFixtureRepo({ "fixture-mod": manifest });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(readValidationError(root), /already deprecated/);
+});
+
+test("deprecate validation rejects a test listing", (t) => {
+  const manifest = baseModManifest("fixture-mod");
+  manifest.is_test = true;
+  const root = makeFixtureRepo({ "fixture-mod": manifest });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(readValidationError(root), /test listing/);
+});
+
+// --- deprecate-listing ---
+
+test("deprecate-listing stamps a schema-valid deprecation record with reason", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("deprecate-listing", root, {
+    ISSUE_JSON: issueJson("fixture-mod", "Superseded by fixture-mod-2"),
+    ISSUE_AUTHOR_ID: String(ACTIVE_CARETAKER_ID),
+  });
+  assert.equal(result.status, 0, result.stderr);
+
+  const written = JSON.parse(
+    readFileSync(join(root, "mods", "fixture-mod", "manifest.json"), "utf-8"),
+  ) as Record<string, unknown>;
+  const deprecation = written.deprecation as Record<string, unknown>;
+  assert.equal(deprecation.by_github_id, ACTIVE_CARETAKER_ID);
+  assert.equal(deprecation.reason, "Superseded by fixture-mod-2");
+  assert.ok(!Number.isNaN(Date.parse(deprecation.since as string)), "since must be a timestamp");
+});
+
+test("deprecate-listing omits the reason when the form field is blank", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("deprecate-listing", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.equal(result.status, 0, result.stderr);
+
+  const written = JSON.parse(
+    readFileSync(join(root, "mods", "fixture-mod", "manifest.json"), "utf-8"),
+  ) as Record<string, unknown>;
+  const deprecation = written.deprecation as Record<string, unknown>;
+  assert.equal(deprecation.by_github_id, AUTHOR_ID);
+  assert.equal("reason" in deprecation, false);
+});
+
+test("deprecate-listing refuses to double-deprecate", (t) => {
+  const manifest = baseModManifest("fixture-mod");
+  manifest.deprecation = { since: "2026-08-01T00:00:00Z", by_github_id: AUTHOR_ID };
+  const root = makeFixtureRepo({ "fixture-mod": manifest });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("deprecate-listing", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.notEqual(result.status, 0);
+});

--- a/scripts/tsconfig.test.json
+++ b/scripts/tsconfig.test.json
@@ -5,5 +5,5 @@
     "rootDir": ".",
     "noEmit": false
   },
-  "include": ["lib/**/*.ts", "tests/**/*.ts", "intake/validate-publish.ts", "intake/validate-update.ts", "listings/generate-map-basemaps.ts"]
+  "include": ["lib/**/*.ts", "tests/**/*.ts", "intake/validate-publish.ts", "intake/validate-update.ts", "intake/validate-deprecate.ts", "intake/deprecate-listing.ts", "listings/generate-map-basemaps.ts"]
 }


### PR DESCRIPTION
Second of the asset-deprecation series (design: tmp/plans/asset-deprecation-plan.md; follows #6805).

## Summary
- **New issue form** `.github/ISSUE_TEMPLATE/deprecate-asset.yml` (label `deprecate-asset`): asset-type agnostic — takes just the bare asset ID (resolved via `resolveListingById` from PR A), an optional public reason, and a required confirmation checkbox.
- **New workflow** `deprecate.yml`, mirroring the update-metadata shape: parse (github-issue-parser) → `validate-deprecate` → `deprecate-listing` (stamps `manifest.deprecation`) → branch `deprecate/<id>` → PR labeled `automated-pr` for **maintainer merge** — a deprecation never lands unreviewed. `revalidate` comment support included.
- **Authorization is deliberately stricter than metadata updates**: only the original publisher (`github_id`) or the **active caretaker** (`getActiveCaretaker`) may deprecate. Ordinary collaborators and closed-window caretakers are rejected. Also rejected: unknown IDs, already-deprecated listings, test listings (those get purged instead).
- **close-invalid**: `deprecate-asset` added to the allowlist (same bug class as #6795) and to the template list in the auto-close comment.
- **README**: new submit-list entry with the deprecation policy summary; `revalidate` scope updated.

## Tests
11 new integration tests running the compiled scripts against synthetic fixture repos via `RAILYARD_REPO_ROOT` — publisher passes, active caretaker passes, collaborator rejected, past caretaker rejected, stranger rejected, unknown ID, double-deprecation, test listing, reason stamped/omitted, schema-valid output. Both scripts added to `tsconfig.test.json`. Full suite: **333 pass / 0 fail**.

## Notes for review
- The stamped record is `deprecation: { since: <now>, by_github_id: <issue author>, reason? }` — validated against the v0.2.2 schema via `assertValidRegistryManifest` before write.
- Deprecation has **no effect on consumers yet** — that's PR C (pipeline overlay: published integrity view, bucket-ledger download merge, alert suppression). Merging this PR only enables the intake path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)