### PR TITLE
feat: deprecation pipeline overlay — published integrity view + alert/warning suppression (deprecation PR C)

### DIFF
--- a/scripts/downloads/generate-downloads.ts
+++ b/scripts/downloads/generate-downloads.ts
@@ -33,6 +33,7 @@ import {
 } from "../lib/script-runtime.js";
 import { compareStableSemverAsc, isStableSemverTag } from "../lib/semver.js";
 import { filterListingMessages, isTestListing } from "../lib/test-listings.js";
+import { isDeprecatedListing } from "../lib/downloads-full/deprecation.js";
 import { loadAuthorAliasIndex } from "../lib/author-aliases.js";
 import {
   buildIntegrityAlertEmbed,
@@ -445,17 +446,22 @@ async function run(): Promise<void> {
     ...warnings,
     ...buildZeroValidSemverWarnings(integrity),
   ];
+  // Test listings and deprecated listings are both suppressed from outbound
+  // warning/alert channels — a deprecated listing whose upstream repo later
+  // vanishes must not nag maintainers or authors every run.
+  const isSuppressedListing = (dir: "maps" | "mods", listingId: string): boolean =>
+    isTestListing(repoRoot, dir, listingId) || isDeprecatedListing(repoRoot, dir, listingId);
   const warningsForGitHub = filterListingMessages(
     filterWarningsForGitHub(warningsForOutput, integrity, downloads),
-    (listingId) => isTestListing(repoRoot, listingType === "map" ? "maps" : "mods", listingId),
+    (listingId) => isSuppressedListing(listingType === "map" ? "maps" : "mods", listingId),
   );
   const securityErrorsForOutput = filterListingMessages(
     securityAlerts.errors,
-    (listingId) => isTestListing(repoRoot, "mods", listingId),
+    (listingId) => isSuppressedListing("mods", listingId),
   );
   const securityWarningsForOutput = filterListingMessages(
     securityAlerts.warnings,
-    (listingId) => isTestListing(repoRoot, "mods", listingId),
+    (listingId) => isSuppressedListing("mods", listingId),
   );
   const suppressedWarnings = warningsForOutput.length - warningsForGitHub.length;
   if (suppressedWarnings > 0) {

--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -60,6 +60,11 @@ import {
 } from "./download-attribution.js";
 import { toDownloadAssetBucketKey } from "./download-version-buckets.js";
 import { getActiveCaretaker } from "./caretakers.js";
+import {
+  applyDeprecationOverlay,
+  filterDeprecatedIntegrityAlerts,
+  isManifestDeprecated,
+} from "./downloads-full/deprecation.js";
 
 // Per-listing display/routing metadata carried from the manifest into
 // integrity-alert assembly.
@@ -67,6 +72,7 @@ interface ListingMetaEntry {
   listingName: string;
   authorId: string;
   caretakerGithubId?: number;
+  deprecated?: boolean;
 }
 
 interface AdjustedVersionCount {
@@ -363,6 +369,7 @@ async function resolveListingContexts(params: {
       listingName: manifest.name,
       authorId: manifest.author,
       caretakerGithubId: getActiveCaretaker(manifest)?.github_id,
+      deprecated: isManifestDeprecated(manifest),
     });
 
     if (manifest.update.type === "github") {
@@ -1385,6 +1392,17 @@ export async function generateDownloadsDataFull(
     sortedDownloads[id] = sortObjectByKeys(downloadsByListing[id] ?? {});
   }
 
+  // Deprecation output overlay (see downloads-full/deprecation.ts): the
+  // published integrity view reports deprecated listings with zero installable
+  // versions while downloads, buckets, and the integrity cache above keep the
+  // true evaluated state. Applied centrally so preserved/unavailable listing
+  // paths are covered too; alerts for deprecated listings are dropped.
+  const isDeprecatedId = (id: string): boolean => listingMeta.get(id)?.deprecated === true;
+  const overlaidIds = applyDeprecationOverlay(ctx.integrityListings, isDeprecatedId);
+  if (overlaidIds.length > 0) {
+    console.log(`[downloads] Deprecation overlay applied to: ${overlaidIds.join(", ")}`);
+  }
+
   return {
     downloads: sortedDownloads,
     versionBucketInputs: ctx.versionBucketInputs,
@@ -1397,7 +1415,7 @@ export async function generateDownloadsDataFull(
       schema_version: 1,
       entries: sortObjectByKeys(nextCache.entries),
     },
-    integrityAlerts: ctx.integrityAlerts,
+    integrityAlerts: filterDeprecatedIntegrityAlerts(ctx.integrityAlerts, isDeprecatedId),
     stats: {
       listings: ids.length,
       versions_checked: ctx.stats.versionsChecked,

--- a/scripts/lib/downloads-full/deprecation.ts
+++ b/scripts/lib/downloads-full/deprecation.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { ListingIntegrityEntry } from "../integrity.js";
+import type { IntegrityAlert } from "../download-definitions.js";
+
+// Deprecation is an OUTPUT overlay, not an integrity rule: the pipeline
+// evaluates deprecated listings normally (so download counts keep accruing
+// while the upstream repo is reachable, and the integrity CACHE keeps the true
+// computed state for clean un-deprecation), but the PUBLISHED integrity.json
+// reports the listing with zero installable versions. Existing app versions
+// treat that as "no installable versions" and refuse to download; the website
+// drops the listing from browse. This never touches INTEGRITY_RULES_VERSION
+// and never fights the never-downgrade guard.
+
+export const DEPRECATED_LISTING_ERROR = "listing_deprecated";
+
+/** Value-level check used where a parsed manifest is already in hand. */
+export function isManifestDeprecated(manifest: { deprecation?: unknown }): boolean {
+  return manifest.deprecation !== undefined;
+}
+
+/**
+ * Disk-probing predicate mirroring isTestListing, for suppressing warning /
+ * alert output about deprecated listings (a deprecated listing whose repo
+ * later disappears must not ping authors or maintainers every run).
+ */
+export function isDeprecatedListing(
+  repoRoot: string,
+  listingType: "maps" | "mods",
+  id: string,
+): boolean {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(resolve(repoRoot, listingType, id, "manifest.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    return isManifestDeprecated(manifest);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The published view of a deprecated listing: every version reported
+ * incomplete (with an explicit marker error appended for human readers),
+ * no complete versions, has_complete_version false. All other version data
+ * (source, released_at, file_sizes, game_version, ...) is preserved so
+ * downstream consumers of those fields keep working.
+ */
+export function overlayDeprecatedListingEntry(
+  entry: ListingIntegrityEntry,
+): ListingIntegrityEntry {
+  const versions: ListingIntegrityEntry["versions"] = {};
+  for (const [version, versionEntry] of Object.entries(entry.versions)) {
+    versions[version] = {
+      ...versionEntry,
+      is_complete: false,
+      errors: versionEntry.errors.includes(DEPRECATED_LISTING_ERROR)
+        ? versionEntry.errors
+        : [...versionEntry.errors, DEPRECATED_LISTING_ERROR],
+    };
+  }
+  return {
+    ...entry,
+    has_complete_version: false,
+    latest_semver_complete: entry.latest_semver_version === null ? null : false,
+    complete_versions: [],
+    incomplete_versions: Object.keys(versions).sort(),
+    versions,
+  };
+}
+
+/**
+ * Applies the overlay in place to the published integrity listings record.
+ * Runs centrally at the end of the full pipeline so every code path that
+ * produced a listing entry (fresh evaluation, transient-error preservation,
+ * repo-unavailable preservation) is covered. Returns the overlaid ids.
+ */
+export function applyDeprecationOverlay(
+  integrityListings: Record<string, ListingIntegrityEntry>,
+  isDeprecated: (id: string) => boolean,
+): string[] {
+  const overlaid: string[] = [];
+  for (const id of Object.keys(integrityListings)) {
+    if (!isDeprecated(id)) continue;
+    integrityListings[id] = overlayDeprecatedListingEntry(integrityListings[id]!);
+    overlaid.push(id);
+  }
+  return overlaid.sort();
+}
+
+/** Deprecated listings never alert their author/caretaker. */
+export function filterDeprecatedIntegrityAlerts(
+  alerts: IntegrityAlert[],
+  isDeprecated: (id: string) => boolean,
+): IntegrityAlert[] {
+  return alerts.filter((alert) => !isDeprecated(alert.listingId));
+}

--- a/scripts/tests/deprecation-overlay.unit.test.ts
+++ b/scripts/tests/deprecation-overlay.unit.test.ts
@@ -1,0 +1,155 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ListingIntegrityEntry } from "../lib/integrity.js";
+import type { IntegrityAlert } from "../lib/download-definitions.js";
+import {
+  DEPRECATED_LISTING_ERROR,
+  applyDeprecationOverlay,
+  filterDeprecatedIntegrityAlerts,
+  isDeprecatedListing,
+  isManifestDeprecated,
+  overlayDeprecatedListingEntry,
+} from "../lib/downloads-full/deprecation.js";
+
+function versionEntry(overrides: Record<string, unknown> = {}): ListingIntegrityEntry["versions"][string] {
+  return {
+    is_complete: true,
+    errors: [],
+    required_checks: { config_version_matches_tag: true },
+    matched_files: {},
+    game_version: ">=1.2.0",
+    released_at: "2026-05-01T00:00:00Z",
+    source: {
+      update_type: "github",
+      repo: "owner/repo",
+      tag: "v1.0.0",
+      download_url: "https://example.com/release.zip",
+    },
+    fingerprint: "abc",
+    checked_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  } as ListingIntegrityEntry["versions"][string];
+}
+
+function listingEntry(): ListingIntegrityEntry {
+  return {
+    has_complete_version: true,
+    latest_semver_version: "1.1.0",
+    latest_semver_complete: true,
+    complete_versions: ["v1.0.0", "v1.1.0"],
+    incomplete_versions: ["v0.9.0"],
+    last_updated: 1750000000,
+    versions: {
+      "v1.0.0": versionEntry(),
+      "v1.1.0": versionEntry({ source: { update_type: "github", repo: "owner/repo", tag: "v1.1.0" } }),
+      "v0.9.0": versionEntry({ is_complete: false, errors: ["manifest-version-mismatch"] }),
+    },
+  };
+}
+
+test("overlay reports every version incomplete with the deprecation marker", () => {
+  const overlaid = overlayDeprecatedListingEntry(listingEntry());
+
+  assert.equal(overlaid.has_complete_version, false);
+  assert.equal(overlaid.latest_semver_complete, false);
+  assert.deepEqual(overlaid.complete_versions, []);
+  assert.deepEqual(overlaid.incomplete_versions, ["v0.9.0", "v1.0.0", "v1.1.0"]);
+  for (const entry of Object.values(overlaid.versions)) {
+    assert.equal(entry.is_complete, false);
+    assert.ok(entry.errors.includes(DEPRECATED_LISTING_ERROR));
+  }
+  // Pre-existing errors are preserved, not replaced.
+  assert.deepEqual(overlaid.versions["v0.9.0"]!.errors, [
+    "manifest-version-mismatch",
+    DEPRECATED_LISTING_ERROR,
+  ]);
+});
+
+test("overlay preserves version data consumers rely on", () => {
+  const overlaid = overlayDeprecatedListingEntry(listingEntry());
+  const v1 = overlaid.versions["v1.0.0"]!;
+
+  assert.equal(v1.released_at, "2026-05-01T00:00:00Z");
+  assert.equal(v1.game_version, ">=1.2.0");
+  assert.equal(v1.source.download_url, "https://example.com/release.zip");
+  assert.equal(overlaid.last_updated, 1750000000);
+  assert.equal(overlaid.latest_semver_version, "1.1.0");
+});
+
+test("overlay is idempotent (marker not duplicated on already-overlaid input)", () => {
+  const once = overlayDeprecatedListingEntry(listingEntry());
+  const twice = overlayDeprecatedListingEntry(once);
+  assert.deepEqual(twice, once);
+});
+
+test("overlay keeps latest_semver_complete null when no semver version exists", () => {
+  const entry: ListingIntegrityEntry = {
+    has_complete_version: false,
+    latest_semver_version: null,
+    latest_semver_complete: null,
+    complete_versions: [],
+    incomplete_versions: [],
+    versions: {},
+  };
+  const overlaid = overlayDeprecatedListingEntry(entry);
+  assert.equal(overlaid.latest_semver_complete, null);
+});
+
+test("overlay does not mutate its input", () => {
+  const entry = listingEntry();
+  const before = JSON.stringify(entry);
+  overlayDeprecatedListingEntry(entry);
+  assert.equal(JSON.stringify(entry), before);
+});
+
+test("applyDeprecationOverlay only touches deprecated ids and returns them sorted", () => {
+  const listings: Record<string, ListingIntegrityEntry> = {
+    "zeta-mod": listingEntry(),
+    "alpha-mod": listingEntry(),
+    "kept-mod": listingEntry(),
+  };
+  const overlaid = applyDeprecationOverlay(listings, (id) => id !== "kept-mod");
+
+  assert.deepEqual(overlaid, ["alpha-mod", "zeta-mod"]);
+  assert.equal(listings["kept-mod"]!.has_complete_version, true);
+  assert.equal(listings["alpha-mod"]!.has_complete_version, false);
+  assert.equal(listings["zeta-mod"]!.has_complete_version, false);
+});
+
+test("filterDeprecatedIntegrityAlerts drops alerts for deprecated listings only", () => {
+  const alerts = [
+    { listingId: "deprecated-mod", version: "v1.0.0" },
+    { listingId: "live-mod", version: "v2.0.0" },
+  ] as IntegrityAlert[];
+  const filtered = filterDeprecatedIntegrityAlerts(alerts, (id) => id === "deprecated-mod");
+  assert.deepEqual(filtered.map((a) => a.listingId), ["live-mod"]);
+});
+
+test("isManifestDeprecated keys on field presence", () => {
+  assert.equal(isManifestDeprecated({}), false);
+  assert.equal(
+    isManifestDeprecated({ deprecation: { since: "2026-08-03T00:00:00Z", by_github_id: 1 } }),
+    true,
+  );
+});
+
+test("isDeprecatedListing probes the manifest on disk and defaults to false", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "railyard-depr-overlay-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  mkdirSync(join(root, "mods", "gone-mod"), { recursive: true });
+  writeFileSync(
+    join(root, "mods", "gone-mod", "manifest.json"),
+    JSON.stringify({ id: "gone-mod", deprecation: { since: "2026-08-03T00:00:00Z", by_github_id: 1 } }),
+    "utf-8",
+  );
+  mkdirSync(join(root, "mods", "live-mod"), { recursive: true });
+  writeFileSync(join(root, "mods", "live-mod", "manifest.json"), JSON.stringify({ id: "live-mod" }), "utf-8");
+
+  assert.equal(isDeprecatedListing(root, "mods", "gone-mod"), true);
+  assert.equal(isDeprecatedListing(root, "mods", "live-mod"), false);
+  assert.equal(isDeprecatedListing(root, "mods", "missing-mod"), false);
+});


### PR DESCRIPTION
Third of the asset-deprecation series (design: tmp/plans/asset-deprecation-plan.md; follows #6805 and #6806). **Merging this makes deprecation fully effective for all existing clients.**

## The key design property
Deprecation is an **output overlay, not an integrity rule**. During grounding I confirmed `applyDownloadCountForVersion` gates on the *evaluation-state* `is_complete`, not the published output — so overlaying only the published view gives us everything the locked decisions require, with zero new bookkeeping:

- **Downloads keep counting until the repo is private/gone** (locked decision 2): evaluation state is untouched, so counts accrue live from GraphQL; the existing post-429-cascade preserve guards freeze them when the repo becomes unavailable. No grandfathered-snapshot machinery needed.
- **`integrity-cache.json` keeps the true computed state** — un-deprecation is a clean revert (remove the manifest field; the overlay disappears next run). No recheck storm, no cache invalidation, `INTEGRITY_RULES_VERSION` untouched, never-downgrade guard never fought.
- **Published `integrity.json`** reports every version of a deprecated listing `is_complete: false` with a `listing_deprecated` marker appended to `errors`, `has_complete_version: false`. All other version data (source, released_at, game_version, file_sizes) is preserved for downstream consumers (analytics credits use `released_at`).

## Effect on existing clients (no client changes needed)
- **App**: treats the listing as having no installable versions — install button disabled, backend install blocked (`GetInstallableVersions` reads the published integrity view).
- **Website**: listing drops out of browse via the existing `hasCompleteVersion` eligibility filter (accepted interim per locked decision 1; PR D re-includes it with a badge).

## Implementation
- `scripts/lib/downloads-full/deprecation.ts` — pure overlay + alert filter + disk predicate.
- Applied **centrally** at the end of `generateDownloadsDataFull`, so every path that writes a listing entry (fresh evaluation, transient-error preservation, repo-unavailable preservation) is covered identically.
- **Alert + warning suppression**: integrity alerts for deprecated listings are dropped, and outbound GitHub/Discord warning channels suppress them like test listings — a deprecated listing whose repo later vanishes never pings its author or nags maintainers.

## Tests
9 new unit tests: overlay shape, idempotency, input non-mutation, preservation of consumer-relied fields, null-semver edge, alert filter, disk predicate. Full suite: **342 pass / 0 fail**.

## After this merges
The next hourly `regenerate-downloads` run picks up any merged `deprecate/<id>` PRs automatically — no manual step. Remaining work is consumer-side (monorepo): PR D (website badge/toggle/sort-last) and PR E (app Deprecated status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)