### PR TITLE
fix(ci): re-mint bot token before map-data publish in analytics workflow

### DIFF
--- a/.github/workflows/regenerate-registry-analytics.yml
+++ b/.github/workflows/regenerate-registry-analytics.yml
@@ -305,10 +305,21 @@ jobs:
           OSM_OVERPASS_URL: https://overpass-api.de/api/interpreter
         run: pnpm run generate-map-basemaps:backfill -- --continue-on-error
 
+      # Re-mint right before the push: app installation tokens live 1 hour, and the
+      # demand-stats + basemap steps can run past that (a 49-map re-extraction took
+      # ~87 minutes on 2026-08-13 and the publish failed with an expired token).
+      - name: Re-mint bot token for publish
+        id: bot-token-publish
+        if: ${{ always() }}
+        uses: ./.github/actions/mint-bot-token
+        with:
+          app-id: ${{ vars.REGISTRY_BOT_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+
       - name: Publish grid + basemap to map-data
         if: ${{ always() }}
         env:
-          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.bot-token-publish.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           shopt -s nullglob


### PR DESCRIPTION
Companion to #7706. [Run 31657238307](https://github.com/Subway-Builder-Modded/registry/actions/runs/31657238307)'s `generate-map-demand-stats` job took 87 minutes (49 republished jp-maps re-extracted) and the bot app installation token — minted at job start, 1-hour lifetime — was dead by the "Publish grid + basemap to map-data" step: `fatal: Authentication failed`, job failed, `commit` skipped, no bot PR.

Without this fix the failure self-perpetuates: the demand-stats cache that would make the next run fast only lands via a successful `commit` job, so every 4-hourly full run re-extracts the same 49 maps (~78 min), exceeds the token lifetime, and dies at the same step.

Fix: re-mint a fresh token (`bot-token-publish`) immediately before the publish step and use it there. The original job-start token remains for the restore + GraphQL steps, which run early. `if: always()` matches the publish step's own condition so the re-mint isn't skipped when basemap generation has soft-failed.

Note for merge order: this only affects future runs (reruns of the failed run use its original workflow snapshot). After merging both PRs, the next scheduled full run should complete end-to-end and land the demand-stats tar contents (demand cache, manifests, basemap-completeness) that #7706 couldn't salvage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)