### PR TITLE
feat: daily lifecycle automation for integrity-alert issues

### DIFF
--- a/.github/workflows/prune-integrity-alerts.yml
+++ b/.github/workflows/prune-integrity-alerts.yml
@@ -1,0 +1,57 @@
+name: Prune Integrity Alert Issues
+
+# Daily lifecycle pass over creator-facing integrity-alert issues:
+# - closes alerts whose failing version now passes integrity (or disappeared,
+#   or whose listing was deprecated/removed) as resolved;
+# - closes alerts with no comment activity for two weeks where the creator
+#   never had the last word (stale) — a recurrence re-fires a fresh alert on
+#   the next integrity state transition;
+# - escalates alerts where the CREATOR's comment has been waiting on a
+#   maintainer for two weeks: labels needs-maintainer and pings maintainers.
+#   Escalated issues are exempt from stale pruning.
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log intended actions without closing/labeling anything
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: prune-integrity-alerts
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: scripts/pnpm-lock.yaml
+
+      - name: Install script dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: scripts
+
+      - name: Prune integrity-alert issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAINTAINER_MENTIONS: ${{ vars.MAINTAINER_MENTIONS || '@ahkimn' }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '1' || '' }}
+        run: pnpm --dir scripts run prune-integrity-alerts

--- a/scripts/lib/integrity-alert-pruning.ts
+++ b/scripts/lib/integrity-alert-pruning.ts
@@ -1,0 +1,139 @@
+import type { IntegrityOutput } from "@subway-builder-modded/registry-schemas";
+
+// Lifecycle automation for creator-facing integrity-alert issues:
+// - RESOLVED alerts (the failing version now passes integrity, disappeared, or
+//   the listing was deprecated) are closed as completed.
+// - STALE alerts (no comment activity for two weeks where the creator never
+//   responded — the last word is the bot's alert or a maintainer's) are closed
+//   as not_planned; a genuine recurrence re-fires a fresh alert on the next
+//   state transition.
+// - Alerts where the LAST comment is from the creator (a non-maintainer) are
+//   ESCALATED instead: labeled needs-maintainer and maintainers are pinged.
+//   Escalated issues are exempt from stale pruning until a human acts.
+
+export const NEEDS_MAINTAINER_LABEL = "needs-maintainer";
+export const STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
+
+const ALERT_TITLE_REGEX = /^\[Integrity\] (\S+) (\S+): failing checks$/;
+
+export interface AlertIssueRef {
+  listingId: string;
+  version: string;
+}
+
+export function parseAlertIssueTitle(title: string): AlertIssueRef | null {
+  const match = ALERT_TITLE_REGEX.exec(title.trim());
+  if (!match) return null;
+  return { listingId: match[1]!, version: match[2]! };
+}
+
+export type AlertResolution =
+  | { resolved: true; reason: "version_complete" | "version_removed" | "listing_removed" | "listing_deprecated" }
+  | { resolved: false };
+
+/**
+ * Determines whether the failure an alert issue describes still exists in the
+ * PUBLISHED integrity outputs. The deprecation overlay reports deprecated
+ * listings with zero complete versions, so deprecation is detected via the
+ * listing_deprecated marker error rather than treated as a live failure.
+ */
+export function resolveAlertAgainstIntegrity(
+  ref: AlertIssueRef,
+  integrityByDir: { maps: IntegrityOutput | null; mods: IntegrityOutput | null },
+): AlertResolution {
+  const listing = integrityByDir.maps?.listings[ref.listingId]
+    ?? integrityByDir.mods?.listings[ref.listingId];
+  if (!listing) {
+    return { resolved: true, reason: "listing_removed" };
+  }
+  const version = listing.versions[ref.version];
+  if (!version) {
+    return { resolved: true, reason: "version_removed" };
+  }
+  if (version.is_complete) {
+    return { resolved: true, reason: "version_complete" };
+  }
+  if (version.errors.includes("listing_deprecated")) {
+    return { resolved: true, reason: "listing_deprecated" };
+  }
+  return { resolved: false };
+}
+
+export interface AlertIssueState {
+  title: string;
+  createdAt: string;
+  labels: string[];
+  // Most recent issue comment, if any. isMaintainer covers repo
+  // admin/maintain collaborators AND bot accounts (the alert body and any
+  // automation comments are the registry's side of the conversation).
+  lastComment: { createdAt: string; isMaintainer: boolean } | null;
+}
+
+export type AlertIssueAction =
+  | { action: "close_resolved"; reason: Extract<AlertResolution, { resolved: true }>["reason"] }
+  | { action: "close_stale" }
+  | { action: "escalate" }
+  | { action: "none"; reason: string };
+
+export function decideAlertIssueAction(
+  issue: AlertIssueState,
+  resolution: AlertResolution,
+  now: Date,
+): AlertIssueAction {
+  if (resolution.resolved) {
+    return { action: "close_resolved", reason: resolution.reason };
+  }
+
+  const lastActivityAt = Date.parse(issue.lastComment?.createdAt ?? issue.createdAt);
+  if (!Number.isFinite(lastActivityAt)) {
+    return { action: "none", reason: "unparseable activity timestamp" };
+  }
+  if (now.getTime() - lastActivityAt < STALE_AFTER_MS) {
+    return { action: "none", reason: "recent activity" };
+  }
+
+  // The creator has the last word: surface it to maintainers (once) instead of
+  // pruning. Already-escalated issues wait for a human.
+  if (issue.lastComment && !issue.lastComment.isMaintainer) {
+    if (issue.labels.includes(NEEDS_MAINTAINER_LABEL)) {
+      return { action: "none", reason: "already escalated" };
+    }
+    return { action: "escalate" };
+  }
+  if (issue.labels.includes(NEEDS_MAINTAINER_LABEL)) {
+    return { action: "none", reason: "escalated; awaiting maintainer" };
+  }
+
+  return { action: "close_stale" };
+}
+
+export function buildResolvedCloseComment(
+  ref: AlertIssueRef,
+  reason: Extract<AlertResolution, { resolved: true }>["reason"],
+): string {
+  switch (reason) {
+    case "version_complete":
+      return `\`${ref.listingId}\` \`${ref.version}\` now passes its integrity checks — closing this alert as resolved. Thanks for fixing it!`;
+    case "version_removed":
+      return `\`${ref.version}\` is no longer part of \`${ref.listingId}\`'s published releases, so this alert no longer applies — closing as resolved.`;
+    case "listing_removed":
+      return `\`${ref.listingId}\` is no longer in the registry, so this alert no longer applies — closing.`;
+    case "listing_deprecated":
+      return `\`${ref.listingId}\` has been deprecated, so its versions are intentionally not installable and this alert no longer applies — closing.`;
+  }
+}
+
+export function buildStaleCloseComment(): string {
+  return (
+    "Closing this alert as stale — there has been no activity for two weeks. "
+    + "The underlying check failure may still exist; if the version starts failing again after a fix attempt, "
+    + "a fresh alert will be opened automatically. Feel free to reopen or comment if you are still working on this."
+  );
+}
+
+export function buildEscalationComment(maintainerMentions: string): string {
+  return (
+    `${maintainerMentions} — the creator responded to this integrity alert and it has been waiting on a maintainer for two weeks. `
+    + `Labeling \`${NEEDS_MAINTAINER_LABEL}\`; this issue is exempt from stale pruning until a maintainer follows up.`
+  );
+}

--- a/scripts/ops/prune-integrity-alerts.ts
+++ b/scripts/ops/prune-integrity-alerts.ts
@@ -1,0 +1,192 @@
+import { resolve } from "node:path";
+import { loadIntegritySnapshot } from "../lib/downloads-support.js";
+import {
+  NEEDS_MAINTAINER_LABEL,
+  buildEscalationComment,
+  buildResolvedCloseComment,
+  buildStaleCloseComment,
+  decideAlertIssueAction,
+  parseAlertIssueTitle,
+  resolveAlertAgainstIntegrity,
+} from "../lib/integrity-alert-pruning.js";
+
+const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
+  ? resolve(process.env.RAILYARD_REPO_ROOT)
+  : resolve(import.meta.dirname, "..", "..");
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY ?? "Subway-Builder-Modded/registry";
+const maintainerMentions = process.env.MAINTAINER_MENTIONS ?? "@ahkimn";
+const dryRun = process.env.DRY_RUN === "1" || process.env.DRY_RUN === "true";
+
+if (!token) {
+  console.error("GITHUB_TOKEN environment variable is required");
+  process.exit(1);
+}
+
+const apiHeaders: Record<string, string> = {
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+
+interface IssueListItem {
+  number: number;
+  title: string;
+  created_at: string;
+  comments: number;
+  labels: Array<{ name?: string }>;
+}
+
+interface IssueComment {
+  created_at: string;
+  user: { login?: string; type?: string } | null;
+}
+
+async function api(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`https://api.github.com${path}`, { ...init, headers: { ...apiHeaders, ...(init?.headers ?? {}) } });
+}
+
+async function listOpenAlertIssues(): Promise<IssueListItem[]> {
+  const issues: IssueListItem[] = [];
+  for (let page = 1; page <= 10; page++) {
+    const response = await api(
+      `/repos/${repository}/issues?labels=integrity-alert&state=open&per_page=100&page=${page}`,
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to list integrity-alert issues: HTTP ${response.status}`);
+    }
+    const batch = await response.json() as IssueListItem[];
+    issues.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return issues;
+}
+
+async function fetchLastComment(issueNumber: number, commentCount: number): Promise<IssueComment | null> {
+  if (commentCount === 0) return null;
+  const response = await api(
+    `/repos/${repository}/issues/${issueNumber}/comments?per_page=1&page=${commentCount}`,
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch comments for #${issueNumber}: HTTP ${response.status}`);
+  }
+  const comments = await response.json() as IssueComment[];
+  return comments[comments.length - 1] ?? null;
+}
+
+const maintainerCache = new Map<string, boolean>();
+
+async function isMaintainerSide(user: IssueComment["user"]): Promise<boolean> {
+  const login = user?.login ?? "";
+  if (!login) return true;
+  if (user?.type === "Bot" || login.endsWith("[bot]")) return true;
+  const cached = maintainerCache.get(login);
+  if (cached !== undefined) return cached;
+  const response = await api(`/repos/${repository}/collaborators/${login}/permission`);
+  let maintainer = false;
+  if (response.ok) {
+    const payload = await response.json() as { role_name?: string; permission?: string };
+    const role = payload.role_name ?? payload.permission ?? "";
+    maintainer = role === "admin" || role === "maintain";
+  }
+  maintainerCache.set(login, maintainer);
+  return maintainer;
+}
+
+async function comment(issueNumber: number, body: string): Promise<void> {
+  const response = await api(`/repos/${repository}/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+  });
+  if (!response.ok) throw new Error(`Failed to comment on #${issueNumber}: HTTP ${response.status}`);
+}
+
+async function closeIssue(issueNumber: number, stateReason: "completed" | "not_planned"): Promise<void> {
+  const response = await api(`/repos/${repository}/issues/${issueNumber}`, {
+    method: "PATCH",
+    body: JSON.stringify({ state: "closed", state_reason: stateReason }),
+  });
+  if (!response.ok) throw new Error(`Failed to close #${issueNumber}: HTTP ${response.status}`);
+}
+
+async function addLabel(issueNumber: number, label: string): Promise<void> {
+  const response = await api(`/repos/${repository}/issues/${issueNumber}/labels`, {
+    method: "POST",
+    body: JSON.stringify({ labels: [label] }),
+  });
+  if (!response.ok) throw new Error(`Failed to label #${issueNumber}: HTTP ${response.status}`);
+}
+
+async function main(): Promise<void> {
+  const integrityByDir = {
+    maps: loadIntegritySnapshot(REPO_ROOT, "maps"),
+    mods: loadIntegritySnapshot(REPO_ROOT, "mods"),
+  };
+  const now = new Date();
+  const issues = await listOpenAlertIssues();
+  console.log(`[prune-alerts] ${issues.length} open integrity-alert issue(s)`);
+
+  const summary = { closed_resolved: 0, closed_stale: 0, escalated: 0, skipped: 0 };
+  for (const issue of issues) {
+    const ref = parseAlertIssueTitle(issue.title);
+    if (!ref) {
+      console.log(`[prune-alerts] #${issue.number} skipped (unrecognized title: ${issue.title})`);
+      summary.skipped += 1;
+      continue;
+    }
+
+    const lastCommentRaw = await fetchLastComment(issue.number, issue.comments);
+    const lastComment = lastCommentRaw
+      ? { createdAt: lastCommentRaw.created_at, isMaintainer: await isMaintainerSide(lastCommentRaw.user) }
+      : null;
+    const resolution = resolveAlertAgainstIntegrity(ref, integrityByDir);
+    const decision = decideAlertIssueAction(
+      {
+        title: issue.title,
+        createdAt: issue.created_at,
+        labels: issue.labels.map((label) => label.name ?? ""),
+        lastComment,
+      },
+      resolution,
+      now,
+    );
+
+    const describe = `#${issue.number} (${ref.listingId} ${ref.version})`;
+    if (decision.action === "none") {
+      console.log(`[prune-alerts] ${describe}: no action (${decision.reason})`);
+      summary.skipped += 1;
+      continue;
+    }
+    if (dryRun) {
+      console.log(`[prune-alerts] ${describe}: DRY RUN — would ${decision.action}`);
+      continue;
+    }
+
+    if (decision.action === "close_resolved") {
+      await comment(issue.number, buildResolvedCloseComment(ref, decision.reason));
+      await closeIssue(issue.number, "completed");
+      console.log(`[prune-alerts] ${describe}: closed as resolved (${decision.reason})`);
+      summary.closed_resolved += 1;
+    } else if (decision.action === "close_stale") {
+      await comment(issue.number, buildStaleCloseComment());
+      await closeIssue(issue.number, "not_planned");
+      console.log(`[prune-alerts] ${describe}: closed as stale`);
+      summary.closed_stale += 1;
+    } else {
+      await addLabel(issue.number, NEEDS_MAINTAINER_LABEL);
+      await comment(issue.number, buildEscalationComment(maintainerMentions));
+      console.log(`[prune-alerts] ${describe}: escalated to maintainers`);
+      summary.escalated += 1;
+    }
+  }
+
+  console.log(
+    `[prune-alerts] Done: resolved=${summary.closed_resolved}, stale=${summary.closed_stale}, escalated=${summary.escalated}, skipped=${summary.skipped}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(`[prune-alerts] Failed: ${(error as Error).message}`);
+  process.exit(1);
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -42,6 +42,7 @@
     "backfill-download-attribution": "tsx ops/backfill-download-attribution.ts",
     "spotcheck-attribution-logs": "tsx ops/spotcheck-attribution-logs.ts",
     "create-manual-download-attribution": "tsx ops/create-manual-download-attribution.ts",
+    "prune-integrity-alerts": "tsx ops/prune-integrity-alerts.ts",
     "rebuild-download-version-buckets": "tsx ops/rebuild-download-version-buckets.ts",
     "reconcile-attributed-downloads": "tsx downloads/reconcile-attributed-downloads.ts",
     "analytics": "tsx downloads/generate-analytics.ts",

--- a/scripts/tests/integrity-alert-pruning.unit.test.ts
+++ b/scripts/tests/integrity-alert-pruning.unit.test.ts
@@ -1,0 +1,176 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { IntegrityOutput } from "@subway-builder-modded/registry-schemas";
+import {
+  NEEDS_MAINTAINER_LABEL,
+  decideAlertIssueAction,
+  parseAlertIssueTitle,
+  resolveAlertAgainstIntegrity,
+} from "../lib/integrity-alert-pruning.js";
+
+const NOW = new Date("2026-08-20T00:00:00Z");
+const SIXTEEN_DAYS_AGO = "2026-08-04T00:00:00Z";
+const TWO_DAYS_AGO = "2026-08-18T00:00:00Z";
+
+function versionEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    is_complete: false,
+    errors: ["config_version_matches_tag failed"],
+    required_checks: { config_version_matches_tag: false },
+    matched_files: {},
+    source: { update_type: "github" as const },
+    fingerprint: "f",
+    checked_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function integrityWith(listingId: string, versions: Record<string, ReturnType<typeof versionEntry>>): IntegrityOutput {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-20T00:00:00Z",
+    listings: {
+      [listingId]: {
+        has_complete_version: Object.values(versions).some((v) => v.is_complete),
+        latest_semver_version: null,
+        latest_semver_complete: null,
+        complete_versions: [],
+        incomplete_versions: Object.keys(versions),
+        versions,
+      },
+    },
+  };
+}
+
+// --- title parsing ---
+
+test("parses the alert issue title format", () => {
+  assert.deepEqual(parseAlertIssueTitle("[Integrity] my-map v1.2.0: failing checks"), {
+    listingId: "my-map",
+    version: "v1.2.0",
+  });
+  assert.equal(parseAlertIssueTitle("[Deprecate]: Prospector"), null);
+  assert.equal(parseAlertIssueTitle("random title"), null);
+});
+
+// --- resolution against integrity ---
+
+test("resolution: version now complete", () => {
+  const integrity = integrityWith("my-map", { "v1.0.0": versionEntry({ is_complete: true, errors: [] }) });
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "my-map", version: "v1.0.0" }, { maps: integrity, mods: null }),
+    { resolved: true, reason: "version_complete" },
+  );
+});
+
+test("resolution: version still failing", () => {
+  const integrity = integrityWith("my-map", { "v1.0.0": versionEntry() });
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "my-map", version: "v1.0.0" }, { maps: integrity, mods: null }),
+    { resolved: false },
+  );
+});
+
+test("resolution: version removed / listing removed / deprecated", () => {
+  const integrity = integrityWith("my-map", { "v2.0.0": versionEntry() });
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "my-map", version: "v1.0.0" }, { maps: integrity, mods: null }),
+    { resolved: true, reason: "version_removed" },
+  );
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "gone-map", version: "v1.0.0" }, { maps: integrity, mods: null }),
+    { resolved: true, reason: "listing_removed" },
+  );
+  const deprecated = integrityWith("old-mod", {
+    "v1.0.0": versionEntry({ errors: ["config_version_matches_tag failed", "listing_deprecated"] }),
+  });
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "old-mod", version: "v1.0.0" }, { maps: null, mods: deprecated }),
+    { resolved: true, reason: "listing_deprecated" },
+  );
+});
+
+test("resolution: mods integrity is consulted when maps misses", () => {
+  const mods = integrityWith("some-mod", { "v1.0.0": versionEntry({ is_complete: true }) });
+  const maps = integrityWith("other-map", { "v9.0.0": versionEntry() });
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "some-mod", version: "v1.0.0" }, { maps, mods }),
+    { resolved: true, reason: "version_complete" },
+  );
+});
+
+// --- decision logic ---
+
+const BASE_ISSUE = {
+  title: "[Integrity] my-map v1.0.0: failing checks",
+  createdAt: SIXTEEN_DAYS_AGO,
+  labels: [] as string[],
+  lastComment: null,
+};
+
+test("resolved alerts close regardless of activity", () => {
+  const decision = decideAlertIssueAction(
+    { ...BASE_ISSUE, lastComment: { createdAt: TWO_DAYS_AGO, isMaintainer: false } },
+    { resolved: true, reason: "version_complete" },
+    NOW,
+  );
+  assert.deepEqual(decision, { action: "close_resolved", reason: "version_complete" });
+});
+
+test("recent activity is left alone", () => {
+  const decision = decideAlertIssueAction(
+    { ...BASE_ISSUE, lastComment: { createdAt: TWO_DAYS_AGO, isMaintainer: true } },
+    { resolved: false },
+    NOW,
+  );
+  assert.deepEqual(decision, { action: "none", reason: "recent activity" });
+});
+
+test("stale with no comments at all is pruned", () => {
+  const decision = decideAlertIssueAction(BASE_ISSUE, { resolved: false }, NOW);
+  assert.deepEqual(decision, { action: "close_stale" });
+});
+
+test("stale with a maintainer's last word is pruned", () => {
+  const decision = decideAlertIssueAction(
+    { ...BASE_ISSUE, lastComment: { createdAt: SIXTEEN_DAYS_AGO, isMaintainer: true } },
+    { resolved: false },
+    NOW,
+  );
+  assert.deepEqual(decision, { action: "close_stale" });
+});
+
+test("stale with the creator's last word escalates instead of pruning", () => {
+  const decision = decideAlertIssueAction(
+    { ...BASE_ISSUE, lastComment: { createdAt: SIXTEEN_DAYS_AGO, isMaintainer: false } },
+    { resolved: false },
+    NOW,
+  );
+  assert.deepEqual(decision, { action: "escalate" });
+});
+
+test("escalated issues are exempt from both re-escalation and pruning", () => {
+  const escalatedByCreator = decideAlertIssueAction(
+    {
+      ...BASE_ISSUE,
+      labels: [NEEDS_MAINTAINER_LABEL],
+      lastComment: { createdAt: SIXTEEN_DAYS_AGO, isMaintainer: false },
+    },
+    { resolved: false },
+    NOW,
+  );
+  assert.deepEqual(escalatedByCreator, { action: "none", reason: "already escalated" });
+
+  // After the escalation the bot's ping is the last comment (maintainer-side):
+  // the label still shields the issue from stale pruning.
+  const escalatedThenQuiet = decideAlertIssueAction(
+    {
+      ...BASE_ISSUE,
+      labels: [NEEDS_MAINTAINER_LABEL],
+      lastComment: { createdAt: SIXTEEN_DAYS_AGO, isMaintainer: true },
+    },
+    { resolved: false },
+    NOW,
+  );
+  assert.deepEqual(escalatedThenQuiet, { action: "none", reason: "escalated; awaiting maintainer" });
+});


### PR DESCRIPTION
Fixes the observed toil: creator-facing integrity alerts stayed open even after the failure was fixed (e.g. the manually-closed #6842/#6882/#6774). A daily workflow (**prune-integrity-alerts**, cron 06:17 UTC + `workflow_dispatch` with a `dry_run` input) now runs a three-way lifecycle pass over open `integrity-alert` issues:

| Condition | Action |
| --- | --- |
| Failing version now passes integrity / version or listing gone / listing deprecated | Close as **resolved** (`completed`) with a per-reason comment |
| No comment activity for **two weeks** and the creator never had the last word (no comments, or last comment from maintainer/bot) | Close as **stale** (`not_planned`) — a recurrence re-fires a fresh alert on the next state transition |
| The **creator's** comment has waited two weeks | **Escalate**: `needs-maintainer` label (created, red) + maintainer ping (`MAINTAINER_MENTIONS` repo var, default `@ahkimn`); exempt from pruning until a human acts |

Design notes:
- Resolution is checked against the **published integrity.json** in the checkout, so it composes with the deprecation overlay (deprecated listings' alerts close with a dedicated message).
- Maintainer detection via collaborator `role_name` admin/maintain — not `author_association`, which the Actions token downgrades for private org members (the live-tested gotcha from the comment-command work).
- The escalation ping comment doesn't reset the clock into a stale-close: labeled issues are shielded until a maintainer acts.

Pure decision logic in `lib/integrity-alert-pruning.ts` with 11 unit tests (suite **365/0**); live `DRY_RUN` verified against the repo (one open alert, #6723, correctly untouched — its failure is real and it has recent activity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)