### PR TITLE
fix(registry): prune private-repo-wipe restoration burst from hourly series

### DIFF
--- a/analytics/hourly/downloads.csv
+++ b/analytics/hourly/downloads.csv
@@ -10518,13 +10518,10 @@ bucket_utc,listing_type,id,downloads
 2026-08-06T01:00Z,mod,advanced-analytics,10
 2026-08-06T01:00Z,mod,any-money,2
 2026-08-06T01:00Z,mod,citymapper,2
-2026-08-06T01:00Z,mod,danield1909-dantrains,2376
 2026-08-06T01:00Z,mod,danield1909-realism-pathfinding,2
 2026-08-06T01:00Z,mod,dantrains-abridged,1
 2026-08-06T01:00Z,mod,distance-circles,5
 2026-08-06T01:00Z,mod,game-speedup,3
-2026-08-06T01:00Z,mod,imb11-moveit,1255
-2026-08-06T01:00Z,mod,imb11-subwaycine,33
 2026-08-06T01:00Z,mod,improved-schematics,4
 2026-08-06T01:00Z,mod,induced-demand,4
 2026-08-06T01:00Z,mod,lrt-trains,1

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -33,7 +33,12 @@ when these lived at the top level), e.g. `pnpm --dir scripts run audit-download-
 - `backfill-hourly-downloads.ts` — deterministically rebuilds
   `analytics/hourly/downloads.csv` (rolling per-listing hourly deltas) from the
   git history of `downloads.json`; initial backfill and the recovery path if
-  the hourly appender's series is ever lost or corrupted.
+  the hourly appender's series is ever lost or corrupted. Caveat: any
+  administrative counter RAISE (grandfathered restore, ledger-rebuild recovery)
+  reads as a one-hour download burst — the clamp only guards drops. After such
+  a recovery (and after any backfill re-run spanning one), prune the affected
+  bucket rows manually; they otherwise distort the hour-of-day seasonality
+  until they age out of the 14-day window.
 
 One-time migrations that already ran are deleted rather than kept here — git
 history is the archive (see tmp/plans/registry-downsizing-audit.md for the list).


### PR DESCRIPTION
The 2026-08-06T01:00Z recovery commit that restored the wiped
dantrains/moveit/subwaycine counts (KNOWN_INCIDENTS, private-repo-wipe
entry) reads as a 3,664-download hour in the backfilled hourly series —
the backfill clamps counter drops but passes administrative raises
through. Zero real downloads (all three listings deprecated); the burst
inflated the mods hour-of-day seasonality at 01:00 to ~282/day vs a
~38/day organic average. Rows pruned; caveat documented in ops/README.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
