### PR TITLE
publish: preserve data-quality answers across map re-publish force-pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -441,6 +441,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "publish/map/${{ fromJson(steps.parser.outputs.jsonString).map-id }}"
+          # A re-run regenerates this branch from main and force-pushes, which
+          # would clobber the data-quality answers the questionnaire flow may
+          # have committed to the previous branch head (then rescore_data finds
+          # nothing and the merge gate never opens). Carry the answers file
+          # forward into the regenerated commit.
+          if git fetch origin "publish/map/${{ fromJson(steps.parser.outputs.jsonString).map-id }}"; then
+            git checkout FETCH_HEAD -- "maps/${{ fromJson(steps.parser.outputs.jsonString).map-id }}/data-quality.json" 2>/dev/null \
+              || echo "no prior data-quality answers to preserve"
+          fi
           git add -A
           git commit -m "feat(map): add ${{ fromJson(steps.parser.outputs.jsonString).map-id }}"
           gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/publish" 2>/dev/null || true


### PR DESCRIPTION
Fixes the force-push race that hit yukina-akita (#7430): a publish re-run regenerates \publish/map/<id>\ from main as a single commit and force-pushes, clobbering the \chore(data-quality): answers\ commit the questionnaire flow had added to the branch. \escore_data\ then honestly reports no \data-quality.json\ in the PR, and the \--require-presence\ merge gate never opens.

The regeneration step now fetches the old branch head (when one exists) and restores \maps/<id>/data-quality.json\ into the working tree before committing, so the answers ride along inside the regenerated commit. First publishes (no prior branch) and heads without answers skip the restore harmlessly.

Chose this over the alternative (having \escore_data\ fall back to the questionnaire issue) because a fallback would only fix the *confirmation* — the branch would still lack the answers file and \--require-presence\ would still block the merge. Preserving the file fixes both.

For #7430 itself the orphaned answers commit was recovered by cherry-pick (\26ee84459\) and re-confirmed — this PR prevents the next occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)