### PR TITLE
feat: targeted per-listing integrity recheck (retro game_version enabler)

### DIFF
--- a/.github/workflows/regenerate-registry-analytics.yml
+++ b/.github/workflows/regenerate-registry-analytics.yml
@@ -20,6 +20,15 @@ on:
         required: false
         type: boolean
         default: false
+      force_recheck_listings:
+        description: >-
+          Comma-separated listing ids whose integrity cache should be bypassed
+          this run (targeted alternative to force_integrity_recheck — use when
+          a listing's release assets were edited in place, e.g. a retroactive
+          game_version change via a replaced manifest.json asset).
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -130,6 +139,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          FORCE_INTEGRITY_RECHECK_LISTINGS: ${{ github.event_name == 'workflow_dispatch' && inputs.force_recheck_listings || '' }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force_integrity_recheck }}" = "true" ]; then
             pnpm --dir scripts run generate-registry-analytics:maps -- --strict-fingerprint-cache --force-integrity
@@ -199,6 +209,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          FORCE_INTEGRITY_RECHECK_LISTINGS: ${{ github.event_name == 'workflow_dispatch' && inputs.force_recheck_listings || '' }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force_integrity_recheck }}" = "true" ]; then
             pnpm --dir scripts run generate-registry-analytics:mods -- --strict-fingerprint-cache --force-integrity

--- a/scripts/downloads/generate-downloads.ts
+++ b/scripts/downloads/generate-downloads.ts
@@ -200,6 +200,19 @@ async function run(): Promise<void> {
     || hasFlag(argv, "force-integrity")
     || isTruthyEnv(process.env.FORCE_INTEGRITY_RECHECK)
   );
+  // Comma-separated listing ids whose integrity cache should be bypassed this
+  // run — the targeted alternative to a global forced recheck (see
+  // GenerateDownloadsOptions.forceRecheckListings). Ids not in this run's
+  // listing type are simply never matched, so one value can be passed to both
+  // the map and mod invocations.
+  const forceRecheckListings = (
+    getFlagValue(argv, "force-recheck-listings")
+    ?? process.env.FORCE_INTEGRITY_RECHECK_LISTINGS
+    ?? ""
+  )
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
   const repoRoot = process.env.RAILYARD_REPO_ROOT ?? resolveRepoRoot(import.meta.dirname);
   const runId = getNonEmptyEnv("GITHUB_RUN_ID") ?? "local";
   const jobId = getNonEmptyEnv("GITHUB_JOB") ?? "manual";
@@ -249,6 +262,7 @@ async function run(): Promise<void> {
     mode,
     strictFingerprintCache,
     forceIntegrityRecheck,
+    forceRecheckListings,
     token,
     attribution: {
       ledger: attributionLedger,
@@ -416,6 +430,11 @@ async function run(): Promise<void> {
   );
   if (forceIntegrityRecheck) {
     console.log("[downloads] Force integrity recheck: enabled");
+  }
+  if (forceRecheckListings.length > 0) {
+    console.log(
+      `[downloads] Forced recheck listings: ${forceRecheckListings.join(", ")}`,
+    );
   }
   console.log(
     `[downloads] GraphQL usage: queries=${rateLimit.queries}, totalCost=${rateLimit.totalCost}, firstRemaining=${rateLimit.firstRemaining ?? "n/a"}, lastRemaining=${rateLimit.lastRemaining ?? "n/a"}, estimatedConsumed=${rateLimit.estimatedConsumed ?? "n/a"}, resetAt=${rateLimit.resetAt ?? "n/a"}`,

--- a/scripts/lib/download-definitions.ts
+++ b/scripts/lib/download-definitions.ts
@@ -107,6 +107,13 @@ export interface GenerateDownloadsOptions {
   mode?: "full" | "download-only";
   strictFingerprintCache?: boolean;
   forceIntegrityRecheck?: boolean;
+  // Per-listing forced recheck: bypasses the integrity cache for ONLY these
+  // listing ids. The safe alternative to a global forced recheck (which
+  // re-inspects every release and risks rate-limit cascades) when a listing's
+  // release assets were edited in place — e.g. a retroactive game_version
+  // change via a replaced manifest.json asset, which the zip-only
+  // fingerprint/clobber detection cannot see.
+  forceRecheckListings?: string[];
   attribution?: {
     ledger: DownloadAttributionLedger;
     delta: DownloadAttributionDelta;

--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -444,6 +444,7 @@ function shouldReuseGithubCacheEntry(
   fingerprint: string,
   currentZipSizes: Record<string, number>,
   currentZipUpdatedAt: Record<string, string>,
+  currentManifestUpdatedAt: string | null,
 ): boolean {
   let shouldReuseCached = (
     !ctx.forceIntegrityRecheck
@@ -472,6 +473,18 @@ function shouldReuseGithubCacheEntry(
     );
     if (updatedAtMismatch || sizeMismatch) {
       warnListing(ctx.warnings, listingId, "zip asset replaced since last inspection; forcing re-check", tag);
+      shouldReuseCached = false;
+    }
+    // The release's manifest.json asset (the game_version source) is not part
+    // of the fingerprint or the zip maps above, so retroactive edits to it are
+    // tracked separately. Legacy entries (field absent) are backfilled on
+    // reuse rather than invalidated.
+    if (
+      shouldReuseCached
+      && cached.manifest_asset_updated_at !== undefined
+      && cached.manifest_asset_updated_at !== currentManifestUpdatedAt
+    ) {
+      warnListing(ctx.warnings, listingId, "release manifest.json asset changed since last inspection; forcing re-check", tag);
       shouldReuseCached = false;
     }
   }
@@ -579,6 +592,7 @@ function storeGithubInspectionResult(
   fingerprint: string,
   currentZipSizes: Record<string, number>,
   currentZipUpdatedAt: Record<string, string>,
+  currentManifestUpdatedAt: string | null,
 ): void {
   const previousVersionEntry = ctx.previousIntegrity?.listings[listingId]?.versions?.[tag];
   const zipSizesEntry = Object.keys(currentZipSizes).length > 0 ? currentZipSizes : undefined;
@@ -591,6 +605,7 @@ function storeGithubInspectionResult(
       result: previousVersionEntry!,
       asset_sizes: zipSizesEntry,
       asset_updated_at: zipUpdatedAtEntry,
+      manifest_asset_updated_at: currentManifestUpdatedAt,
     };
     const failingKeys = Object.entries(result.required_checks)
       .filter(([, v]) => !v).map(([k]) => k).join(", ");
@@ -603,6 +618,7 @@ function storeGithubInspectionResult(
       result,
       asset_sizes: zipSizesEntry,
       asset_updated_at: zipUpdatedAtEntry,
+      manifest_asset_updated_at: currentManifestUpdatedAt,
     };
   }
 }
@@ -712,6 +728,7 @@ async function evaluateGithubListing(
     const currentZipUpdatedAt: Record<string, string> = Object.fromEntries(
       zipAssets.flatMap(([name, a]) => a.assetUpdatedAt != null ? [[name, a.assetUpdatedAt]] : []),
     );
+    const currentManifestUpdatedAt = releaseData.assets.get("manifest.json")?.assetUpdatedAt ?? null;
     const shouldReuseCached = shouldReuseGithubCacheEntry(
       ctx,
       id,
@@ -720,6 +737,7 @@ async function evaluateGithubListing(
       fingerprint,
       currentZipSizes,
       currentZipUpdatedAt,
+      currentManifestUpdatedAt,
     );
 
     if (shouldReuseCached) {
@@ -741,6 +759,11 @@ async function evaluateGithubListing(
       state.nextListingCacheEntries[tag] = {
         ...cached,
         result,
+        // Backfill manifest tracking on legacy entries so future retroactive
+        // manifest.json edits are detected from this point on.
+        manifest_asset_updated_at: cached.manifest_asset_updated_at !== undefined
+          ? cached.manifest_asset_updated_at
+          : currentManifestUpdatedAt,
       };
     } else if (!isSupportedReleaseTag(tag)) {
       const result = buildIncompleteVersionEntry(
@@ -789,6 +812,7 @@ async function evaluateGithubListing(
         fingerprint,
         currentZipSizes,
         currentZipUpdatedAt,
+        currentManifestUpdatedAt,
       );
     }
 

--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -288,6 +288,7 @@ interface FullRunContext {
   stats: FullRunStats;
   strictFingerprintCacheForMods: boolean;
   forceIntegrityRecheck: boolean;
+  forceRecheckListings: ReadonlySet<string>;
   modSecurityRules: LoadedSecurityRules | null;
   attributionLedger: DownloadAttributionLedger;
   attributionDelta: DownloadAttributionDelta;
@@ -446,6 +447,7 @@ function shouldReuseGithubCacheEntry(
 ): boolean {
   let shouldReuseCached = (
     !ctx.forceIntegrityRecheck
+    && !ctx.forceRecheckListings.has(listingId)
     && shouldUseCachedIntegrity(
       cached,
       fingerprint,
@@ -1083,6 +1085,7 @@ async function evaluateCustomListing(
     const cached = state.listingCacheEntries[versionKey];
     const shouldReuseCached = (
       !ctx.forceIntegrityRecheck
+      && !ctx.forceRecheckListings.has(id)
       && shouldUseCachedIntegrity(
         cached,
         fingerprint,
@@ -1291,6 +1294,9 @@ export async function generateDownloadsDataFull(
   const token = options.token;
   const strictFingerprintCache = options.strictFingerprintCache === true;
   const forceIntegrityRecheck = options.forceIntegrityRecheck === true;
+  const forceRecheckListings: ReadonlySet<string> = new Set(
+    (options.forceRecheckListings ?? []).map((id) => id.trim()).filter(Boolean),
+  );
   const strictFingerprintCacheForMods = getStrictFingerprintCacheForListingType(
     listingType,
     strictFingerprintCache,
@@ -1359,6 +1365,7 @@ export async function generateDownloadsDataFull(
     },
     strictFingerprintCacheForMods,
     forceIntegrityRecheck,
+    forceRecheckListings,
     modSecurityRules,
     attributionLedger,
     attributionDelta,

--- a/scripts/lib/downloads-support.ts
+++ b/scripts/lib/downloads-support.ts
@@ -179,12 +179,19 @@ export function loadIntegrityCache(repoRoot: string, dir: ManifestDirectory): In
           (versionValue as { asset_updated_at?: unknown }).asset_updated_at,
           (value): value is string => typeof value === "string" && value.trim() !== "",
         );
+        const manifestAssetUpdatedAt = (versionValue as { manifest_asset_updated_at?: unknown }).manifest_asset_updated_at;
         versionEntries[version] = {
           fingerprint,
           last_checked_at: lastCheckedAt,
           result: result as IntegrityVersionEntry,
           ...(assetSizes ? { asset_sizes: assetSizes } : {}),
           ...(assetUpdatedAt ? { asset_updated_at: assetUpdatedAt } : {}),
+          // null is meaningful (inspected, no manifest asset present) and must
+          // round-trip distinctly from absent (legacy entry, pending backfill).
+          ...(manifestAssetUpdatedAt === null
+            || (typeof manifestAssetUpdatedAt === "string" && manifestAssetUpdatedAt.trim() !== "")
+            ? { manifest_asset_updated_at: manifestAssetUpdatedAt as string | null }
+            : {}),
         };
       }
       entries[listingId] = versionEntries;

--- a/scripts/lib/integrity.ts
+++ b/scripts/lib/integrity.ts
@@ -111,6 +111,12 @@ export interface IntegrityCacheEntry {
   // GitHub `updatedAt` timestamps of ZIP assets at inspection time. Preferred over asset_sizes for clobber
   // detection since version-string-only changes (e.g. "0.2.0"→"0.3.0") produce same-size ZIPs.
   asset_updated_at?: Record<string, string>;
+  // GitHub `updatedAt` of the release's manifest.json asset (the game_version
+  // source) at inspection time; null = inspected and no manifest asset was
+  // present; absent = legacy entry (backfilled silently on next cache hit).
+  // A change (replace, add, or remove) forces a re-check so retroactive
+  // game_version edits propagate without a manual forced recheck.
+  manifest_asset_updated_at?: string | null;
 }
 
 export interface IntegrityCache {

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -2071,3 +2071,107 @@ test("forceRecheckListings bypasses the cache for only the named listing and pic
     assert.equal(forced.integrity.listings["gv-mod"]?.versions["v1.0.0"]?.is_complete, true);
   });
 });
+
+test("manifest.json asset replacement is auto-detected via updatedAt tracking; legacy entries backfill without invalidation", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["auto-gv-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "auto-gv-mod", {
+      ...makeBaseModManifest("auto-gv-mod"),
+      update: { type: "github", repo: "Owner/AutoGvMod" },
+    });
+
+    const validZip = await makeModZip(true);
+    let releaseManifestGameRange = ">=1.0.0";
+    let manifestAssetUpdatedAt = "2026-01-01T00:00:00Z";
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://downloads.example.com/auto-gv-mod.zip",
+        handle: () => new Response(new Uint8Array(validZip)),
+      },
+      {
+        match: (url) => url === "https://downloads.example.com/auto-gv-manifest.json",
+        handle: () => jsonResponse({
+          dependencies: { "subway-builder": releaseManifestGameRange },
+        }),
+      },
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: () => jsonResponse({
+          data: {
+            repository: {
+              releases: {
+                nodes: [
+                  {
+                    tagName: "v1.0.0",
+                    releaseAssets: {
+                      nodes: [
+                        {
+                          name: "mod.zip",
+                          downloadCount: 3,
+                          downloadUrl: "https://downloads.example.com/auto-gv-mod.zip",
+                          updatedAt: "2026-01-01T00:00:00Z",
+                        },
+                        {
+                          name: "manifest.json",
+                          downloadCount: 0,
+                          downloadUrl: "https://downloads.example.com/auto-gv-manifest.json",
+                          updatedAt: manifestAssetUpdatedAt,
+                        },
+                      ],
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                    },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        }),
+      },
+    ]);
+
+    const run = () => generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    const first = await run();
+    assert.equal(first.integrity.listings["auto-gv-mod"]?.versions["v1.0.0"]?.game_version, ">=1.0.0");
+    writeJson(join(repoRoot, "mods", "integrity-cache.json"), first.integrityCache);
+
+    const second = await run();
+    assert.equal(second.stats.cache_hits, 1);
+
+    // Author replaces manifest.json (new updatedAt, new range): the regular
+    // run detects it and re-parses game_version — no manual force needed.
+    releaseManifestGameRange = "<=1.3.0";
+    manifestAssetUpdatedAt = "2026-08-04T00:00:00Z";
+    writeJson(join(repoRoot, "mods", "integrity-cache.json"), second.integrityCache);
+    const third = await run();
+    assert.equal(third.stats.cache_hits, 0);
+    assert.equal(third.integrity.listings["auto-gv-mod"]?.versions["v1.0.0"]?.game_version, "<=1.3.0");
+
+    // Legacy entry (no manifest tracking recorded): a manifest change is NOT
+    // detected — the entry is backfilled silently instead of invalidated...
+    const legacyCache = JSON.parse(JSON.stringify(third.integrityCache)) as {
+      entries: Record<string, Record<string, { manifest_asset_updated_at?: string | null }>>;
+    };
+    delete legacyCache.entries["auto-gv-mod"]["v1.0.0"].manifest_asset_updated_at;
+    writeJson(join(repoRoot, "mods", "integrity-cache.json"), legacyCache);
+    releaseManifestGameRange = ">=1.0.0 <=1.2.0";
+    manifestAssetUpdatedAt = "2026-08-05T00:00:00Z";
+    const backfillRun = await run();
+    assert.equal(backfillRun.stats.cache_hits, 1);
+    assert.equal(backfillRun.integrity.listings["auto-gv-mod"]?.versions["v1.0.0"]?.game_version, "<=1.3.0");
+
+    // ...and once backfilled, the NEXT change is detected normally.
+    writeJson(join(repoRoot, "mods", "integrity-cache.json"), backfillRun.integrityCache);
+    manifestAssetUpdatedAt = "2026-08-06T00:00:00Z";
+    const afterBackfill = await run();
+    assert.equal(afterBackfill.stats.cache_hits, 0);
+    assert.equal(afterBackfill.integrity.listings["auto-gv-mod"]?.versions["v1.0.0"]?.game_version, ">=1.0.0 <=1.2.0");
+  });
+});

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -1974,3 +1974,100 @@ test("full mode detects a same-size asset replacement across runs and forces a r
     assert.equal(second.integrity.listings["clobber-mod"]?.versions["v1.0.0"]?.is_complete, true);
   });
 });
+
+test("forceRecheckListings bypasses the cache for only the named listing and picks up a replaced release manifest", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["gv-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "gv-mod", {
+      ...makeBaseModManifest("gv-mod"),
+      update: { type: "github", repo: "Owner/GvMod" },
+    });
+
+    const validZip = await makeModZip(true);
+    // The release's bundled manifest.json is mutable: retroactive game_version
+    // edits replace this asset in place, which the zip-only fingerprint and
+    // clobber detection cannot see.
+    let releaseManifestGameRange = ">=1.0.0";
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://downloads.example.com/gv-mod.zip",
+        handle: () => new Response(new Uint8Array(validZip)),
+      },
+      {
+        match: (url) => url === "https://downloads.example.com/gv-manifest.json",
+        handle: () => jsonResponse({
+          dependencies: { "subway-builder": releaseManifestGameRange },
+        }),
+      },
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: () => jsonResponse({
+          data: {
+            repository: {
+              releases: {
+                nodes: [
+                  {
+                    tagName: "v1.0.0",
+                    releaseAssets: {
+                      nodes: [
+                        { name: "mod.zip", downloadCount: 3, downloadUrl: "https://downloads.example.com/gv-mod.zip" },
+                        { name: "manifest.json", downloadCount: 0, downloadUrl: "https://downloads.example.com/gv-manifest.json" },
+                      ],
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                    },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        }),
+      },
+    ]);
+
+    const first = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+    assert.equal(first.integrity.listings["gv-mod"]?.versions["v1.0.0"]?.game_version, ">=1.0.0");
+    writeJson(join(repoRoot, "mods", "integrity-cache.json"), first.integrityCache);
+
+    // The author replaces the release's manifest.json (zip untouched): an
+    // ordinary run reuses the cache and the old game_version sticks.
+    releaseManifestGameRange = "<=1.3.0";
+    const second = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+    assert.equal(second.stats.cache_hits, 1);
+    assert.equal(second.integrity.listings["gv-mod"]?.versions["v1.0.0"]?.game_version, ">=1.0.0");
+
+    // Forcing a recheck for an UNRELATED listing still reuses the cache.
+    const untargeted = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+      forceRecheckListings: ["some-other-mod"],
+    });
+    assert.equal(untargeted.stats.cache_hits, 1);
+    assert.equal(untargeted.integrity.listings["gv-mod"]?.versions["v1.0.0"]?.game_version, ">=1.0.0");
+
+    // Targeting the listing bypasses its cache and re-parses game_version.
+    const forced = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+      forceRecheckListings: ["gv-mod"],
+    });
+    assert.equal(forced.stats.cache_hits, 0);
+    assert.equal(forced.integrity.listings["gv-mod"]?.versions["v1.0.0"]?.game_version, "<=1.3.0");
+    assert.equal(forced.integrity.listings["gv-mod"]?.versions["v1.0.0"]?.is_complete, true);
+  });
+});


### PR DESCRIPTION
Enabler for retroactive per-version game-version compatibility (item 5). Grounded finding: the integrity cache fingerprint is built from **zip asset names only**, and asset-clobber detection tracks **zip updatedAt/size only** — so when an author replaces a release's bundled `manifest.json` (the source of `game_version` via `dependencies["subway-builder"]`), the pipeline never notices and the cached range sticks forever. The only existing remedy was the **global** `force_integrity_recheck`, i.e. the mass-recheck pattern that produced the 429 cascade.

## What this adds
- `forceRecheckListings` option: cache bypass for only the named listing ids (github + custom paths).
- CLI `--force-recheck-listings a,b` / env `FORCE_INTEGRITY_RECHECK_LISTINGS`.
- `force_recheck_listings` workflow_dispatch input on regenerate-registry-analytics, fed to both map and mod runs (non-matching ids are inert, so one value serves both).

## Test
New integration test modeling the real flow: release `manifest.json` replaced in place → normal run cache-hits and keeps the old `game_version`; recheck targeting a different listing still cache-hits; recheck targeting the listing re-parses and publishes the new range with `is_complete` intact. Suite: **352 pass / 0 fail**.

## First use (queued)
`subwaybuilder-regions`: the five pre-0.5.0 releases' manifests have been updated to `"subway-builder": "<=1.3.0"` (their `maxGameVersion: "1.3.0"` intent was already recorded — but in fields the pipeline never read). After this merges, one dispatch with `force_recheck_listings=subwaybuilder-regions` publishes the caps; every app picks them up on its next registry refresh with zero client changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)