### PR TITLE
feat: permanent zz-deprecation-fixture listing (deprecation item 3)

### DIFF
--- a/mods/index.json
+++ b/mods/index.json
@@ -49,6 +49,7 @@
     "track-visualizer",
     "train-anarchy",
     "transit-overlay",
-    "valdotoriums-trains"
+    "valdotoriums-trains",
+    "zz-deprecation-fixture"
   ]
 }

--- a/mods/zz-deprecation-fixture/manifest.json
+++ b/mods/zz-deprecation-fixture/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "zz-deprecation-fixture",
+  "name": "Deprecation Fixture",
+  "author": "subway-builder-modded-admin",
+  "github_id": 268817724,
+  "description": "Permanent synthetic listing used to validate deprecated-asset behavior across the Railyard app and website. It has never been installable and carries no releases.",
+  "tags": ["misc"],
+  "gallery": [],
+  "is_test": false,
+  "source": "https://github.com/Subway-Builder-Modded/registry",
+  "update": {
+    "type": "github",
+    "repo": "subway-builder-modded/zz-deprecation-fixture"
+  },
+  "deprecation": {
+    "since": "2026-08-04T00:00:00Z",
+    "by_github_id": 268817724,
+    "reason": "Permanent synthetic fixture for validating deprecation behavior across clients; this listing was never a real mod."
+  }
+}


### PR DESCRIPTION
Adds a synthetic, **deprecated-from-birth** mod listing (`zz-deprecation-fixture`, admin-authored, no releases) as a persisted test target for deprecation behavior:

- **Existing clients** (old app builds, pre-#603 website): must NOT show it — the pipeline's deprecation overlay publishes it with zero complete versions, which old clients treat as delisted/ineligible.
- **New website** (#603): appears only behind Visibility → Deprecated, sorted last, with the reason on its detail page and no download path.
- **App after #604**: appears only behind the Deprecated facet with the gray badge; install hard-blocked.

Safety properties verified against the pipeline code before adding:
- **No Discord announcement**: `buildPendingAnnouncements` selects listings whose published integrity newly shows `has_complete_version=true` — the overlay guarantees this never happens for deprecated listings.
- **No analytics/most_popular rows**: no releases → empty downloads entry → analytics skips it.
- **No noise**: integrity alerts + outbound warnings are suppressed for deprecated listings, so the nonexistent update repo never nags anyone.
- `is_test` is deliberately **false** — test listings are invisible on the website entirely and rejected by deprecation validation, which would defeat the purpose of the fixture.

After merge, the next hourly pipeline run materializes its integrity entry and the fixture becomes permanently available for client validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)