### PR TITLE
docs(registry): document the delete flow, repo liveness, and the real script layout

### DIFF
--- a/.github/ISSUE_TEMPLATE/deprecate-asset.yml
+++ b/.github/ISSUE_TEMPLATE/deprecate-asset.yml
@@ -1,5 +1,5 @@
 name: Deprecate an Asset
-description: Permanently deprecate a mod or map you author or caretake in The Railyard registry.
+description: Retire a mod or map you author or caretake, reversibly, in The Railyard registry.
 title: "[Deprecate]: "
 labels: ["deprecate-asset"]
 body:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,32 +25,16 @@ registry/
 |       |-- close-invalid.yml
 |       `-- report.yml
 |-- scripts/
-|   |-- lib/
-|   |   |-- manifests.ts
-|   |   |-- map-constants.ts
-|   |   |-- map-field-utils.ts
-|   |   |-- map-update-logic.ts
-|   |   |-- downloads.ts
-|   |   |-- download-history.ts
-|   |   |-- map-demand-stats.ts
-|   |   |-- release-resolution.ts
-|   |   |-- discord-webhook.ts
-|   |   |-- registry-manifest.ts
-|   |   |-- mod-manifest.ts
-|   |   |-- gallery.ts
-|   |   |-- github.ts
-|   |   `-- custom-url.ts
-|   |-- tests/
-|   |-- generate-map-templates.ts
-|   |-- validate-publish.ts
-|   |-- validate-update.ts
-|   |-- create-listing.ts
-|   |-- update-listing.ts
-|   |-- generate-downloads.ts
-|   |-- generate-download-history.ts
-|   |-- generate-map-demand-stats.ts
-|   |-- notify-discord.ts
-|   `-- regenerate-indexes.ts
+|   |-- lib/            # shared modules (manifests, downloads, integrity, ...)
+|   |-- intake/         # issue-form flows: validate-*/create-listing/update-listing,
+|   |                   #   deprecate-listing, delete-listing, undeprecate-listing
+|   |-- downloads/      # generate-downloads, download history, attribution reconcile
+|   |-- listings/       # indexes, basemaps, demand stats, manifest sync
+|   |-- quality/        # data-quality checks, check-formatting
+|   |-- announce/       # Discord notification + announcement records
+|   |-- telemetry/      # app/website analytics capture
+|   |-- ops/            # one-off and recurring maintenance (repo liveness, repairs)
+|   `-- tests/
 |-- mods/
 |   |-- index.json
 |   |-- downloads.json
@@ -158,9 +142,19 @@ Each daily snapshot includes:
   "update": {
     "type": "github",
     "repo": "someuser/better-trains"
-  }
+  },
+  "is_test": false
 }
 ```
+
+Registry-maintained fields authors do not write directly:
+
+- `caretakers`: tenure records; the active caretaker shares the publisher's authority over
+  metadata, retirement, and download credit.
+- `deprecation` (`{since, by_github_id, reason?, deleted?}`): present iff the listing is
+  retired. `deleted: true` makes it permanent. Every consumer derives retirement from this
+  one field — the pipeline republishes retired listings with no complete integrity versions,
+  and clients hide them from browse by default.
 
 ### Map manifest (`maps/<map-id>/manifest.json`)
 
@@ -322,17 +316,27 @@ map-name.zip
 
 ## Script Responsibilities
 
-- `validate-publish.ts`: publish-time validation for maps/mods.
-- `validate-update.ts`: update-time validation and ownership checks.
-- `create-listing.ts`: creates new manifests and gallery files.
-- `update-listing.ts`: applies manifest metadata updates.
-- `regenerate-indexes.ts`: reindexes listings.
-- `generate-downloads.ts`: generates downloads in `full` or `download-only` mode.
-- `generate-download-history.ts`: caches daily combined download snapshots in `history/`.
-- `generate-map-demand-stats.ts`: updates map `population`/`residents_total`/`points_count`/`population_count`, writes `maps/<id>/grid.geojson`, and refreshes the versioned demand-stats cache.
-- `sync-map-file-sizes.ts`: syncs map manifest `file_sizes` from `maps/integrity.json` latest complete semver entries.
-- `generate-map-templates.ts`: generates and verifies map issue templates.
-- `notify-discord.ts`: shared Discord webhook notifier for workflow summaries.
+- `intake/validate-publish.ts`: publish-time validation for maps/mods.
+- `intake/validate-update.ts`: update-time validation and ownership checks.
+- `intake/create-listing.ts`: creates new manifests and gallery files.
+- `intake/update-listing.ts`: applies manifest metadata updates.
+- `intake/validate-deprecate.ts` / `intake/deprecate-listing.ts`: reversible retirement —
+  publisher or active caretaker only; stamps `deprecation` and freezes download counts.
+- `intake/validate-delete.ts` / `intake/delete-listing.ts`: permanent retirement — same
+  authorization, requires the permanence acknowledgement, accepts an already-deprecated
+  listing as escalation, and freezes counts the same way.
+- `intake/validate-undeprecate.ts` / `intake/undeprecate-listing.ts`: reverses a
+  deprecation; refuses deleted listings.
+- `listings/regenerate-indexes.ts`: reindexes listings.
+- `downloads/generate-downloads.ts`: generates downloads in `full` or `download-only` mode.
+- `downloads/generate-download-history.ts`: caches daily combined download snapshots in `history/`.
+- `listings/generate-map-demand-stats.ts`: updates map `population`/`residents_total`/`points_count`/`population_count`, writes `maps/<id>/grid.geojson`, and refreshes the versioned demand-stats cache.
+- `listings/sync-map-file-sizes.ts`: syncs map manifest `file_sizes` from `maps/integrity.json` latest complete semver entries.
+- `intake/generate-map-templates.ts`: generates and verifies map issue templates.
+- `announce/notify-discord.ts`: shared Discord webhook notifier for workflow summaries.
+- `ops/check-repo-liveness.ts`: opens/closes `repo-unreachable` review issues from
+  `maps|mods/repo-liveness.json`.
+- `quality/check-formatting.ts`: encoding and canonical-JSON invariants over tracked files.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,23 @@ All submissions are handled through GitHub Issues. Pick a template to get starte
 - [Update Your Author Profile](https://github.com/Subway-Builder-Modded/registry/issues/new?template=update-author.yml)
 - [Report an Issue](https://github.com/Subway-Builder-Modded/registry/issues/new?template=report.yml)
 - [Deprecate an Asset](https://github.com/Subway-Builder-Modded/registry/issues/new?template=deprecate-asset.yml)
+- [Delete an Asset](https://github.com/Subway-Builder-Modded/registry/issues/new?template=delete-asset.yml)
 - [Remove Asset Deprecation](https://github.com/Subway-Builder-Modded/registry/issues/new?template=undeprecate-asset.yml)
 
-Deprecation is asset-type agnostic (mods and maps share one form) and is restricted to the
-listing's original publisher or its **active caretaker** — collaborators cannot deprecate.
-A deprecated listing stops being downloadable and is hidden from browse and search results by
-default (it remains viewable behind the Deprecated filter on the app and website), and the
-listing itself, its download history, and its author attribution are kept permanently.
-Deprecation is fully reversible via the Remove Asset Deprecation form (same authorization rule).
+Retirement is asset-type agnostic (mods and maps share each form) and is restricted to the
+listing's original publisher or its **active caretaker** — collaborators cannot retire a
+listing. A retired listing stops being downloadable and is hidden from browse and search
+results by default (its class is selectable under the Status filter on the app and website),
+while the listing itself, its download history, and its author attribution are kept
+permanently.
+
+Two forms, differing only in permanence:
+
+- **Deprecate an Asset** is reversible via the Remove Asset Deprecation form (same
+  authorization rule). Existing installs are left in place.
+- **Delete an Asset** is permanent — there is no restoration flow, and clients purge the
+  asset from profiles, uninstalling it for users who had it. A deprecated listing may later
+  be escalated to deleted; the reverse is not possible.
 
 ## How It Works
 
@@ -44,7 +53,7 @@ PRs. Who can use each command is enforced by the workflows:
 
 | Command | Where | Who | Effect |
 | --- | --- | --- | --- |
-| `revalidate` | Any submission/update issue (publish-mod/map, update-mod/map, update-author, data-quality, deprecate-asset, undeprecate-asset) | Issue author or org OWNER/MEMBER/COLLABORATOR | Re-runs validation after the issue was edited (e.g. after a `failed-validation` result). |
+| `revalidate` | Any submission/update issue (publish-mod/map, update-mod/map, update-author, data-quality, deprecate-asset, delete-asset, undeprecate-asset) | Issue author or org OWNER/MEMBER/COLLABORATOR | Re-runs validation after the issue was edited (e.g. after a `failed-validation` result). |
 | `rescore_data [flags]` | Automated data-quality / publish **PRs** | OWNER/MEMBER/COLLABORATOR | Confirms the submitter's data-quality answers, applies the tier, and marks the publish PR ready to merge. Optional flags on the same line are passed through (e.g. `--admin` to bypass-merge). |
 | `admin_author` | Publish issues | Repo admin/maintain | Creates the listing with author `subway-builder-modded-admin`; the issue submitter is recorded as active **caretaker** (credited for downloads of versions released during their tenure) and added as a collaborator. Use for assets whose true author has no GitHub account. |
 | `data_quality_exempt` | Publish-map issues | Repo admin/maintain | Waives the data-quality merge gate for this submission: the publish PR is created (or updated) ready with the `dq-grandfathered` label and merges at `unknown-quality`. |
@@ -71,6 +80,11 @@ Download and release-integrity snapshots are generated into:
 - `mods/downloads.json`
 - `maps/integrity.json`
 - `mods/integrity.json`
+- `maps/grandfathered-downloads.json`, `mods/grandfathered-downloads.json` — counts frozen
+  when a listing is retired or a version stops resolving, so totals never regress
+- `maps/repo-liveness.json`, `mods/repo-liveness.json` — source repos observed as
+  definitively unreachable (deleted, renamed, or made private), with the clock that drives
+  the daily `repo-liveness-review` workflow
 
 Local commands:
 
@@ -100,6 +114,10 @@ Automation:
 - `regenerate-downloads-hourly.yml` runs hourly in download-only mode (updates downloads only; no ZIP integrity pass).
 - `regenerate-registry-analytics.yml` runs every 3 hours in full mode (refreshes downloads + integrity + integrity cache, map demand stats, and syncs map manifest `file_sizes` from integrity).
 - Full mode posts two Discord summaries (downloads/integrity and map demand stats) to the same webhook secret: `DISCORD_WEBHOOK_URL`.
+- `repo-liveness-review.yml` runs daily: source repos that have been definitively
+  unreachable past the threshold (default 72h) get a maintainer review issue labelled
+  `repo-unreachable`, closed automatically once the repo returns. Counts and integrity are
+  preserved throughout, so this is hygiene rather than data-loss triage.
 
 ## Security
 


### PR DESCRIPTION
Findings from the docs audit that go beyond the wording fix in #7825. Nothing here changes behavior.

## README

- **Delete an Asset was missing entirely** from the submission list, and from the `revalidate` command's documented scope even though `deprecate.yml` has always implemented revalidate for it.
- The retirement paragraph predated deletion *and* the Status filter — it was the **last remaining "Deprecated filter" reference in the repo** after #7825. Rewritten around the two forms: what they share, and the one way they differ — deletion is permanent, purges the asset from client profiles, and can be escalated to but never from.
- `grandfathered-downloads.json` and `repo-liveness.json` now appear among the generated files, and `repo-liveness-review.yml` in the automation list.

## ARCHITECTURE

- The script tree was **entirely pre-reorg** — none of `scripts/validate-publish.ts`, `scripts/generate-downloads.ts`, `scripts/create-listing.ts` etc. have existed since the move to `intake/`, `downloads/`, `listings/`, `quality/`, `announce/`, `telemetry/`, `ops/`. The file even contradicted itself (line 276 used the correct path while the tree above did not). Both the tree and every entry in Script Responsibilities are corrected, and the retirement/liveness/formatting scripts are now listed.
- The manifest data model never mentioned **`is_test`** (which is required by the schema), **`caretakers`**, or **`deprecation`** — the single field the entire retirement system derives from. Added as a "registry-maintained fields" note, so it is clear they exist but are not author-written.

## Issue form

`deprecate-asset.yml`'s description — the string GitHub shows in the template picker — read *"**Permanently** deprecate a mod or map"*, contradicting the form's own body ("can be restored via the Remove Asset Deprecation form") and claiming the word that now belongs to the delete form.

check-formatting and YAML parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)