### PR TITLE
feat: undeprecate-asset intake — self-service reversal form (deprecation series)

### DIFF
--- a/.github/ISSUE_TEMPLATE/undeprecate-asset.yml
+++ b/.github/ISSUE_TEMPLATE/undeprecate-asset.yml
@@ -1,0 +1,36 @@
+name: Remove Asset Deprecation
+description: Restore a deprecated mod or map you author or caretake in The Railyard registry.
+title: "[Un-deprecate]: "
+labels: ["undeprecate-asset"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Remove Asset Deprecation
+
+        This restores a previously deprecated asset: once a maintainer merges the resulting pull
+        request, the next registry pipeline run makes it downloadable and searchable again.
+
+        Only the asset's **original publisher or its active caretaker** can remove a deprecation.
+        Collaborators cannot. This form works for both mods and maps — just enter the asset ID.
+
+        If validation fails, you can edit this issue and comment **revalidate** to retry.
+
+  - type: input
+    id: asset-id
+    attributes:
+      label: Asset ID
+      description: The ID of the deprecated mod or map you want to restore.
+      placeholder: better-trains
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: >
+            I am the original publisher or active caretaker of this asset and want it restored to
+            the registry as downloadable and searchable.
+          required: true

--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -18,6 +18,7 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'data-quality') &&
       !contains(github.event.issue.labels.*.name, 'report') &&
       !contains(github.event.issue.labels.*.name, 'deprecate-asset') &&
+      !contains(github.event.issue.labels.*.name, 'undeprecate-asset') &&
       !contains(github.event.issue.labels.*.name, 'integrity-alert') &&
       github.event.issue.author_association != 'MEMBER' &&
       github.event.issue.author_association != 'OWNER' &&
@@ -44,6 +45,7 @@ jobs:
                 '- **[Map Data Quality](../../issues/new?template=data-quality.yml)** - Answer the data-quality questions for a map you own',
                 '- **[Report a Mod or Map](../../issues/new?template=report.yml)** - Report an issue with a listing',
                 '- **[Deprecate an Asset](../../issues/new?template=deprecate-asset.yml)** - Deprecate a mod or map you author or caretake',
+                '- **[Remove Asset Deprecation](../../issues/new?template=undeprecate-asset.yml)** - Restore a deprecated mod or map you author or caretake',
               ].join('\n')
             });
 

--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -1,10 +1,11 @@
 name: Deprecate Asset
 
-# Author/caretaker-initiated deprecation (asset-type agnostic — the form takes
-# a bare asset ID; listing IDs are unique across maps and mods). Validation is
-# deliberately stricter than metadata updates: only the original publisher or
-# the ACTIVE caretaker may deprecate, never ordinary collaborators. The
-# resulting PR is merged by a maintainer — deprecation never lands unreviewed.
+# Author/caretaker-initiated deprecation and un-deprecation (asset-type
+# agnostic — the forms take a bare asset ID; listing IDs are unique across maps
+# and mods). Validation is deliberately stricter than metadata updates: only
+# the original publisher or the ACTIVE caretaker may (un)deprecate, never
+# ordinary collaborators. The resulting PRs are merged by a maintainer —
+# neither action ever lands unreviewed.
 
 on:
   issues:
@@ -172,6 +173,176 @@ jobs:
               errorMsg = fs.readFileSync('scripts/validation-error.md', 'utf-8');
             } catch {
               errorMsg = 'Something went wrong while processing your deprecation request. Please check the [workflow logs](' +
+                `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['failed-validation']
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: errorMsg + '\n\n---\nEdit your issue to fix the problems above, then comment **revalidate** to try again.'
+            });
+
+  undeprecate-asset:
+    if: >-
+      contains(github.event.issue.labels.*.name, 'undeprecate-asset') && (
+        github.event_name == 'issues' ||
+        (github.event_name == 'issue_comment' &&
+         contains(github.event.comment.body, 'revalidate') &&
+         (github.event.comment.user.id == github.event.issue.user.id ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      # Optional CI-triggering bot identity — see publish.yml.
+      - name: Mint bot token
+        id: bot-token
+        if: vars.REGISTRY_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.bot-token.outputs.token || github.token }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: scripts/pnpm-lock.yaml
+
+      - name: Install script dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: scripts
+
+      - name: Acknowledge revalidation
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Parse issue body
+        id: parser
+        uses: stefanbuck/github-issue-parser@v3
+        with:
+          template-path: .github/ISSUE_TEMPLATE/undeprecate-asset.yml
+          issue-body: ${{ github.event.issue.body }}
+
+      - name: Validate un-deprecation request
+        env:
+          ISSUE_JSON: ${{ steps.parser.outputs.jsonString }}
+          ISSUE_AUTHOR_ID: ${{ github.event.issue.user.id }}
+        run: pnpm --dir scripts run validate-undeprecate
+
+      - name: Un-deprecate listing
+        env:
+          ISSUE_JSON: ${{ steps.parser.outputs.jsonString }}
+        run: pnpm --dir scripts run undeprecate-listing
+
+      - name: Commit and push changes
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "undeprecate/${{ fromJson(steps.parser.outputs.jsonString).asset-id }}"
+          git add -A
+          git commit -m "chore: un-deprecate ${{ fromJson(steps.parser.outputs.jsonString).asset-id }}"
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/undeprecate" 2>/dev/null || true
+          git push --force origin "undeprecate/${{ fromJson(steps.parser.outputs.jsonString).asset-id }}"
+
+      - name: Create or update pull request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.bot-token.outputs.token || github.token }}
+          script: |
+            const branch = 'undeprecate/${{ fromJson(steps.parser.outputs.jsonString).asset-id }}';
+            const { data: existing } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open'
+            });
+            if (existing.length > 0) {
+              console.log(`PR #${existing[0].number} already exists — updated via force push`);
+              return;
+            }
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'chore: un-deprecate `${{ fromJson(steps.parser.outputs.jsonString).asset-id }}`',
+              body: [
+                'Fixes #${{ github.event.issue.number }}',
+                '',
+                'Automated PR to remove the deprecation from `${{ fromJson(steps.parser.outputs.jsonString).asset-id }}`.',
+                'On merge, the next pipeline run restores it as downloadable and searchable',
+                '(the integrity cache retained its true state throughout the deprecation).',
+                '',
+                'Requested by @${{ github.event.issue.user.login }} (verified author or active caretaker).'
+              ].join('\n'),
+              head: branch,
+              base: 'main'
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['automated-pr']
+            });
+
+      - name: Handle success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'failed-validation'
+              });
+            } catch {}
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'A pull request has been created for your un-deprecation request. A maintainer will review and merge it shortly — the asset is restored once merged and the next registry pipeline run completes.'
+            });
+
+      - name: Handle failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let errorMsg;
+            try {
+              errorMsg = fs.readFileSync('scripts/validation-error.md', 'utf-8');
+            } catch {
+              errorMsg = 'Something went wrong while processing your un-deprecation request. Please check the [workflow logs](' +
                 `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`;
             }
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ All submissions are handled through GitHub Issues. Pick a template to get starte
 - [Update Your Author Profile](https://github.com/Subway-Builder-Modded/registry/issues/new?template=update-author.yml)
 - [Report an Issue](https://github.com/Subway-Builder-Modded/registry/issues/new?template=report.yml)
 - [Deprecate an Asset](https://github.com/Subway-Builder-Modded/registry/issues/new?template=deprecate-asset.yml)
+- [Remove Asset Deprecation](https://github.com/Subway-Builder-Modded/registry/issues/new?template=undeprecate-asset.yml)
 
 Deprecation is asset-type agnostic (mods and maps share one form) and is restricted to the
 listing's original publisher or its **active caretaker** — collaborators cannot deprecate.
 A deprecated listing stops being downloadable and drops out of search, but the listing itself,
-its download history, and its author attribution are kept permanently.
+its download history, and its author attribution are kept permanently. Deprecation is fully
+reversible via the Remove Asset Deprecation form (same authorization rule).
 
 ## How It Works
 
@@ -41,7 +43,7 @@ PRs. Who can use each command is enforced by the workflows:
 
 | Command | Where | Who | Effect |
 | --- | --- | --- | --- |
-| `revalidate` | Any submission/update issue (publish-mod/map, update-mod/map, update-author, data-quality, deprecate-asset) | Issue author or org OWNER/MEMBER/COLLABORATOR | Re-runs validation after the issue was edited (e.g. after a `failed-validation` result). |
+| `revalidate` | Any submission/update issue (publish-mod/map, update-mod/map, update-author, data-quality, deprecate-asset, undeprecate-asset) | Issue author or org OWNER/MEMBER/COLLABORATOR | Re-runs validation after the issue was edited (e.g. after a `failed-validation` result). |
 | `rescore_data [flags]` | Automated data-quality / publish **PRs** | OWNER/MEMBER/COLLABORATOR | Confirms the submitter's data-quality answers, applies the tier, and marks the publish PR ready to merge. Optional flags on the same line are passed through (e.g. `--admin` to bypass-merge). |
 | `admin_author` | Publish issues | Repo admin/maintain | Creates the listing with author `subway-builder-modded-admin`; the issue submitter is recorded as active **caretaker** (credited for downloads of versions released during their tenure) and added as a collaborator. Use for assets whose true author has no GitHub account. |
 | `data_quality_exempt` | Publish-map issues | Repo admin/maintain | Waives the data-quality merge gate for this submission: the publish PR is created (or updated) ready with the `dq-grandfathered` label and merges at `unknown-quality`. |

--- a/scripts/intake/undeprecate-listing.ts
+++ b/scripts/intake/undeprecate-listing.ts
@@ -1,0 +1,44 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { resolveListingById } from "../lib/manifests.js";
+import { assertValidRegistryManifest } from "../lib/registry-manifest.js";
+
+const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
+  ? resolve(process.env.RAILYARD_REPO_ROOT)
+  : resolve(import.meta.dirname, "..", "..");
+
+function main() {
+  const issueJson = process.env.ISSUE_JSON;
+
+  if (!issueJson) {
+    console.error("ISSUE_JSON environment variable is required");
+    process.exit(1);
+  }
+
+  const data = JSON.parse(issueJson) as Record<string, unknown>;
+  const rawId = data["asset-id"];
+  const id = typeof rawId === "string" ? rawId.trim() : "";
+
+  const resolved = resolveListingById(REPO_ROOT, id);
+  if (!resolved) {
+    throw new Error(`No mod or map with ID "${id}" exists in the registry`);
+  }
+  if (resolved.manifest.deprecation === undefined) {
+    throw new Error(`The ${resolved.type} "${id}" is not deprecated`);
+  }
+
+  // Removing the field is the complete reversal: the published integrity view,
+  // search visibility, and downloadability all derive from it and self-heal on
+  // the next pipeline run (the integrity cache kept the true state throughout).
+  delete resolved.manifest.deprecation;
+
+  assertValidRegistryManifest(
+    resolved.manifest,
+    `Un-deprecated ${resolved.dir}/${id}/manifest.json`,
+  );
+
+  writeFileSync(resolved.manifestPath, JSON.stringify(resolved.manifest, null, 2) + "\n");
+  console.log(`Un-deprecated ${resolved.dir}/${id}/manifest.json`);
+}
+
+main();

--- a/scripts/intake/validate-undeprecate.ts
+++ b/scripts/intake/validate-undeprecate.ts
@@ -1,0 +1,68 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { getActiveCaretaker, type ManifestWithCaretakers } from "../lib/caretakers.js";
+import { resolveListingById } from "../lib/manifests.js";
+
+const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
+  ? resolve(process.env.RAILYARD_REPO_ROOT)
+  : resolve(import.meta.dirname, "..", "..");
+
+function main() {
+  const issueJson = process.env.ISSUE_JSON;
+  const issueAuthorId = process.env.ISSUE_AUTHOR_ID;
+
+  if (!issueJson || !issueAuthorId) {
+    console.error("ISSUE_JSON and ISSUE_AUTHOR_ID environment variables are required");
+    process.exit(1);
+  }
+
+  const data = JSON.parse(issueJson) as Record<string, unknown>;
+  const rawId = data["asset-id"];
+  const id = typeof rawId === "string" ? rawId.trim() : "";
+  const errors: string[] = [];
+
+  if (!id) {
+    errors.push("**asset-id**: Must provide an asset ID.");
+  } else {
+    const resolved = resolveListingById(REPO_ROOT, id);
+    if (!resolved) {
+      errors.push(`**asset-id**: No mod or map with ID \`${id}\` exists in the registry.`);
+    } else {
+      const manifest = resolved.manifest;
+
+      if (manifest.deprecation === undefined) {
+        errors.push(`**asset-id**: The ${resolved.type} \`${id}\` is not deprecated.`);
+      }
+
+      // Same authorization rule as deprecation itself: only the original
+      // publisher or the ACTIVE caretaker, never ordinary collaborators.
+      const requesterId = String(issueAuthorId);
+      const ownerId = String(manifest.github_id);
+      const activeCaretaker = getActiveCaretaker(manifest as unknown as ManifestWithCaretakers);
+      const caretakerId = activeCaretaker ? String(activeCaretaker.github_id) : null;
+
+      if (requesterId !== ownerId && requesterId !== caretakerId) {
+        errors.push(
+          `**Ownership check failed**: Only the original publisher or the active caretaker of `
+          + `\`${id}\` can remove its deprecation. Collaborators cannot.`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    const errorMessage = [
+      "Un-deprecation validation failed:\n",
+      ...errors.map((e) => `- ${e}`),
+      "\nIf you believe this is an error, please contact a maintainer.",
+    ].join("\n");
+
+    writeFileSync(resolve(REPO_ROOT, "scripts", "validation-error.md"), errorMessage);
+    console.error(errorMessage);
+    process.exit(1);
+  }
+
+  console.log("Un-deprecation validation passed.");
+}
+
+main();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -17,6 +17,8 @@
     "update-listing": "tsx intake/update-listing.ts",
     "validate-deprecate": "tsx intake/validate-deprecate.ts",
     "deprecate-listing": "tsx intake/deprecate-listing.ts",
+    "validate-undeprecate": "tsx intake/validate-undeprecate.ts",
+    "undeprecate-listing": "tsx intake/undeprecate-listing.ts",
     "update-author": "tsx intake/update-author.ts",
     "apply-data-quality": "tsx quality/apply-data-quality.ts",
     "check-data-quality": "tsx quality/check-data-quality.ts",

--- a/scripts/tests/undeprecate-intake.integration.test.ts
+++ b/scripts/tests/undeprecate-intake.integration.test.ts
@@ -1,0 +1,174 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+
+const scriptsRoot = resolve(import.meta.dirname, "..", "..");
+
+const AUTHOR_ID = 1000;
+const COLLABORATOR_ID = 2000;
+const ACTIVE_CARETAKER_ID = 3000;
+const STRANGER_ID = 9000;
+
+function deprecatedModManifest(id: string): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    id,
+    name: "Fixture Mod",
+    author: "fixture-author",
+    github_id: AUTHOR_ID,
+    collaborators: [COLLABORATOR_ID, ACTIVE_CARETAKER_ID],
+    caretakers: [{ github_id: ACTIVE_CARETAKER_ID, since: "2026-03-01T00:00:00Z" }],
+    description: "A fixture mod.",
+    tags: ["qol"],
+    gallery: [],
+    is_test: false,
+    source: "https://example.com/fixture",
+    update: { type: "github", repo: "fixture/fixture" },
+    deprecation: {
+      since: "2026-08-01T00:00:00Z",
+      by_github_id: AUTHOR_ID,
+      reason: "Superseded",
+    },
+  };
+}
+
+function makeFixtureRepo(manifests: Record<string, Record<string, unknown>>): string {
+  const root = mkdtempSync(join(tmpdir(), "railyard-undeprecate-"));
+  mkdirSync(join(root, "maps"), { recursive: true });
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  for (const [id, manifest] of Object.entries(manifests)) {
+    const dir = join(root, "mods", id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+  }
+  return root;
+}
+
+function runScript(
+  scriptName: "validate-undeprecate" | "undeprecate-listing",
+  fixtureRoot: string,
+  env: Record<string, string>,
+): SpawnSyncReturns<string> {
+  const compiledScriptPath = resolve(scriptsRoot, ".test-dist", "intake", `${scriptName}.js`);
+  return spawnSync(process.execPath, [compiledScriptPath], {
+    cwd: fixtureRoot,
+    env: {
+      ...process.env,
+      RAILYARD_REPO_ROOT: fixtureRoot,
+      ...env,
+    },
+    encoding: "utf-8",
+  });
+}
+
+function readValidationError(fixtureRoot: string): string {
+  const path = join(fixtureRoot, "scripts", "validation-error.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : "";
+}
+
+const ISSUE_JSON = JSON.stringify({ "asset-id": "fixture-mod" });
+
+// --- validate-undeprecate ---
+
+test("un-deprecate validation passes for the original publisher", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": deprecatedModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-undeprecate", root, {
+    ISSUE_JSON,
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("un-deprecate validation passes for the active caretaker", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": deprecatedModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-undeprecate", root, {
+    ISSUE_JSON,
+    ISSUE_AUTHOR_ID: String(ACTIVE_CARETAKER_ID),
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("un-deprecate validation rejects an ordinary collaborator", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": deprecatedModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-undeprecate", root, {
+    ISSUE_JSON,
+    ISSUE_AUTHOR_ID: String(COLLABORATOR_ID),
+  });
+  assert.notEqual(result.status, 0, "collaborators must not be able to un-deprecate");
+  assert.match(readValidationError(root), /Only the original publisher or the active caretaker/);
+});
+
+test("un-deprecate validation rejects a stranger", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": deprecatedModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-undeprecate", root, {
+    ISSUE_JSON,
+    ISSUE_AUTHOR_ID: String(STRANGER_ID),
+  });
+  assert.notEqual(result.status, 0);
+});
+
+test("un-deprecate validation rejects an unknown asset ID", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": deprecatedModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-undeprecate", root, {
+    ISSUE_JSON: JSON.stringify({ "asset-id": "does-not-exist" }),
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(readValidationError(root), /No mod or map with ID `does-not-exist` exists/);
+});
+
+test("un-deprecate validation rejects a listing that is not deprecated", (t) => {
+  const manifest = deprecatedModManifest("fixture-mod");
+  delete manifest.deprecation;
+  const root = makeFixtureRepo({ "fixture-mod": manifest });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-undeprecate", root, {
+    ISSUE_JSON,
+    ISSUE_AUTHOR_ID: String(AUTHOR_ID),
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(readValidationError(root), /is not deprecated/);
+});
+
+// --- undeprecate-listing ---
+
+test("undeprecate-listing removes the deprecation field and keeps everything else", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": deprecatedModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("undeprecate-listing", root, { ISSUE_JSON });
+  assert.equal(result.status, 0, result.stderr);
+
+  const written = JSON.parse(
+    readFileSync(join(root, "mods", "fixture-mod", "manifest.json"), "utf-8"),
+  ) as Record<string, unknown>;
+  assert.equal("deprecation" in written, false);
+  assert.equal(written.github_id, AUTHOR_ID);
+  assert.deepEqual(written.caretakers, [
+    { github_id: ACTIVE_CARETAKER_ID, since: "2026-03-01T00:00:00Z" },
+  ]);
+});
+
+test("undeprecate-listing refuses a listing that is not deprecated", (t) => {
+  const manifest = deprecatedModManifest("fixture-mod");
+  delete manifest.deprecation;
+  const root = makeFixtureRepo({ "fixture-mod": manifest });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("undeprecate-listing", root, { ISSUE_JSON });
+  assert.notEqual(result.status, 0);
+});

--- a/scripts/tsconfig.test.json
+++ b/scripts/tsconfig.test.json
@@ -5,5 +5,5 @@
     "rootDir": ".",
     "noEmit": false
   },
-  "include": ["lib/**/*.ts", "tests/**/*.ts", "intake/validate-publish.ts", "intake/validate-update.ts", "intake/validate-deprecate.ts", "intake/deprecate-listing.ts", "listings/generate-map-basemaps.ts"]
+  "include": ["lib/**/*.ts", "tests/**/*.ts", "intake/validate-publish.ts", "intake/validate-update.ts", "intake/validate-deprecate.ts", "intake/deprecate-listing.ts", "intake/validate-undeprecate.ts", "intake/undeprecate-listing.ts", "listings/generate-map-basemaps.ts"]
 }


### PR DESCRIPTION
Companion to #6806, making deprecation fully self-service reversible. Answers the requirement that both deprecation issue types exist and neither is ever auto-closed.

## Summary
- **New issue form** `undeprecate-asset.yml`: bare asset ID + confirmation checkbox, type-agnostic like its counterpart.
- **Allowlisting (both directions covered)**: `undeprecate-asset` added to the close-invalid label allowlist next to `deprecate-asset` (which shipped in #6806), plus both templates listed in the auto-close guidance comment. Neither issue type can be auto-closed.
- **New `undeprecate-asset` job** in the deprecate workflow, mirroring the deprecate job: parse → `validate-undeprecate` → `undeprecate-listing` (deletes `manifest.deprecation`) → branch `undeprecate/<id>` → PR for **maintainer merge**. `revalidate` supported.
- **Same strict authorization as deprecation**: original publisher or **active caretaker** only — collaborators cannot un-deprecate. Also rejects unknown IDs and listings that aren't deprecated.
- **Reversal is complete by construction**: everything (published integrity view, search visibility, downloadability) derives from the manifest field, and the integrity cache retains the true computed state throughout a deprecation (#6838) — so removing the field self-heals on the next pipeline run with no recheck storm and no residue.
- README: submit-list entry + reversibility note + `revalidate` scope.

## Tests
8 new integration tests (publisher/caretaker pass, collaborator/stranger rejected, unknown ID, not-deprecated rejection for both validate and mutate, field removal preserves the rest of the manifest). Clean suite: **341 pass / 0 fail** (clean `.test-dist` rebuild — the stale-dist gotcha strikes again across branch switches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)