### PR TITLE
Flag zz-deprecation-fixture as is_test

### DIFF
--- a/mods/zz-deprecation-fixture/manifest.json
+++ b/mods/zz-deprecation-fixture/manifest.json
@@ -7,7 +7,7 @@
   "description": "Permanent synthetic listing used to validate deprecated-asset behavior across the Railyard app and website. It has never been installable and carries no releases.",
   "tags": ["misc"],
   "gallery": [],
-  "is_test": false,
+  "is_test": true,
   "source": "https://github.com/Subway-Builder-Modded/registry",
   "update": {
     "type": "github",


### PR DESCRIPTION
The permanent deprecation fixture shipped with is_test: false, so it leaks into real analytics (listing counts, the new negative deprecations series on the website) and public browse. Flipping the flag keeps it out of every analytics artifact like other fixtures; deprecation UI validation still works via the dev mock-inject script and the real prospector-ghebeek deprecation.

**Merge timing note:** if you want to first see the fixture's own negative bar on the dev website's New Listings chart (it charts once the 2026-08-04 snapshot lands and the dev site redeploys), merge this after that check — once merged, the fixture is excluded from analytics by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)