### PR TITLE
fix: close data-quality issues when the map's publish PR merges

### DIFF
--- a/.github/workflows/process-data-quality.yml
+++ b/.github/workflows/process-data-quality.yml
@@ -167,6 +167,20 @@ jobs:
               return;
             }
             core.setOutput('number', prs[0].number);
+            // Link this data-quality issue to the publish PR with a closing
+            // keyword so merging the map also closes the issue (the comment
+            // below alone would not — closing keywords only work in the PR
+            // body). Idempotent across revalidations.
+            const closingLine = 'Fixes #${{ github.event.issue.number }}';
+            const prBody = prs[0].body ?? '';
+            if (!prBody.includes(closingLine)) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prs[0].number,
+                body: prBody === '' ? closingLine : prBody + '\n\n' + closingLine
+              });
+            }
             let report = '';
             try {
               report = fs.readFileSync('dq-validation-report.md', 'utf-8');


### PR DESCRIPTION
Closes the lifecycle gap: data-quality issues stayed open after their map merged.

Root cause — the flow has two paths:
- **Already-merged maps** get a standalone `dq/<id>` PR whose body carries `Fixes #<issue>` → auto-closes ✓
- **Unmerged maps** get their answers pushed onto the `publish/map/<id>` branch, and the data-quality issue was only referenced in a PR *comment* — GitHub honors closing keywords **only in the PR body**, so merging the publish PR closed the publish issue but left the data-quality issue open ✗

The publish-mode step now appends `Fixes #<dq-issue>` to the publish PR body (idempotent across `revalidate` re-runs; resubmissions append their own line). GitHub then shows the linked issue on the PR and closes both issues atomically on merge — no new workflow needed.

Note: all four currently-open data-quality issues (#6925/#6580/#6555/#6466) belong to still-open publish PRs, so no backfill closing is needed; their publish PRs gain the link on their next answers update/revalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)