### PR TITLE
feat: close integrity alerts superseded by a newer complete version

### DIFF
--- a/scripts/lib/integrity-alert-pruning.ts
+++ b/scripts/lib/integrity-alert-pruning.ts
@@ -1,8 +1,10 @@
 import type { IntegrityOutput } from "@subway-builder-modded/registry-schemas";
+import { compareStableSemverAsc, isStableSemverTag } from "./semver.js";
 
 // Lifecycle automation for creator-facing integrity-alert issues:
-// - RESOLVED alerts (the failing version now passes integrity, disappeared, or
-//   the listing was deprecated) are closed as completed.
+// - RESOLVED alerts (the failing version now passes integrity, disappeared,
+//   was superseded by a newer complete version, or the listing was
+//   deprecated) are closed as completed.
 // - STALE alerts (no comment activity for two weeks where the creator never
 //   responded — the last word is the bot's alert or a maintainer's) are closed
 //   as not_planned; a genuine recurrence re-fires a fresh alert on the next
@@ -28,7 +30,12 @@ export function parseAlertIssueTitle(title: string): AlertIssueRef | null {
 }
 
 export type AlertResolution =
-  | { resolved: true; reason: "version_complete" | "version_removed" | "listing_removed" | "listing_deprecated" }
+  | {
+    resolved: true;
+    reason: "version_complete" | "version_removed" | "listing_removed" | "listing_deprecated" | "version_superseded";
+    /** Set for version_superseded: the newer complete version that moots the alert. */
+    supersededBy?: string;
+  }
   | { resolved: false };
 
 /**
@@ -55,6 +62,19 @@ export function resolveAlertAgainstIntegrity(
   }
   if (version.errors.includes("listing_deprecated")) {
     return { resolved: true, reason: "listing_deprecated" };
+  }
+  // A newer complete version moots the alert: creators fix forward, and old
+  // release tags are never rewritten retroactively (e.g. a config.json version
+  // baked into an old tag's zip). Strict semver comparison on both sides so a
+  // REGRESSION of the latest version — or any non-semver tag — never matches.
+  if (
+    listing.latest_semver_complete === true
+    && typeof listing.latest_semver_version === "string"
+    && isStableSemverTag(listing.latest_semver_version)
+    && isStableSemverTag(ref.version)
+    && compareStableSemverAsc(ref.version, listing.latest_semver_version) < 0
+  ) {
+    return { resolved: true, reason: "version_superseded", supersededBy: listing.latest_semver_version };
   }
   return { resolved: false };
 }
@@ -110,10 +130,17 @@ export function decideAlertIssueAction(
 export function buildResolvedCloseComment(
   ref: AlertIssueRef,
   reason: Extract<AlertResolution, { resolved: true }>["reason"],
+  supersededBy?: string,
 ): string {
   switch (reason) {
     case "version_complete":
       return `\`${ref.listingId}\` \`${ref.version}\` now passes its integrity checks — closing this alert as resolved. Thanks for fixing it!`;
+    case "version_superseded":
+      return (
+        `\`${ref.listingId}\` \`${ref.version}\` still fails its integrity checks, but the newer version `
+        + `\`${supersededBy ?? "(latest)"}\` passes and is what users install — closing this alert as superseded. `
+        + `Old release tags don't need retroactive fixes.`
+      );
     case "version_removed":
       return `\`${ref.version}\` is no longer part of \`${ref.listingId}\`'s published releases, so this alert no longer applies — closing as resolved.`;
     case "listing_removed":

--- a/scripts/ops/prune-integrity-alerts.ts
+++ b/scripts/ops/prune-integrity-alerts.ts
@@ -164,7 +164,8 @@ async function main(): Promise<void> {
     }
 
     if (decision.action === "close_resolved") {
-      await comment(issue.number, buildResolvedCloseComment(ref, decision.reason));
+      const supersededBy = resolution.resolved ? resolution.supersededBy : undefined;
+      await comment(issue.number, buildResolvedCloseComment(ref, decision.reason, supersededBy));
       await closeIssue(issue.number, "completed");
       console.log(`[prune-alerts] ${describe}: closed as resolved (${decision.reason})`);
       summary.closed_resolved += 1;

--- a/scripts/tests/integrity-alert-pruning.unit.test.ts
+++ b/scripts/tests/integrity-alert-pruning.unit.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { IntegrityOutput } from "@subway-builder-modded/registry-schemas";
 import {
   NEEDS_MAINTAINER_LABEL,
+  buildResolvedCloseComment,
   decideAlertIssueAction,
   parseAlertIssueTitle,
   resolveAlertAgainstIntegrity,
@@ -25,7 +26,11 @@ function versionEntry(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function integrityWith(listingId: string, versions: Record<string, ReturnType<typeof versionEntry>>): IntegrityOutput {
+function integrityWith(
+  listingId: string,
+  versions: Record<string, ReturnType<typeof versionEntry>>,
+  listingOverrides: Record<string, unknown> = {},
+): IntegrityOutput {
   return {
     schema_version: 1,
     generated_at: "2026-08-20T00:00:00Z",
@@ -37,6 +42,7 @@ function integrityWith(listingId: string, versions: Record<string, ReturnType<ty
         complete_versions: [],
         incomplete_versions: Object.keys(versions),
         versions,
+        ...listingOverrides,
       },
     },
   };
@@ -90,6 +96,80 @@ test("resolution: version removed / listing removed / deprecated", () => {
   );
 });
 
+test("resolution: superseded by a newer complete version", () => {
+  const integrity = integrityWith(
+    "my-map",
+    {
+      "1.0.1": versionEntry(),
+      "1.0.2": versionEntry({ is_complete: true, errors: [] }),
+    },
+    { latest_semver_version: "1.0.2", latest_semver_complete: true, complete_versions: ["1.0.2"] },
+  );
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "my-map", version: "1.0.1" }, { maps: integrity, mods: null }),
+    { resolved: true, reason: "version_superseded", supersededBy: "1.0.2" },
+  );
+});
+
+test("resolution: superseded handles v-prefix mismatch between alert and latest", () => {
+  const integrity = integrityWith(
+    "my-map",
+    {
+      "v1.0.0": versionEntry(),
+      "1.0.2": versionEntry({ is_complete: true, errors: [] }),
+    },
+    { latest_semver_version: "1.0.2", latest_semver_complete: true, complete_versions: ["1.0.2"] },
+  );
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "my-map", version: "v1.0.0" }, { maps: integrity, mods: null }),
+    { resolved: true, reason: "version_superseded", supersededBy: "1.0.2" },
+  );
+});
+
+test("resolution: not superseded when the latest version is not complete", () => {
+  const integrity = integrityWith(
+    "my-map",
+    {
+      "1.0.1": versionEntry(),
+      "1.0.2": versionEntry(),
+    },
+    { latest_semver_version: "1.0.2", latest_semver_complete: false },
+  );
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "my-map", version: "1.0.1" }, { maps: integrity, mods: null }),
+    { resolved: false },
+  );
+});
+
+test("resolution: not superseded for non-semver alert versions", () => {
+  const integrity = integrityWith(
+    "my-map",
+    {
+      "nightly": versionEntry(),
+      "1.0.2": versionEntry({ is_complete: true, errors: [] }),
+    },
+    { latest_semver_version: "1.0.2", latest_semver_complete: true, complete_versions: ["1.0.2"] },
+  );
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "my-map", version: "nightly" }, { maps: integrity, mods: null }),
+    { resolved: false },
+  );
+});
+
+test("resolution: a regression of the latest version itself is never superseded", () => {
+  // latest_semver_complete reflects the stale pre-regression snapshot here;
+  // the alert version equals latest, so the semver comparison must not match.
+  const integrity = integrityWith(
+    "my-map",
+    { "1.0.2": versionEntry() },
+    { latest_semver_version: "1.0.2", latest_semver_complete: true },
+  );
+  assert.deepEqual(
+    resolveAlertAgainstIntegrity({ listingId: "my-map", version: "1.0.2" }, { maps: integrity, mods: null }),
+    { resolved: false },
+  );
+});
+
 test("resolution: mods integrity is consulted when maps misses", () => {
   const mods = integrityWith("some-mod", { "v1.0.0": versionEntry({ is_complete: true }) });
   const maps = integrityWith("other-map", { "v9.0.0": versionEntry() });
@@ -97,6 +177,17 @@ test("resolution: mods integrity is consulted when maps misses", () => {
     resolveAlertAgainstIntegrity({ listingId: "some-mod", version: "v1.0.0" }, { maps, mods }),
     { resolved: true, reason: "version_complete" },
   );
+});
+
+test("superseded close comment names the newer version", () => {
+  const message = buildResolvedCloseComment(
+    { listingId: "my-map", version: "1.0.1" },
+    "version_superseded",
+    "1.0.2",
+  );
+  assert.match(message, /`my-map` `1\.0\.1`/);
+  assert.match(message, /`1\.0\.2`/);
+  assert.match(message, /superseded/);
 });
 
 // --- decision logic ---


### PR DESCRIPTION
## Context

Follow-up from the ile-de-france incident: alerts for `1.0.0`/`1.0.1` stayed open (or had to be closed by hand) even after `1.0.2` passed integrity. Old release tags are never rewritten retroactively — creators fix forward — so an alert for a version strictly older than a complete latest version is moot.

## Changes

- `resolveAlertAgainstIntegrity` gains a `version_superseded` resolution: when the listing's `latest_semver_complete` is true and the alert's version is semver-older than `latest_semver_version`, the daily pruner closes the alert as completed, with a comment naming the newer version.
- Guards: strict stable-semver parsing on **both** sides (a non-semver tag never matches), and strict `<` comparison (a regression of the latest version itself is never closed as superseded — it stays live).
- `buildResolvedCloseComment` takes an optional `supersededBy` and renders a dedicated message.
- Unit tests: superseded, v-prefix mismatch, incomplete latest, non-semver version, latest-version regression, and the close-comment text. Full scripts suite passes (404/404).

With this, the currently open #7108 / #7109 (and any future equivalents) get closed automatically on the next daily prune run instead of waiting two weeks for the stale close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)