### PR TITLE
fix: stop analytics bot PR conflicts and duplicate content announcements

### DIFF
--- a/.github/actions/bot-pr-automation/action.yml
+++ b/.github/actions/bot-pr-automation/action.yml
@@ -58,6 +58,13 @@ outputs:
   pr_head_sha:
     description: Resolved PR head SHA.
     value: ${{ steps.run.outputs.pr_head_sha }}
+  merged:
+    description: >-
+      "true" when the PR is confirmed merged by the end of this action, "false"
+      otherwise (e.g. parked on the auto-merge fallback awaiting approval).
+      Callers gating side effects on the committed state actually reaching the
+      base branch must check this, not mere PR existence.
+    value: ${{ steps.run.outputs.merged }}
 
 runs:
   using: composite
@@ -181,6 +188,22 @@ runs:
             merged_directly=true
             echo "Merged PR #${PR_NUMBER} directly with the bot app identity."
           else
+            # A stale mergeability verdict or a behind branch can fail the direct
+            # merge; syncing the branch with base gives one more shot. A genuine
+            # content conflict makes update-branch itself fail (422) and we fall
+            # through to the auto-merge fallback.
+            echo "Direct app merge failed; updating branch from base and retrying." >&2
+            if retry_run 2 gh api --method PUT "repos/${REPO}/pulls/${PR_NUMBER}/update-branch"; then
+              sleep 10
+              if retry_run 2 env GH_TOKEN="${INPUT_MERGE_TOKEN}" gh pr merge "${PR_NUMBER}" --repo "${REPO}" --squash --admin; then
+                merged_directly=true
+                echo "Merged PR #${PR_NUMBER} directly after branch update."
+              fi
+            else
+              echo "Branch update failed (likely a content conflict with base)." >&2
+            fi
+          fi
+          if [ "${merged_directly}" != "true" ]; then
             echo "Direct app merge failed; enabling auto-merge (needs a manual approval)." >&2
           fi
         fi
@@ -188,6 +211,17 @@ runs:
         if [ "${merged_directly}" != "true" ] && bool_true "${INPUT_ENABLE_AUTO_MERGE}"; then
           retry_run "${MAX_ATTEMPTS}" gh pr merge "${PR_NUMBER}" --repo "${REPO}" --auto --squash \
             || echo "Could not enable auto-merge after retries (auto-merge may be disabled or blocked by branch rules)."
+        fi
+
+        # Confirm against the API rather than trusting merged_directly: the
+        # auto-merge fallback can also complete immediately when the PR is
+        # already approved and mergeable.
+        MERGED_STATE="$(retry_cmd "${MAX_ATTEMPTS}" gh pr view "${PR_NUMBER}" --repo "${REPO}" --json state --jq .state || echo "UNKNOWN")"
+        if [ "${MERGED_STATE}" = "MERGED" ]; then
+          echo "merged=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "merged=false" >> "$GITHUB_OUTPUT"
+          echo "PR #${PR_NUMBER} is not merged (state: ${MERGED_STATE})." >&2
         fi
 
         echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/regenerate-registry-analytics.yml
+++ b/.github/workflows/regenerate-registry-analytics.yml
@@ -639,10 +639,14 @@ jobs:
       - name: Stage changes
         id: stage_changes
         run: |
-          # downloads.json and download-version-buckets.json are owned by the hourly workflow. This
-          # run commits only the attribution ledger; the next hourly run reconciles it into
-          # downloads.json. Excluding them here stops this PR from racing the hourly workflow.
-          git add maps/integrity.json mods/integrity.json maps/integrity-cache.json mods/integrity-cache.json maps/repo-liveness.json mods/repo-liveness.json maps/*/manifest.json mods/*/manifest.json maps/basemap-completeness.json maps/demand-stats-cache.json history/registry-download-attribution.json history/content-announcements.json 2>/dev/null || true
+          # downloads.json, download-version-buckets.json, and repo-liveness.json are owned by
+          # the hourly workflow. This run commits only the attribution ledger; the next hourly
+          # run reconciles it into downloads.json. Excluding hourly-owned files here stops this
+          # PR from racing the hourly workflow: repo-liveness.json in particular carries an
+          # updated_at stamp both workflows rewrite, and staging it dragged it into the bot PR
+          # (create-pull-request commits pre-staged files even outside add-paths), which is
+          # what kept the bot PR unmergeable for hours at a time.
+          git add maps/integrity.json mods/integrity.json maps/integrity-cache.json mods/integrity-cache.json maps/*/manifest.json mods/*/manifest.json maps/basemap-completeness.json maps/demand-stats-cache.json history/registry-download-attribution.json history/content-announcements.json 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No registry analytics changes detected; skipping PR update."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -678,6 +682,19 @@ jobs:
             history/registry-download-attribution.json
             history/content-announcements.json
 
+      # The send-time dedup must reflect what has ACTUALLY landed on main, not this
+      # run's checkout (pinned to the trigger SHA) or its own freshly recorded ledger.
+      # Snapshot main's ledger BEFORE the merge below: entries present now were
+      # announced by earlier runs (skip them); our own entry lands with the merge and
+      # must not suppress this run's send.
+      - name: Refresh announcement ledger from main
+        if: ${{ steps.stage_changes.outputs.has_changes == 'true' }}
+        continue-on-error: true
+        run: |
+          git fetch --depth 1 origin main
+          git checkout FETCH_HEAD -- history/content-announcements.json
+          echo "Announcement ledger refreshed from origin/main."
+
       - name: Finalize bot PR automation
         id: bot_pr
         if: ${{ steps.stage_changes.outputs.has_changes == 'true' }}
@@ -712,8 +729,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run regenerate-downloads-hourly.yml --ref main
 
+      # Gated on the bot PR actually MERGING, not merely existing: while the PR is
+      # unmerged, the integrity snapshot + announcement ledger have not landed on
+      # main, so the next run re-detects the same "newly complete" transitions and
+      # would re-send. Only the run that lands the state announces it. Trade-off:
+      # if a stuck PR later merges via the auto-merge fallback (outside any run),
+      # its announcements are recorded-but-unsent — the unmerged-PR Discord warning
+      # below exists so a human notices before that happens.
       - name: Send new content announcements
-        if: ${{ steps.commit_changes.outputs.committed == 'true' }}
+        if: ${{ steps.bot_pr.outputs.merged == 'true' }}
         env:
           DISCORD_ANNOUNCEMENT_WEBHOOK_URL: ${{ secrets.DISCORD_ANNOUNCEMENT_WEBHOOK_URL }}
         run: |
@@ -723,6 +747,31 @@ jobs:
           fi
 
           pnpm --dir scripts run send-pending-announcements -- --file /tmp/pending-announcements/maps-pending-announcements.json --file /tmp/pending-announcements/mods-pending-announcements.json
+
+      - name: Notify Discord (Bot PR Unmerged)
+        if: ${{ always() && steps.stage_changes.outputs.has_changes == 'true' && steps.bot_pr.outputs.merged != 'true' }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_TITLE: ⚠️ Registry Analytics Bot PR Failed to Merge
+          DISCORD_STATUS: failure
+          DISCORD_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_URL: ${{ steps.bot_pr.outputs.pr_url }}
+        run: |
+          if [ -z "${DISCORD_WEBHOOK_URL}" ]; then
+            echo "DISCORD_WEBHOOK_URL not set; skipping Discord notification."
+            exit 0
+          fi
+
+          export DISCORD_LINES_JSON="$(jq -nc \
+            --arg pr_url "${PR_URL:-unknown}" \
+            '[
+              "- **Bot PR:** \($pr_url)",
+              "- Integrity + announcement state is parked off-main until this PR merges.",
+              "- Until then every 4-hour run re-detects the same transitions (duplicate integrity alerts; content announcements are held back).",
+              "- Merge or close the PR, or investigate the conflict."
+            ]')"
+
+          pnpm --dir scripts run notify-discord
 
       - name: Notify Discord (Downloads + Integrity)
         if: always()

--- a/scripts/announce/send-pending-announcements.ts
+++ b/scripts/announce/send-pending-announcements.ts
@@ -14,8 +14,11 @@ import { resolveRepoRoot, runAndExitOnError } from "../lib/script-runtime.js";
 async function run(): Promise<void> {
   const files = parsePendingAnnouncementFileArgs(process.argv.slice(2));
   const repoRoot = process.env.RAILYARD_REPO_ROOT ?? resolveRepoRoot(import.meta.dirname);
-  // Load the ledger at send time (commit job checks out latest main, so this
-  // reflects any announcements already sent by a concurrent or preceding run).
+  // Load the ledger at send time. The checkout is pinned to the workflow's
+  // trigger SHA, so the workflow refreshes history/content-announcements.json
+  // from origin/main (pre-merge) before this runs — entries present there were
+  // announced by earlier runs and are skipped; this run's own recorded entries
+  // land with its bot PR and must not appear here.
   const ledger = loadContentAnnouncementLedger(repoRoot);
   let sent = 0;
   let skipped = 0;


### PR DESCRIPTION
## Context

Investigation of the Aug 6–7 ile-de-france incident (3 duplicate Discord release announcements; integrity-alert issues recreated after being closed — #7088/#7089 → #7099 → #7108/#7109) found the analytics bot PR (#7091, then #7102) sat unmergeable for ~13 hours. All announcement + alert dedup state (`maps/integrity.json`, `history/content-announcements.json`) only lands on main via that PR, so every 4-hour full run re-detected the same "newly complete" / "newly failing" transitions and re-fired.

## Root cause

The bot PR contained `maps/repo-liveness.json` + `mods/repo-liveness.json` — files the **hourly** workflow also regenerates and commits every hour (each write touches `updated_at`, a guaranteed-conflict hunk). They were never in `add-paths`, but the commit job pre-stages them with `git add`, and `create-pull-request` commits pre-staged files regardless. Same class of conflict that `downloads.json` was already excluded for.

## Changes

- **Stop staging repo-liveness.json** in the analytics commit job — hourly owns it (and refreshes it hourly, so nothing is lost).
- **bot-pr-automation**: on direct-merge failure, update the branch from base and retry once before falling back to auto-merge; add a `merged` output confirmed via `gh pr view` (additive — other consumer workflows unaffected).
- **Gate "Send new content announcements" on `merged == 'true'`** instead of "a PR exists". Only the run that actually lands the ledger announces. Trade-off (documented inline): if a stuck PR later merges via the auto-merge fallback outside any run, its announcements are recorded-but-unsent — mitigated by the next point.
- **New "Notify Discord (Bot PR Unmerged)" step**: fires whenever a run leaves its bot PR unmerged, so a stuck PR gets human attention instead of silently parking dedup state off-main.
- **Refresh the announcement ledger from origin/main before the merge** so the send-time recheck reflects what earlier runs actually announced (the checkout is pinned to the trigger SHA), while this run's own just-merged entry cannot suppress its send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)