### PR TITLE
feat: formatting CI — encoding sanity and canonical JSON style, with PR auto-fix

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,107 @@
+name: Check Formatting
+
+# Formatting invariants over tracked text files (see
+# scripts/quality/check-formatting.ts):
+# - valid UTF-8, no BOM, no CP-1252 mojibake (an editor round-trip through
+#   Windows-1252 shipped "â€”" in publish.yml's user-facing bot comments for
+#   five days — diffs make this near-invisible to reviewers, CI does not);
+# - registry data JSON in canonical style: JSON.stringify(parsed, null, 2)
+#   plus trailing newline — byte-identical to what writeJsonFile and every
+#   generator emit, so hand-edits and bot output never fight.
+#
+# On same-repo pull requests, a failed check triggers an auto-fix commit
+# pushed to the PR branch (BOM removal, mojibake repair, JSON
+# canonicalization). Fork PRs and pushes to main only report — the failure
+# message points at `pnpm --dir scripts run fix-formatting`.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-formatting-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: scripts/pnpm-lock.yaml
+
+      - name: Install script dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: scripts
+
+      - name: Check formatting
+        run: pnpm --dir scripts run check-formatting
+
+  autofix:
+    needs: [check]
+    if: >-
+      failure() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # First checkout only provides the local mint-bot-token action; the
+      # second checks out the PR head with the bot token so the fix commit
+      # retriggers CI (pushes made with the default GITHUB_TOKEN do not
+      # start new workflow runs).
+      - uses: actions/checkout@v4
+
+      - name: Mint bot token
+        id: bot-token
+        uses: ./.github/actions/mint-bot-token
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.bot-token.outputs.token || github.token }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: scripts/pnpm-lock.yaml
+
+      - name: Install script dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: scripts
+
+      - name: Apply formatting fixes
+        run: pnpm --dir scripts run fix-formatting
+
+      - name: Commit and push fixes
+        run: |
+          if git diff --quiet; then
+            echo "Nothing to fix — check failure was not auto-fixable (see check job log)."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: auto-fix formatting (encoding + JSON canonicalization)"
+          git push

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -3,8 +3,8 @@ name: Check Formatting
 # Formatting invariants over tracked text files (see
 # scripts/quality/check-formatting.ts):
 # - valid UTF-8, no BOM, no CP-1252 mojibake (an editor round-trip through
-#   Windows-1252 shipped "â€”" in publish.yml's user-facing bot comments for
-#   five days — diffs make this near-invisible to reviewers, CI does not);
+#   Windows-1252 shipped a corrupted em dash in publish.yml's user-facing
+#   bot comments for five days — near-invisible in diffs, trivial for CI);
 # - registry data JSON in canonical style: JSON.stringify(parsed, null, 2)
 #   plus trailing newline — byte-identical to what writeJsonFile and every
 #   generator emit, so hand-edits and bot output never fight.
@@ -13,6 +13,10 @@ name: Check Formatting
 # pushed to the PR branch (BOM removal, mojibake repair, JSON
 # canonicalization). Fork PRs and pushes to main only report — the failure
 # message points at `pnpm --dir scripts run fix-formatting`.
+#
+# Files under .github/workflows/ are checked but never auto-edited: the bot
+# token lacks the `workflows` permission, and CI must not modify CI. Problems
+# there always require a manual fix.
 
 on:
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-﻿name: Publish Listing
+name: Publish Listing
 
 on:
   issues:

--- a/history/download_attribution_2026_06_08.json
+++ b/history/download_attribution_2026_06_08.json
@@ -6,6 +6,5 @@
   "total_attributed_fetches": 6845,
   "net_attributed_fetches": 3,
   "daily_attributed_fetches": 1,
-  "assets_daily": {
-  }
+  "assets_daily": {}
 }

--- a/mods/zz-deprecation-fixture/manifest.json
+++ b/mods/zz-deprecation-fixture/manifest.json
@@ -5,7 +5,9 @@
   "author": "subway-builder-modded-admin",
   "github_id": 268817724,
   "description": "Permanent synthetic listing used to validate deprecated-asset behavior across the Railyard app and website. It has never been installable and carries no releases.",
-  "tags": ["misc"],
+  "tags": [
+    "misc"
+  ],
   "gallery": [],
   "is_test": false,
   "source": "https://github.com/Subway-Builder-Modded/registry",

--- a/schemas/package.json
+++ b/schemas/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "@subway-builder-modded/registry-schemas",
   "version": "0.2.2",
   "type": "module",

--- a/scripts/lib/formatting.ts
+++ b/scripts/lib/formatting.ts
@@ -3,11 +3,14 @@
 //
 // Mojibake background: an editor that decodes UTF-8 bytes as Windows-1252 and
 // re-saves as UTF-8 turns every multi-byte character into a distinctive
-// sequence (— becomes â€”, é becomes Ã©). The repair is the exact reverse:
-// map each character of the sequence back to the CP-1252 byte it was decoded
-// from, then decode those bytes as UTF-8. A candidate is only replaced when
-// that strict decode succeeds, which is what keeps legitimate text (SÃO, café)
-// untouched — real prose never forms a byte-valid UTF-8 sequence by accident.
+// sequence (an em dash becomes the three-character a-circumflex / euro /
+// right-double-quote run; e-acute becomes A-tilde-capital / copyright). The
+// repair is the exact reverse: map each character of the sequence back to the
+// CP-1252 byte it was decoded from, then decode those bytes as UTF-8. A
+// candidate is only replaced when that strict decode succeeds AND the result
+// is a plausible character — see PLAUSIBLE_REPLACEMENT_RANGES below.
+// (This file deliberately contains no literal mojibake examples: it must stay
+// clean under its own check. The unit tests build fixtures from \u escapes.)
 
 // CP-1252 bytes 0x80–0x9F map to these codepoints (the range where CP-1252
 // differs from Latin-1); bytes 0xA0–0xFF map to the identical codepoints.
@@ -42,10 +45,10 @@ const strictUtf8 = new TextDecoder("utf-8", { fatal: true });
 // A candidate repair is only accepted when the decoded character is one that
 // plausibly appears in registry prose. This guards against real-text
 // collisions: Czech "Úžice" reverse-decodes to a byte-valid Arabic letter
-// (Ú=0xDA lead + ž=0x9E continuation), so strict UTF-8 validity alone is not
-// sufficient evidence of mojibake. Genuine mojibake of Czech text is still
-// repaired — ž corrupts to "Å¾", whose repair decodes back into Latin
-// Extended-A, inside this allowlist.
+// (U-acute = 0xDA lead + z-caron = 0x9E continuation), so strict UTF-8
+// validity alone is not sufficient evidence of mojibake. Genuine mojibake of
+// Czech text is still repaired — corrupted z-caron reverse-decodes back into
+// Latin Extended-A, inside this allowlist.
 const PLAUSIBLE_REPLACEMENT_RANGES: Array<[number, number]> = [
   [0x00a0, 0x024f], // Latin-1 supplement, Latin Extended-A/B
   [0x0370, 0x04ff], // Greek, Cyrillic

--- a/scripts/lib/formatting.ts
+++ b/scripts/lib/formatting.ts
@@ -1,0 +1,158 @@
+// Formatting invariants for tracked text files: UTF-8 validity, no BOM, no
+// CP-1252 mojibake, and canonical JSON style for registry data files.
+//
+// Mojibake background: an editor that decodes UTF-8 bytes as Windows-1252 and
+// re-saves as UTF-8 turns every multi-byte character into a distinctive
+// sequence (— becomes â€”, é becomes Ã©). The repair is the exact reverse:
+// map each character of the sequence back to the CP-1252 byte it was decoded
+// from, then decode those bytes as UTF-8. A candidate is only replaced when
+// that strict decode succeeds, which is what keeps legitimate text (SÃO, café)
+// untouched — real prose never forms a byte-valid UTF-8 sequence by accident.
+
+// CP-1252 bytes 0x80–0x9F map to these codepoints (the range where CP-1252
+// differs from Latin-1); bytes 0xA0–0xFF map to the identical codepoints.
+const CP1252_HIGH_TO_CODEPOINT: Record<number, number> = {
+  0x80: 0x20ac, 0x82: 0x201a, 0x83: 0x0192, 0x84: 0x201e, 0x85: 0x2026,
+  0x86: 0x2020, 0x87: 0x2021, 0x88: 0x02c6, 0x89: 0x2030, 0x8a: 0x0160,
+  0x8b: 0x2039, 0x8c: 0x0152, 0x8e: 0x017d, 0x91: 0x2018, 0x92: 0x2019,
+  0x93: 0x201c, 0x94: 0x201d, 0x95: 0x2022, 0x96: 0x2013, 0x97: 0x2014,
+  0x98: 0x02dc, 0x99: 0x2122, 0x9a: 0x0161, 0x9b: 0x203a, 0x9c: 0x0153,
+  0x9e: 0x017e, 0x9f: 0x0178,
+};
+
+const CODEPOINT_TO_CP1252_BYTE = new Map<number, number>();
+for (const [byte, codepoint] of Object.entries(CP1252_HIGH_TO_CODEPOINT)) {
+  CODEPOINT_TO_CP1252_BYTE.set(codepoint, Number(byte));
+}
+
+/** The CP-1252 byte this character would have been decoded from, or null. */
+function charToCp1252Byte(char: string): number | null {
+  const codepoint = char.codePointAt(0)!;
+  const mapped = CODEPOINT_TO_CP1252_BYTE.get(codepoint);
+  if (mapped !== undefined) return mapped;
+  // 0x80-0xFF: Latin-1 passthrough, including the five codepoints CP-1252
+  // leaves undefined (0x81, 0x8D, 0x8F, 0x90, 0x9D) — editors commonly carry
+  // those through as C1 controls.
+  if (codepoint >= 0x80 && codepoint <= 0xff) return codepoint;
+  return null;
+}
+
+const strictUtf8 = new TextDecoder("utf-8", { fatal: true });
+
+// A candidate repair is only accepted when the decoded character is one that
+// plausibly appears in registry prose. This guards against real-text
+// collisions: Czech "Úžice" reverse-decodes to a byte-valid Arabic letter
+// (Ú=0xDA lead + ž=0x9E continuation), so strict UTF-8 validity alone is not
+// sufficient evidence of mojibake. Genuine mojibake of Czech text is still
+// repaired — ž corrupts to "Å¾", whose repair decodes back into Latin
+// Extended-A, inside this allowlist.
+const PLAUSIBLE_REPLACEMENT_RANGES: Array<[number, number]> = [
+  [0x00a0, 0x024f], // Latin-1 supplement, Latin Extended-A/B
+  [0x0370, 0x04ff], // Greek, Cyrillic
+  [0x1e00, 0x1eff], // Latin Extended Additional
+  [0x2000, 0x206f], // general punctuation (dashes, quotes, ellipsis, bullet)
+  [0x20a0, 0x20cf], // currency symbols
+  [0x2100, 0x214f], // letterlike symbols (™, №)
+  [0x2600, 0x27bf], // misc symbols, dingbats
+  [0x3000, 0x30ff], // CJK punctuation, kana
+  [0x4e00, 0x9fff], // CJK unified ideographs
+  [0xfe00, 0xfe0f], // variation selectors (emoji presentation)
+  [0x1f300, 0x1faff], // emoji
+];
+
+function isPlausibleReplacement(replacement: string): boolean {
+  const codepoint = replacement.codePointAt(0)!;
+  return PLAUSIBLE_REPLACEMENT_RANGES.some(([lo, hi]) => codepoint >= lo && codepoint <= hi);
+}
+
+export interface MojibakeFinding {
+  index: number;
+  sequence: string;
+  replacement: string;
+}
+
+/**
+ * Finds CP-1252 mojibake sequences: a character mapping to a UTF-8 lead byte
+ * (0xC2–0xF4) followed by exactly the right number of characters mapping to
+ * continuation bytes (0x80–0xBF), where the reassembled bytes strictly decode
+ * as UTF-8. Single-pass; call fixMojibake for iterated (double-encoded) repair.
+ */
+export function findMojibake(text: string): MojibakeFinding[] {
+  const findings: MojibakeFinding[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const lead = charToCp1252Byte(text[i]!);
+    if (lead === null || lead < 0xc2 || lead > 0xf4) continue;
+    const continuations = lead < 0xe0 ? 1 : lead < 0xf0 ? 2 : 3;
+    if (i + continuations >= text.length) continue;
+    const bytes = [lead];
+    let valid = true;
+    for (let j = 1; j <= continuations; j++) {
+      const byte = charToCp1252Byte(text[i + j]!);
+      if (byte === null || byte < 0x80 || byte > 0xbf) {
+        valid = false;
+        break;
+      }
+      bytes.push(byte);
+    }
+    if (!valid) continue;
+    let replacement: string;
+    try {
+      replacement = strictUtf8.decode(Uint8Array.from(bytes));
+    } catch {
+      continue;
+    }
+    if (!isPlausibleReplacement(replacement)) continue;
+    findings.push({ index: i, sequence: text.slice(i, i + continuations + 1), replacement });
+    i += continuations;
+  }
+  return findings;
+}
+
+/** Repairs mojibake, unwinding double-encoding by iterating until stable. */
+export function fixMojibake(text: string): { text: string; replacements: number } {
+  let current = text;
+  let replacements = 0;
+  for (let pass = 0; pass < 4; pass++) {
+    const findings = findMojibake(current);
+    if (findings.length === 0) break;
+    let result = "";
+    let cursor = 0;
+    for (const finding of findings) {
+      result += current.slice(cursor, finding.index) + finding.replacement;
+      cursor = finding.index + finding.sequence.length;
+    }
+    result += current.slice(cursor);
+    current = result;
+    replacements += findings.length;
+  }
+  return { text: current, replacements };
+}
+
+export const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+export function hasUtf8Bom(buffer: Buffer): boolean {
+  return buffer.length >= 3 && buffer.subarray(0, 3).equals(UTF8_BOM);
+}
+
+export function decodeStrictUtf8(buffer: Buffer): string | null {
+  try {
+    return strictUtf8.decode(buffer);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Canonical JSON style: exactly what every writer in this repo emits —
+ * JSON.stringify(value, null, 2) with a trailing newline, key order preserved.
+ * Returns null when the text is not parseable JSON.
+ */
+export function canonicalizeJsonText(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -41,6 +41,8 @@
     "merge-download-attribution": "tsx downloads/merge-download-attribution.ts",
     "backfill-download-attribution": "tsx ops/backfill-download-attribution.ts",
     "spotcheck-attribution-logs": "tsx ops/spotcheck-attribution-logs.ts",
+    "check-formatting": "tsx quality/check-formatting.ts",
+    "fix-formatting": "tsx quality/check-formatting.ts --fix",
     "check-repo-liveness": "tsx ops/check-repo-liveness.ts",
     "create-manual-download-attribution": "tsx ops/create-manual-download-attribution.ts",
     "prune-integrity-alerts": "tsx ops/prune-integrity-alerts.ts",

--- a/scripts/quality/check-formatting.ts
+++ b/scripts/quality/check-formatting.ts
@@ -16,8 +16,8 @@ import {
 //
 // Checks:
 // 1. Every tracked text file: valid UTF-8, no BOM, no CP-1252 mojibake
-//    (see lib/formatting.ts — motivated by publish.yml shipping "â€”" in
-//    user-facing bot comments for five days, KNOWN_INCIDENTS-adjacent).
+//    (see lib/formatting.ts — motivated by publish.yml shipping a corrupted
+//    em dash in user-facing bot comments for five days, invisible in diffs).
 // 2. Registry data JSON (maps/, mods/, authors/, analytics/, history/ and
 //    root-level *.json): canonical style, i.e. byte-identical to
 //    JSON.stringify(parsed, null, 2) + "\n" — exactly what writeJsonFile and
@@ -46,6 +46,13 @@ function isCanonicalJsonTarget(path: string): boolean {
   if (!path.endsWith(".json")) return false;
   if (basename(path).startsWith("tsconfig")) return false;
   return JSON_CANONICAL_DIRS.some((dir) => path.startsWith(dir)) || !path.includes("/");
+}
+
+// Workflow definitions are checked but never auto-edited: pushing a change to
+// .github/workflows/ requires the `workflows` token permission the bot does
+// not hold, and CI definitions should not be modified by CI regardless.
+function isAutoFixExcluded(path: string): boolean {
+  return path.startsWith(".github/workflows/");
 }
 
 function listTrackedFiles(): string[] {
@@ -77,6 +84,7 @@ function main(): void {
       continue; // tracked but locally deleted
     }
 
+    const autoFixable = !isAutoFixExcluded(path);
     const bom = hasUtf8Bom(buffer);
     const content = decodeStrictUtf8(bom ? buffer.subarray(3) : buffer);
     if (content === null) {
@@ -84,7 +92,7 @@ function main(): void {
       continue;
     }
     if (bom) {
-      problems.push({ path, kind: "bom", detail: "file starts with a UTF-8 BOM", fixable: true });
+      problems.push({ path, kind: "bom", detail: "file starts with a UTF-8 BOM", fixable: autoFixable });
     }
 
     const mojibake = findMojibake(content);
@@ -98,7 +106,7 @@ function main(): void {
         path,
         kind: "mojibake",
         detail: `${mojibake.length} mojibake sequence(s): ${preview}${mojibake.length > 3 ? ", ..." : ""}`,
-        fixable: true,
+        fixable: autoFixable,
       });
       fixedContent = fixMojibake(content).text;
     }
@@ -108,12 +116,12 @@ function main(): void {
       if (canonical === null) {
         problems.push({ path, kind: "json-parse", detail: "file is not parseable JSON", fixable: false });
       } else if (canonical !== fixedContent) {
-        problems.push({ path, kind: "json-style", detail: "not in canonical JSON style (stringify indent-2 + trailing newline)", fixable: true });
+        problems.push({ path, kind: "json-style", detail: "not in canonical JSON style (stringify indent-2 + trailing newline)", fixable: autoFixable });
         fixedContent = canonical;
       }
     }
 
-    if (fixMode && (bom || fixedContent !== content)) {
+    if (fixMode && autoFixable && (bom || fixedContent !== content)) {
       writeFileSync(absolute, fixedContent, "utf-8");
       fixedFiles += 1;
     }

--- a/scripts/quality/check-formatting.ts
+++ b/scripts/quality/check-formatting.ts
@@ -1,0 +1,142 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, basename } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  canonicalizeJsonText,
+  decodeStrictUtf8,
+  findMojibake,
+  fixMojibake,
+  hasUtf8Bom,
+} from "../lib/formatting.js";
+
+// Formatting invariants over tracked files. Default mode reports and exits
+// non-zero on any problem; --fix rewrites what is mechanically fixable
+// (BOM removal, mojibake repair, JSON canonicalization) and exits non-zero
+// only if unfixable problems remain (invalid UTF-8, unparseable JSON).
+//
+// Checks:
+// 1. Every tracked text file: valid UTF-8, no BOM, no CP-1252 mojibake
+//    (see lib/formatting.ts — motivated by publish.yml shipping "â€”" in
+//    user-facing bot comments for five days, KNOWN_INCIDENTS-adjacent).
+// 2. Registry data JSON (maps/, mods/, authors/, analytics/, history/ and
+//    root-level *.json): canonical style, i.e. byte-identical to
+//    JSON.stringify(parsed, null, 2) + "\n" — exactly what writeJsonFile and
+//    every generator already emit. tsconfig*.json is excluded (dev config,
+//    not registry data).
+
+const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
+  ? resolve(process.env.RAILYARD_REPO_ROOT)
+  : resolve(import.meta.dirname, "..", "..");
+
+const fixMode = process.argv.includes("--fix");
+
+const TEXT_EXTENSIONS = new Set([
+  ".json", ".yml", ".yaml", ".md", ".mdx", ".ts", ".tsx", ".js", ".mjs",
+  ".cjs", ".csv", ".txt", ".html", ".css",
+]);
+
+const JSON_CANONICAL_DIRS = ["maps/", "mods/", "authors/", "analytics/", "history/"];
+
+function isTextFile(path: string): boolean {
+  const dot = path.lastIndexOf(".");
+  return dot !== -1 && TEXT_EXTENSIONS.has(path.slice(dot).toLowerCase());
+}
+
+function isCanonicalJsonTarget(path: string): boolean {
+  if (!path.endsWith(".json")) return false;
+  if (basename(path).startsWith("tsconfig")) return false;
+  return JSON_CANONICAL_DIRS.some((dir) => path.startsWith(dir)) || !path.includes("/");
+}
+
+function listTrackedFiles(): string[] {
+  const result = spawnSync("git", ["ls-files", "-z"], { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 });
+  if (result.status !== 0) {
+    throw new Error(`git ls-files failed: ${result.stderr}`);
+  }
+  return result.stdout.split("\0").filter((path) => path.length > 0);
+}
+
+interface Problem {
+  path: string;
+  kind: "invalid-utf8" | "bom" | "mojibake" | "json-style" | "json-parse";
+  detail: string;
+  fixable: boolean;
+}
+
+function main(): void {
+  const problems: Problem[] = [];
+  let fixedFiles = 0;
+
+  for (const path of listTrackedFiles()) {
+    if (!isTextFile(path)) continue;
+    const absolute = resolve(REPO_ROOT, path);
+    let buffer: Buffer;
+    try {
+      buffer = readFileSync(absolute);
+    } catch {
+      continue; // tracked but locally deleted
+    }
+
+    const bom = hasUtf8Bom(buffer);
+    const content = decodeStrictUtf8(bom ? buffer.subarray(3) : buffer);
+    if (content === null) {
+      problems.push({ path, kind: "invalid-utf8", detail: "file is not valid UTF-8", fixable: false });
+      continue;
+    }
+    if (bom) {
+      problems.push({ path, kind: "bom", detail: "file starts with a UTF-8 BOM", fixable: true });
+    }
+
+    const mojibake = findMojibake(content);
+    let fixedContent = content;
+    if (mojibake.length > 0) {
+      const preview = mojibake
+        .slice(0, 3)
+        .map((finding) => `"${finding.sequence}" -> "${finding.replacement}"`)
+        .join(", ");
+      problems.push({
+        path,
+        kind: "mojibake",
+        detail: `${mojibake.length} mojibake sequence(s): ${preview}${mojibake.length > 3 ? ", ..." : ""}`,
+        fixable: true,
+      });
+      fixedContent = fixMojibake(content).text;
+    }
+
+    if (isCanonicalJsonTarget(path)) {
+      const canonical = canonicalizeJsonText(fixedContent);
+      if (canonical === null) {
+        problems.push({ path, kind: "json-parse", detail: "file is not parseable JSON", fixable: false });
+      } else if (canonical !== fixedContent) {
+        problems.push({ path, kind: "json-style", detail: "not in canonical JSON style (stringify indent-2 + trailing newline)", fixable: true });
+        fixedContent = canonical;
+      }
+    }
+
+    if (fixMode && (bom || fixedContent !== content)) {
+      writeFileSync(absolute, fixedContent, "utf-8");
+      fixedFiles += 1;
+    }
+  }
+
+  for (const problem of problems) {
+    const tag = fixMode && problem.fixable ? "fixed" : problem.fixable ? "fixable" : "NOT AUTO-FIXABLE";
+    console.log(`[formatting] ${problem.path}: ${problem.kind} (${tag}) — ${problem.detail}`);
+  }
+
+  const unfixable = problems.filter((problem) => !problem.fixable);
+  if (fixMode) {
+    console.log(`[formatting] fixed ${fixedFiles} file(s); ${unfixable.length} problem(s) need manual attention`);
+    process.exit(unfixable.length > 0 ? 1 : 0);
+  }
+  if (problems.length > 0) {
+    console.log(
+      `[formatting] ${problems.length} problem(s) in ${new Set(problems.map((p) => p.path)).size} file(s). ` +
+      "Run `pnpm --dir scripts run fix-formatting` locally, or wait for the auto-fix commit on this PR.",
+    );
+    process.exit(1);
+  }
+  console.log("[formatting] all tracked text files clean");
+}
+
+main();

--- a/scripts/tests/formatting.unit.test.ts
+++ b/scripts/tests/formatting.unit.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  canonicalizeJsonText,
+  decodeStrictUtf8,
+  findMojibake,
+  fixMojibake,
+  hasUtf8Bom,
+} from "../lib/formatting.js";
+
+// --- mojibake ---
+
+test("repairs the CP-1252 round-trip for common punctuation", () => {
+  assert.equal(fixMojibake("results here â€” usually fast").text, "results here — usually fast");
+  assert.equal(fixMojibake("donâ€™t").text, "don’t");
+  assert.equal(fixMojibake("â€œquotedâ€").text, "“quoted”");
+});
+
+test("repairs two-byte accented-latin mojibake", () => {
+  assert.equal(fixMojibake("cafÃ©").text, "café");
+  assert.equal(fixMojibake("SÃ£o Paulo").text, "São Paulo");
+});
+
+test("repairs four-byte (emoji) mojibake", () => {
+  assert.equal(fixMojibake("ðŸ˜€").text, "😀");
+});
+
+test("unwinds double-encoded mojibake", () => {
+  // — encoded twice: â€” re-corrupted through a second CP-1252 round trip.
+  const doubled = fixMojibake("Ã¢â‚¬â€");
+  assert.equal(doubled.text, "—");
+});
+
+test("leaves legitimate Czech place names untouched, but repairs mojibake'd Czech", () => {
+  // Úž / Úš reverse-decode to byte-valid Arabic letters — the plausibility
+  // guard must reject that repair (real case: maps/yukina-cz-praha).
+  assert.deepEqual(findMojibake("Úžice a Úštěk"), []);
+  // ...while genuinely mojibake'd Czech (ž -> Å¾) is still repaired.
+  assert.equal(fixMojibake("Å½elezniÄnÃ­").text.startsWith("Železni"), true);
+});
+
+test("leaves legitimate text untouched", () => {
+  for (const text of [
+    "SÃO PAULO",            // uppercase Portuguese: Ã followed by ASCII
+    "café — naïve résumé",  // genuine accents and em dash
+    "a Â£10 note? no: £10", // £ alone is fine; Â£ would be mojibake
+    "plain ascii text",
+  ]) {
+    const findings = findMojibake(text);
+    if (text.includes("Â£")) {
+      // the Â£ half is mojibake and should be found; the bare £ half is not
+      assert.equal(findings.length, 1);
+    } else {
+      assert.deepEqual(findings, [], `unexpected findings in: ${text}`);
+    }
+  }
+});
+
+test("reports sequence positions and replacements", () => {
+  const findings = findMojibake("x â€” y Ã© z");
+  assert.equal(findings.length, 2);
+  assert.deepEqual(findings.map((f) => f.replacement), ["—", "é"]);
+});
+
+// --- BOM / UTF-8 ---
+
+test("detects a UTF-8 BOM", () => {
+  assert.equal(hasUtf8Bom(Buffer.from([0xef, 0xbb, 0xbf, 0x7b])), true);
+  assert.equal(hasUtf8Bom(Buffer.from('{"a":1}')), false);
+});
+
+test("rejects invalid UTF-8", () => {
+  assert.equal(decodeStrictUtf8(Buffer.from([0x61, 0xe9, 0x62])), null); // raw CP-1252 é
+  assert.equal(decodeStrictUtf8(Buffer.from("valid é")), "valid é");
+});
+
+// --- JSON canonicalization ---
+
+test("canonical form matches every repo writer and is idempotent", () => {
+  const raw = '{\n  "b": [1, 2],\n  "a": {}\n}\n';
+  const canonical = canonicalizeJsonText(raw)!;
+  assert.equal(canonical, '{\n  "b": [\n    1,\n    2\n  ],\n  "a": {}\n}\n');
+  assert.equal(canonicalizeJsonText(canonical), canonical);
+});
+
+test("preserves key order and JS number formatting", () => {
+  const canonical = canonicalizeJsonText('{"z": 1, "a": 9.929497353721012e-8}')!;
+  assert.ok(canonical.indexOf('"z"') < canonical.indexOf('"a"'));
+  assert.ok(canonical.includes("9.929497353721012e-8"));
+});
+
+test("returns null for unparseable JSON", () => {
+  assert.equal(canonicalizeJsonText("{not json"), null);
+});

--- a/scripts/tests/formatting.unit.test.ts
+++ b/scripts/tests/formatting.unit.test.ts
@@ -8,56 +8,67 @@ import {
   hasUtf8Bom,
 } from "../lib/formatting.js";
 
+// Mojibake fixtures are written as \u escapes so this file itself stays
+// ASCII-clean under the formatting check (raw fixtures would self-flag, and
+// the auto-fixer would "repair" the tests into asserting nothing).
+const MOJI_EM_DASH = "\u00e2\u20ac\u201d"; // em dash through a CP-1252 round trip
+const MOJI_RSQUO = "\u00e2\u20ac\u2122"; // right single quote
+const MOJI_LDQUO = "\u00e2\u20ac\u0153"; // left double quote
+const MOJI_RDQUO = "\u00e2\u20ac\u009d"; // right double quote
+const MOJI_E_ACUTE = "\u00c3\u00a9"; // e-acute
+const MOJI_A_TILDE = "\u00c3\u00a3"; // a-tilde
+const MOJI_POUND = "\u00c2\u00a3"; // pound sign
+const MOJI_EMOJI = "\u00f0\u0178\u02dc\u20ac"; // grinning-face emoji
+const MOJI_Z_CARON_UC = "\u00c5\u00bd"; // Z-caron
+const MOJI_Z_CARON = "\u00c5\u00be"; // z-caron
+const MOJI_EM_DASH_DOUBLED = "\u00c3\u00a2\u00e2\u201a\u00ac\u00e2\u20ac\u009d"; // em dash corrupted twice
+
 // --- mojibake ---
 
 test("repairs the CP-1252 round-trip for common punctuation", () => {
-  assert.equal(fixMojibake("results here â€” usually fast").text, "results here — usually fast");
-  assert.equal(fixMojibake("donâ€™t").text, "don’t");
-  assert.equal(fixMojibake("â€œquotedâ€").text, "“quoted”");
+  assert.equal(fixMojibake(`results here ${MOJI_EM_DASH} usually fast`).text, "results here — usually fast");
+  assert.equal(fixMojibake(`don${MOJI_RSQUO}t`).text, "don’t");
+  assert.equal(fixMojibake(`${MOJI_LDQUO}quoted${MOJI_RDQUO}`).text, "“quoted”");
 });
 
 test("repairs two-byte accented-latin mojibake", () => {
-  assert.equal(fixMojibake("cafÃ©").text, "café");
-  assert.equal(fixMojibake("SÃ£o Paulo").text, "São Paulo");
+  assert.equal(fixMojibake(`caf${MOJI_E_ACUTE}`).text, "café");
+  assert.equal(fixMojibake(`S${MOJI_A_TILDE}o Paulo`).text, "São Paulo");
 });
 
 test("repairs four-byte (emoji) mojibake", () => {
-  assert.equal(fixMojibake("ðŸ˜€").text, "😀");
+  assert.equal(fixMojibake(MOJI_EMOJI).text, "\u{1f600}");
 });
 
 test("unwinds double-encoded mojibake", () => {
-  // — encoded twice: â€” re-corrupted through a second CP-1252 round trip.
-  const doubled = fixMojibake("Ã¢â‚¬â€");
-  assert.equal(doubled.text, "—");
+  assert.equal(fixMojibake(MOJI_EM_DASH_DOUBLED).text, "—");
 });
 
 test("leaves legitimate Czech place names untouched, but repairs mojibake'd Czech", () => {
-  // Úž / Úš reverse-decode to byte-valid Arabic letters — the plausibility
-  // guard must reject that repair (real case: maps/yukina-cz-praha).
+  // U-acute + z-caron ("Úž", as in the real place name
+  // Úžice from maps/yukina-cz-praha) reverse-decodes to a
+  // byte-valid Arabic letter — the plausibility guard must reject that.
   assert.deepEqual(findMojibake("Úžice a Úštěk"), []);
-  // ...while genuinely mojibake'd Czech (ž -> Å¾) is still repaired.
-  assert.equal(fixMojibake("Å½elezniÄnÃ­").text.startsWith("Železni"), true);
+  // ...while genuinely mojibake'd Czech is still repaired.
+  assert.equal(fixMojibake(`${MOJI_Z_CARON_UC}elezni`).text, "Železni");
+  assert.equal(fixMojibake(`ku${MOJI_Z_CARON}elka`).text, "kuželka");
 });
 
 test("leaves legitimate text untouched", () => {
   for (const text of [
-    "SÃO PAULO",            // uppercase Portuguese: Ã followed by ASCII
-    "café — naïve résumé",  // genuine accents and em dash
-    "a Â£10 note? no: £10", // £ alone is fine; Â£ would be mojibake
+    "SÃO PAULO", // uppercase Portuguese: A-tilde-capital followed by ASCII
+    "café — naïve résumé", // genuine accents and em dash
     "plain ascii text",
   ]) {
-    const findings = findMojibake(text);
-    if (text.includes("Â£")) {
-      // the Â£ half is mojibake and should be found; the bare £ half is not
-      assert.equal(findings.length, 1);
-    } else {
-      assert.deepEqual(findings, [], `unexpected findings in: ${text}`);
-    }
+    assert.deepEqual(findMojibake(text), [], `unexpected findings in: ${text}`);
   }
+  // A bare pound sign is fine; the A-circumflex-prefixed form is mojibake.
+  assert.deepEqual(findMojibake("a £10 note"), []);
+  assert.equal(findMojibake(`a ${MOJI_POUND}10 note`).length, 1);
 });
 
 test("reports sequence positions and replacements", () => {
-  const findings = findMojibake("x â€” y Ã© z");
+  const findings = findMojibake(`x ${MOJI_EM_DASH} y ${MOJI_E_ACUTE} z`);
   assert.equal(findings.length, 2);
   assert.deepEqual(findings.map((f) => f.replacement), ["—", "é"]);
 });
@@ -70,7 +81,7 @@ test("detects a UTF-8 BOM", () => {
 });
 
 test("rejects invalid UTF-8", () => {
-  assert.equal(decodeStrictUtf8(Buffer.from([0x61, 0xe9, 0x62])), null); // raw CP-1252 é
+  assert.equal(decodeStrictUtf8(Buffer.from([0x61, 0xe9, 0x62])), null); // raw CP-1252 e-acute
   assert.equal(decodeStrictUtf8(Buffer.from("valid é")), "valid é");
 });
 

--- a/security-rules.json
+++ b/security-rules.json
@@ -59,7 +59,10 @@
       "type": "ast",
       "pattern": {
         "kind": "call-in-while",
-        "callees": ["openModsFolder", "openSavesFolder"],
+        "callees": [
+          "openModsFolder",
+          "openSavesFolder"
+        ],
         "allow_aliases": true
       },
       "description": "Repeated folder-opening calls in while loops can crash file explorer.",


### PR DESCRIPTION
## Summary

Adds a generic formatting CI motivated by the `publish.yml` mojibake (#6614 shipped `â€”` in user-facing bot comments for five days — invisible in a diff, trivial for CI). Two invariant families, one workflow, with automatic fixes on PRs.

## Checks

**Encoding sanity** (all tracked text files):
- valid UTF-8 (strict decode)
- no UTF-8 BOM
- no CP-1252 mojibake — detected by reversing the round trip (map chars back to CP-1252 bytes, require a strict UTF-8 re-decode), guarded by a script-plausibility allowlist. The guard is not theoretical: legitimate Czech `Úžice` (maps/yukina-cz-praha) reverse-decodes to a byte-valid Arabic letter and must not be "repaired", while genuinely mojibake'd Czech (`Å¾` → `ž`) still is.

**Canonical JSON style** (registry data: `maps/`, `mods/`, `authors/`, `analytics/`, `history/`, root `*.json`; `tsconfig*` excluded):
- byte-identical to `JSON.stringify(parsed, null, 2) + "\n"` — exactly what `writeJsonFile` and every generator emit, key order preserved, JS number formatting. 850 of 860 tracked JSON files already conformed; the check ratifies the de-facto standard so hand edits and bot output never fight.

## Auto-fix

`check-formatting.yml` runs on PRs and pushes to `main`. On same-repo PRs, a failed check triggers an `autofix` job that runs `fix-formatting` and pushes a `style:` commit to the PR branch using the registry bot token (so CI retriggers on the fix commit). Fork PRs and `main` pushes report only, pointing at `pnpm --dir scripts run fix-formatting`. Unfixable problems (invalid UTF-8, unparseable JSON) always fail the check.

## Fixes applied in this PR (found by the checker itself)

- BOM removed from `.github/workflows/publish.yml` — left behind by the same #6614 editor round-trip and missed by the manual mojibake fix (`7908d7d29`)
- BOM removed from `schemas/package.json`
- JSON canonicalization: `security-rules.json`, `mods/zz-deprecation-fixture/manifest.json`, `history/download_attribution_2026_06_08.json`

## Verification

- Full scripts suite: 388/388 (12 new unit tests: repair of 2/3/4-byte sequences, double-encoding unwind, Czech false-positive guard, BOM, strict UTF-8, canonicalization idempotency/key order/number formatting)
- `check-formatting` runs clean over the whole repo after the applied fixes
- Workflow YAML parses; autofix job checks out the local action before minting the bot token

🤖 Generated with [Claude Code](https://claude.com/claude-code)