### PR TITLE
fix: stop auto-closing Delete an Asset requests; repair the docs contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.gg/syG9YHMyeG
     about: Get help or discuss custom content
   - name: Documentation
-    url: https://subwaybuildermodded.com/https://subwaybuildermodded.com/railyard/docs/v0.2/developers/
+    url: https://subwaybuildermodded.com/railyard/docs/v0.2/developers/
     about: Read the submission documentation

--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -18,6 +18,7 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'data-quality') &&
       !contains(github.event.issue.labels.*.name, 'report') &&
       !contains(github.event.issue.labels.*.name, 'deprecate-asset') &&
+      !contains(github.event.issue.labels.*.name, 'delete-asset') &&
       !contains(github.event.issue.labels.*.name, 'undeprecate-asset') &&
       !contains(github.event.issue.labels.*.name, 'integrity-alert') &&
       github.event.issue.author_association != 'MEMBER' &&
@@ -45,6 +46,7 @@ jobs:
                 '- **[Map Data Quality](../../issues/new?template=data-quality.yml)** - Answer the data-quality questions for a map you own',
                 '- **[Report a Mod or Map](../../issues/new?template=report.yml)** - Report an issue with a listing',
                 '- **[Deprecate an Asset](../../issues/new?template=deprecate-asset.yml)** - Deprecate a mod or map you author or caretake',
+                '- **[Delete an Asset](../../issues/new?template=delete-asset.yml)** - Permanently delete a mod or map you author or caretake',
                 '- **[Remove Asset Deprecation](../../issues/new?template=undeprecate-asset.yml)** - Restore a deprecated mod or map you author or caretake',
               ].join('\n')
             });


### PR DESCRIPTION
Two live bugs found while auditing the retirement docs. Neither is a copy issue.

## 1. Every author's Delete request was being auto-closed

`close-invalid.yml` exempts every submission label **except `delete-asset`**. Its guard only spares MEMBER/OWNER/COLLABORATOR, so a Delete request from any ordinary author was auto-commented *"not created using a valid issue template"* and closed as `not_planned` — while `deprecate.yml`'s `delete-asset` job ran on the same issue in parallel.

The label was missed when the delete flow shipped in #7115, and the path has never been exercised by a non-maintainer (every deletion so far was maintainer-stamped), so it went unnoticed. Also adds **Delete an Asset** to the valid-template list that comment prints.

## 2. The Documentation contact link was broken

`config.yml` had the origin duplicated — `subwaybuildermodded.com/https://subwaybuildermodded.com/railyard/docs/...` — so the "Documentation" link shown to everyone opening an issue 404'd. Pre-existing and unrelated to the retirement work.

YAML parses; check-formatting clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)