### PR TITLE
docs: canonical data-quality questions are a required publishing step; fix template doc links

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-quality.yml
+++ b/.github/ISSUE_TEMPLATE/data-quality.yml
@@ -12,15 +12,17 @@
 
 
         These questions classify the census / official data behind your map so it can
-        receive a data-quality tier. Every question is optional — **leaving a question blank
-        is always safe** — but unanswered questions may keep the map at `unknown-quality`
-        until a reviewer works through them with you.
+        receive a data-quality tier. For new submissions, completing this form is a
+        **required step of publishing** — the publish PR stays draft until a reviewer
+        confirms a score. Every individual question can still be left blank (**leaving a
+        question blank is always safe**); unanswered questions may keep the map at
+        `unknown-quality` until a reviewer works through them with you.
 
 
         Please read the [Submission Questions
-        guide](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — it
-        explains each question in plain language, including the golden rule: **answer with
-        where the numbers are published, not where you placed them**.
+        guide](https://subwaybuildermodded.com/registry/docs/data-quality/submission-questi\
+        ons) — it explains each question in plain language, including the golden rule:
+        **answer with where the numbers are published, not where you placed them**.
 
 
         Your answers produce a provisional score in a pull request; a reviewer confirms it

--- a/.github/ISSUE_TEMPLATE/publish-map.yml
+++ b/.github/ISSUE_TEMPLATE/publish-map.yml
@@ -106,9 +106,9 @@
 
 
         After your submission is validated, you will be invited to answer the [data-quality
-        questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — a
-        **required step**: your map cannot merge until a maintainer confirms your answers,
-        and new submissions are subject to the [quality
+        questions](https://subwaybuildermodded.com/registry/docs/data-quality/submission-qu\
+        estions) — a **required step**: your map cannot merge until a maintainer confirms
+        your answers, and new submissions are subject to the [quality
         floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for
         countries with existing maps."
   - "type": "input"

--- a/.github/ISSUE_TEMPLATE/update-map.yml
+++ b/.github/ISSUE_TEMPLATE/update-map.yml
@@ -96,8 +96,8 @@
 
         Updating metadata does not change your map's data-quality tier. If the underlying
         data changed, submit new answers via the [data-quality
-        questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions)
-        form."
+        questions](https://subwaybuildermodded.com/registry/docs/data-quality/submission-qu\
+        estions) form."
   - "type": "input"
     "id": "data_source"
     "attributes":

--- a/docs/data-quality-questions.md
+++ b/docs/data-quality-questions.md
@@ -1,8 +1,10 @@
 # Data Quality Questions — Guide for Creators
 
-When you publish or update a map, the submission form now asks a short set of **optional** questions
-about the source data you used to create it. This guide explains what each question means, how to answer it, and what
-your answers will be used for.
+When you publish or update a map, the submission form asks a short set of questions about the
+source data you used to create it — answering them is a **required step** of publishing: a new map
+stays at `unknown-quality` and its publish PR cannot merge until a reviewer confirms a score (see the
+[Publishing Content guide](https://subwaybuildermodded.com/registry/docs/publishing-content)). This
+guide explains what each question means, how to answer it, and what your answers will be used for.
 
 Every question has plain-language options, and **"Not sure" is always a safe answer**. Clarifying questions are welcome on the submission issue or in the community [Discord Server](https://discord.gg/syG9YHMyeG).
 

--- a/scripts/intake/generate-map-templates.ts
+++ b/scripts/intake/generate-map-templates.ts
@@ -261,7 +261,7 @@ function withTemplatePolicy(baseDoc: TemplateDoc, mode: TemplateMode): TemplateD
       field.attributes.value.startsWith("## Data Attestation")
     ) {
       field.attributes.value =
-        "## Data Attestation\n\nProvide details about your map's data source. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nUpdating metadata does not change your map's data-quality tier. If the underlying data changed, submit new answers via the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) form.";
+        "## Data Attestation\n\nProvide details about your map's data source. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nUpdating metadata does not change your map's data-quality tier. If the underlying data changed, submit new answers via the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/submission-questions) form.";
     }
   }
 
@@ -307,7 +307,7 @@ const SHARED_FIELDS_AFTER_MAP_ID = [
   spacer(),
   // ===== Data Validation ===== //
   markdown(
-    "## Data Attestation\n\nProvide details about your map's data source. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nAfter your submission is validated, you will be invited to answer the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — a **required step**: your map cannot merge until a maintainer confirms your answers, and new submissions are subject to the [quality floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for countries with existing maps.",
+    "## Data Attestation\n\nProvide details about your map's data source. Be honest and transparent in your descriptions and please include the methodology you used to generate the map's data. See the [Data Quality](https://subwaybuildermodded.com/registry/docs/data-quality) guide for more information.\n\nAfter your submission is validated, you will be invited to answer the [data-quality questions](https://subwaybuildermodded.com/registry/docs/data-quality/submission-questions) — a **required step**: your map cannot merge until a maintainer confirms your answers, and new submissions are subject to the [quality floor](https://subwaybuildermodded.com/registry/docs/data-quality/quality-floor) for countries with existing maps.",
   ),
   input(
     "data_source",
@@ -479,7 +479,7 @@ const dataQualityTemplateBaseDoc: TemplateDoc = {
   labels: ["data-quality"],
   body: [
     markdown(
-      "# Map Data Quality\n\nThese questions classify the census / official data behind your map so it can receive a data-quality tier. Every question is optional — **leaving a question blank is always safe** — but unanswered questions may keep the map at `unknown-quality` until a reviewer works through them with you.\n\nPlease read the [Submission Questions guide](https://subwaybuildermodded.com/registry/docs/data-quality/questions) — it explains each question in plain language, including the golden rule: **answer with where the numbers are published, not where you placed them**.\n\nYour answers produce a provisional score in a pull request; a reviewer confirms it before the tier appears.\n\nIf validation fails, you can edit this issue and comment **revalidate** to retry.",
+      "# Map Data Quality\n\nThese questions classify the census / official data behind your map so it can receive a data-quality tier. For new submissions, completing this form is a **required step of publishing** — the publish PR stays draft until a reviewer confirms a score. Every individual question can still be left blank (**leaving a question blank is always safe**); unanswered questions may keep the map at `unknown-quality` until a reviewer works through them with you.\n\nPlease read the [Submission Questions guide](https://subwaybuildermodded.com/registry/docs/data-quality/submission-questions) — it explains each question in plain language, including the golden rule: **answer with where the numbers are published, not where you placed them**.\n\nYour answers produce a provisional score in a pull request; a reviewer confirms it before the tier appears.\n\nIf validation fails, you can edit this issue and comment **revalidate** to retry.",
     ),
     spacer(),
     mapIdField(


### PR DESCRIPTION
Follow-up 1 of 2 from the docs audit: monorepo #610 corrected the website's *mirror* (`submission-questions.mdx`) to the required-step framing, which left the **canonical** `docs/data-quality-questions.md` out of sync and still claiming the questions are optional.

Both now carry the accurate two-part statement:
- Completing the form is a **required step of publishing** — the publish PR stays draft at `unknown-quality` until a reviewer confirms a score.
- Every **individual question** can still be left blank ("Not sure" is always safe).

Also, in the same sweep:
- The generated map issue templates' intro (via `generate-map-templates.ts`) gets the same clarification — it previously opened with "Every question is optional", which conflated the two senses.
- Their guide links pointed at `/registry/docs/data-quality/questions`, a slug renamed in monorepo #607 (`submission-questions`) — the old URL 404s. All three templates regenerated (`check:map-templates` in sync).

Suite: **354 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)