### PR TITLE
docs: correct deprecation copy — hidden by default, not unsearchable

### DIFF
--- a/.github/ISSUE_TEMPLATE/deprecate-asset.yml
+++ b/.github/ISSUE_TEMPLATE/deprecate-asset.yml
@@ -8,9 +8,11 @@ body:
       value: |
         ## Deprecate an Asset
 
-        Deprecating an asset removes it from downloads and search across the Railyard app and
-        website. Your listing, download history, and author attribution are **kept** — deprecation
-        is not deletion, and your download counts remain credited to you permanently.
+        Deprecating an asset makes it no longer downloadable and hides it from browse and
+        search results by default across the Railyard app and website (it stays viewable behind
+        the Deprecated filter). Your listing, download history, and author attribution are
+        **kept** — deprecation is not deletion, and your download counts remain credited to you
+        permanently.
 
         Only the asset's **original publisher or its active caretaker** can deprecate it.
         Collaborators cannot. This form works for both mods and maps — just enter the asset ID.
@@ -41,7 +43,7 @@ body:
       label: Confirmation
       options:
         - label: >
-            I understand this asset will no longer be downloadable or appear in search once a
-            maintainer merges the deprecation, and that undoing this requires contacting a
-            maintainer.
+            I understand this asset will no longer be downloadable and will be hidden from
+            browse by default once a maintainer merges the deprecation, and that it can be
+            restored via the Remove Asset Deprecation form.
           required: true

--- a/.github/ISSUE_TEMPLATE/undeprecate-asset.yml
+++ b/.github/ISSUE_TEMPLATE/undeprecate-asset.yml
@@ -9,7 +9,8 @@ body:
         ## Remove Asset Deprecation
 
         This restores a previously deprecated asset: once a maintainer merges the resulting pull
-        request, the next registry pipeline run makes it downloadable and searchable again.
+        request, the next registry pipeline run makes it downloadable and visible in browse by
+        default again.
 
         Only the asset's **original publisher or its active caretaker** can remove a deprecation.
         Collaborators cannot. This form works for both mods and maps — just enter the asset ID.
@@ -32,5 +33,5 @@ body:
       options:
         - label: >
             I am the original publisher or active caretaker of this asset and want it restored to
-            the registry as downloadable and searchable.
+            the registry as downloadable and visible in browse by default.
           required: true

--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -126,8 +126,9 @@ jobs:
                 'Fixes #${{ github.event.issue.number }}',
                 '',
                 'Automated PR to deprecate `${{ fromJson(steps.parser.outputs.jsonString).asset-id }}`.',
-                'On merge, the next pipeline run removes it from installable versions and search;',
-                'the listing, download history, and author attribution are retained.',
+                'On merge, the next pipeline run removes its installable versions; the listing is',
+                'hidden from browse by default (still viewable behind the Deprecated filter), and',
+                'its download history and author attribution are retained.',
                 '',
                 'Requested by @${{ github.event.issue.user.login }} (verified author or active caretaker).'
               ].join('\n'),
@@ -296,8 +297,8 @@ jobs:
                 'Fixes #${{ github.event.issue.number }}',
                 '',
                 'Automated PR to remove the deprecation from `${{ fromJson(steps.parser.outputs.jsonString).asset-id }}`.',
-                'On merge, the next pipeline run restores it as downloadable and searchable',
-                '(the integrity cache retained its true state throughout the deprecation).',
+                'On merge, the next pipeline run restores it as downloadable and visible in browse',
+                'by default (the integrity cache retained its true state throughout the deprecation).',
                 '',
                 'Requested by @${{ github.event.issue.user.login }} (verified author or active caretaker).'
               ].join('\n'),

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ All submissions are handled through GitHub Issues. Pick a template to get starte
 
 Deprecation is asset-type agnostic (mods and maps share one form) and is restricted to the
 listing's original publisher or its **active caretaker** — collaborators cannot deprecate.
-A deprecated listing stops being downloadable and drops out of search, but the listing itself,
-its download history, and its author attribution are kept permanently. Deprecation is fully
-reversible via the Remove Asset Deprecation form (same authorization rule).
+A deprecated listing stops being downloadable and is hidden from browse and search results by
+default (it remains viewable behind the Deprecated filter on the app and website), and the
+listing itself, its download history, and its author attribution are kept permanently.
+Deprecation is fully reversible via the Remove Asset Deprecation form (same authorization rule).
 
 ## How It Works
 


### PR DESCRIPTION
Follow-up to #6806/#6839: the intake forms, automated PR bodies, and README described deprecated assets as removed from search. The shipped behavior (website #603, app #604 pending) is: **no longer downloadable, hidden from browse/search by default, and viewable behind the Deprecated filter** — with self-service reversal via the un-deprecate form.

Copy-only changes across:
- `.github/ISSUE_TEMPLATE/deprecate-asset.yml` (intro + confirmation checkbox — the checkbox also now points at the Remove Asset Deprecation form instead of 'contact a maintainer')
- `.github/ISSUE_TEMPLATE/undeprecate-asset.yml` (intro + confirmation)
- `.github/workflows/deprecate.yml` (both automated PR bodies)
- `README.md` (submit-list policy paragraph)

No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)