### PR TITLE
fix: suppress repo-level fetch warnings for deprecated/test-only repos

### DIFF
--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -334,6 +334,12 @@ async function resolveListingContexts(params: {
   listingContexts: Map<string, ListingContext>;
   listingMeta: Map<string, ListingMetaEntry>;
   repoSet: Set<string>;
+  // repo -> whether ANY non-deprecated, non-test listing references it. Repos
+  // referenced only by deprecated/test listings get their repo-level fetch
+  // warnings suppressed (a deprecated listing whose repo was deleted must not
+  // warn every run; the repo-scoped GraphQL messages carry no listing id so
+  // the outbound listing-message filters cannot catch them).
+  repoActiveUse: Map<string, boolean>;
   transientErrorListings: Set<string>;
 }): Promise<void> {
   const {
@@ -348,8 +354,14 @@ async function resolveListingContexts(params: {
     listingContexts,
     listingMeta,
     repoSet,
+    repoActiveUse,
     transientErrorListings,
   } = params;
+
+  const markRepoUse = (repo: string, manifest: { is_test?: boolean; deprecation?: unknown }) => {
+    const isActive = !isManifestDeprecated(manifest) && manifest.is_test !== true;
+    repoActiveUse.set(repo, (repoActiveUse.get(repo) ?? false) || isActive);
+  };
 
   // Pace unauthenticated raw.githubusercontent.com custom-update fetches to
   // avoid GitHub secondary rate limits (429s). 200ms between each fetch.
@@ -376,6 +388,7 @@ async function resolveListingContexts(params: {
     if (manifest.update.type === "github") {
       const repo = manifest.update.repo.toLowerCase();
       repoSet.add(repo);
+      markRepoUse(repo, manifest);
       listingContexts.set(id, {
         id,
         listingType,
@@ -399,6 +412,7 @@ async function resolveListingContexts(params: {
     for (const version of customFetch.versions) {
       if (version.parsed) {
         repoSet.add(version.parsed.repo);
+        markRepoUse(version.parsed.repo, manifest);
       }
     }
     listingContexts.set(id, {
@@ -1347,6 +1361,7 @@ export async function generateDownloadsDataFull(
   const listingContexts = new Map<string, ListingContext>();
   const listingMeta = new Map<string, ListingMetaEntry>();
   const repoSet = new Set<string>();
+  const repoActiveUse = new Map<string, boolean>();
   const transientErrorListings = new Set<string>();
 
   await resolveListingContexts({
@@ -1361,15 +1376,20 @@ export async function generateDownloadsDataFull(
     listingContexts,
     listingMeta,
     repoSet,
+    repoActiveUse,
     transientErrorListings,
   });
 
+  const suppressWarningRepos = new Set(
+    [...repoActiveUse].filter(([, hasActiveUse]) => !hasActiveUse).map(([repo]) => repo),
+  );
   const usageState = createGraphqlUsageState();
   const { repoIndexes, unavailableRepos } = await fetchRepoReleaseIndexes(repoSet, {
     fetchImpl,
     token,
     warnings,
     usageState,
+    suppressWarningRepos,
   });
 
   const ctx: FullRunContext = {

--- a/scripts/lib/release-resolution.ts
+++ b/scripts/lib/release-resolution.ts
@@ -338,6 +338,10 @@ export async function fetchRepoReleaseIndexes(
     token?: string;
     warnings: string[];
     usageState?: D.GraphqlUsageState;
+    // Repos referenced only by deprecated/test listings: fetch failures are
+    // expected (deleted/private/nonexistent upstreams) and logged to the
+    // console instead of the outbound warnings channel.
+    suppressWarningRepos?: ReadonlySet<string>;
   },
 ): Promise<{
   repoIndexes: Map<string, D.RepoReleaseIndex>;
@@ -355,14 +359,28 @@ export async function fetchRepoReleaseIndexes(
     .sort();
 
   for (const repo of repoList) {
+    const suppressWarnings = options.suppressWarningRepos?.has(repo) === true;
+    const warningsSink = suppressWarnings ? [] : options.warnings;
     const result = await fetchGraphqlReleaseIndexForRepo(
       repo,
       fetchImpl,
       options.token,
-      options.warnings,
+      warningsSink,
       rateLimitWarningState,
       usageState,
     );
+    if (suppressWarnings && warningsSink.length > 0) {
+      for (const message of warningsSink) {
+        // Only this repo's own messages are suppressed; anything else routed
+        // through the sink (e.g. the shared rate-limit warning) still reaches
+        // the outbound warnings channel.
+        if (message.includes(`repo=${repo}`)) {
+          console.log(`[downloads] suppressed repo warning (deprecated/test-only repo): ${message}`);
+        } else {
+          options.warnings.push(message);
+        }
+      }
+    }
     if (result.index) {
       repoIndexes.set(repo, result.index);
     } else if (result.unavailable) {

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -2175,3 +2175,53 @@ test("manifest.json asset replacement is auto-detected via updatedAt tracking; l
     assert.equal(afterBackfill.integrity.listings["auto-gv-mod"]?.versions["v1.0.0"]?.game_version, ">=1.0.0 <=1.2.0");
   });
 });
+
+test("repo-level fetch warnings are suppressed for repos referenced only by deprecated listings", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["dead-deprecated-mod", "dead-active-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "dead-deprecated-mod", {
+      ...makeBaseModManifest("dead-deprecated-mod"),
+      update: { type: "github", repo: "Gone/DeprecatedRepo" },
+      deprecation: { since: "2026-08-01T00:00:00Z", by_github_id: 1 },
+    });
+    writeManifest("mods", "dead-active-mod", {
+      ...makeBaseModManifest("dead-active-mod"),
+      update: { type: "github", repo: "Gone/ActiveRepo" },
+    });
+
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: async (_input, init) => {
+          const body = String(init?.body ?? "");
+          const repoName = body.includes("DeprecatedRepo") ? "Gone/DeprecatedRepo" : "Gone/ActiveRepo";
+          return jsonResponse({
+            errors: [
+              { message: `Could not resolve to a Repository with the name '${repoName}'.` },
+            ],
+          });
+        },
+      },
+    ]);
+
+    const result = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    const repoWarnings = result.warnings.filter((w) => w.includes("Could not resolve to a Repository"));
+    assert.equal(
+      repoWarnings.some((w) => w.includes("Gone/ActiveRepo".toLowerCase()) || w.includes("gone/activerepo")),
+      true,
+      `expected active-repo warning, got: ${JSON.stringify(result.warnings)}`,
+    );
+    assert.equal(
+      repoWarnings.some((w) => w.toLowerCase().includes("gone/deprecatedrepo")),
+      false,
+      `deprecated-only repo warning leaked: ${JSON.stringify(result.warnings)}`,
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to the deprecation series: the run log showed
`mod: repo=matematysek/prospector: GraphQL errors: Could not resolve...` and the same for `zz-deprecation-fixture` — these are **repo-scoped** warnings from the release-index fetch, emitted before listing evaluation, so they carry no `listing=` prefix and the existing deprecated/test outbound filters can't catch them.

- `resolveListingContexts` now tracks per repo whether any **non-deprecated, non-test** listing references it (github + custom-parsed repos).
- Repos with no active use get their fetch warnings diverted to a console log (`[downloads] suppressed repo warning...`) instead of the outbound warnings channel — a deprecated listing whose upstream was deleted or never existed stays silent forever.
- Shared-repo safety: if any active listing references the same repo, warnings flow exactly as before; and non-repo-scoped messages routed through the sink (the shared rate-limit warning) are forwarded rather than swallowed.

Integration test covers both directions (deprecated-only dead repo suppressed; active dead repo still warns). Suite: **354 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)