### PR TITLE
feat(ops): track custom update endpoints in source liveness, not just repos

### DIFF
--- a/scripts/lib/downloads-download-only.ts
+++ b/scripts/lib/downloads-download-only.ts
@@ -10,7 +10,7 @@ import {
 } from "./download-attribution.js";
 import { toDownloadAssetBucketKey } from "./download-version-buckets.js";
 import { isManifestDeprecated } from "./downloads-full/deprecation.js";
-import { updateRepoLiveness } from "./repo-liveness.js";
+import { livenessSourceKey, updateSourceLiveness } from "./repo-liveness.js";
 import {
   type ListingContext,
   emptyIntegrity,
@@ -48,17 +48,27 @@ export async function generateDownloadsDataDownloadOnly(
   const versionBucketInputs: D.VersionBucketInputsByListing = {};
   const listingContexts = new Map<string, ListingContext>();
   const repoSet = new Set<string>();
-  // Repo -> non-deprecated, non-test listings referencing it, for liveness tracking.
-  const repoEligibleListings = new Map<string, Set<string>>();
-  const trackRepoListing = (repo: string, id: string, manifest: { is_test?: boolean; deprecation?: unknown }) => {
+  // Source key -> non-deprecated, non-test listings referencing it.
+  const sourceEligibleListings = new Map<string, Set<string>>();
+  const trackSourceListing = (
+    key: string,
+    id: string,
+    manifest: { is_test?: boolean; deprecation?: unknown },
+  ) => {
     if (manifest.is_test || isManifestDeprecated(manifest)) return;
-    let listings = repoEligibleListings.get(repo);
+    let listings = sourceEligibleListings.get(key);
     if (!listings) {
       listings = new Set();
-      repoEligibleListings.set(repo, listings);
+      sourceEligibleListings.set(key, listings);
     }
     listings.add(id);
   };
+  // Custom update endpoints, tracked alongside repos: when the host serving
+  // the JSON dies, the fetch fails before any repo can be parsed out of it, so
+  // repo-only tracking would never see the listing at all.
+  const reachableUrls = new Set<string>();
+  const transientUrls = new Set<string>();
+  const unreachableUrls = new Set<string>();
 
   for (const id of ids) {
     downloadsByListing[id] = {};
@@ -74,7 +84,7 @@ export async function generateDownloadsDataDownloadOnly(
     if (manifest.update.type === "github") {
       const repo = manifest.update.repo.toLowerCase();
       repoSet.add(repo);
-      trackRepoListing(repo, id, manifest);
+      trackSourceListing(livenessSourceKey("repo", repo), id, manifest);
       listingContexts.set(id, {
         id,
         listingType,
@@ -84,16 +94,24 @@ export async function generateDownloadsDataDownloadOnly(
       continue;
     }
 
-    const customFetch = await fetchCustomVersions(id, manifest.update.url, fetchImpl, warnings);
+    const updateUrl = manifest.update.url;
+    trackSourceListing(livenessSourceKey("url", updateUrl), id, manifest);
+    const customFetch = await fetchCustomVersions(id, updateUrl, fetchImpl, warnings);
     if (customFetch.transientError) {
+      transientUrls.add(updateUrl);
       downloadsByListing[id] = sortObjectByKeys(previousDownloads[id] ?? {});
       warnListing(warnings, id, "preserved previous custom-update downloads (transient fetch error)");
       continue;
     }
+    if (customFetch.sourceUnreachable) {
+      unreachableUrls.add(updateUrl);
+    } else {
+      reachableUrls.add(updateUrl);
+    }
     for (const version of customFetch.versions) {
       if (version.parsed) {
         repoSet.add(version.parsed.repo);
-        trackRepoListing(version.parsed.repo, id, manifest);
+        trackSourceListing(livenessSourceKey("repo", version.parsed.repo), id, manifest);
       }
     }
     listingContexts.set(id, {
@@ -120,11 +138,22 @@ export async function generateDownloadsDataDownloadOnly(
     const notFound: Record<string, string[]> = {};
     for (const repo of repoSet) {
       if (repoIndexes.has(repo) || unavailableRepos.has(repo)) continue;
-      notFound[repo] = [...(repoEligibleListings.get(repo) ?? [])];
+      const key = livenessSourceKey("repo", repo);
+      notFound[key] = [...(sourceEligibleListings.get(key) ?? [])];
     }
-    updateRepoLiveness(repoRoot, dir, {
-      reachable: repoIndexes.keys(),
-      transient: unavailableRepos,
+    for (const url of unreachableUrls) {
+      const key = livenessSourceKey("url", url);
+      notFound[key] = [...(sourceEligibleListings.get(key) ?? [])];
+    }
+    updateSourceLiveness(repoRoot, dir, {
+      reachable: [
+        ...[...repoIndexes.keys()].map((repo) => livenessSourceKey("repo", repo)),
+        ...[...reachableUrls].map((url) => livenessSourceKey("url", url)),
+      ],
+      transient: [
+        ...[...unavailableRepos].map((repo) => livenessSourceKey("repo", repo)),
+        ...[...transientUrls].map((url) => livenessSourceKey("url", url)),
+      ],
       notFound,
     }, nowIso);
   }

--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -1,7 +1,11 @@
 import type { ManifestDirectory, MapManifest } from "./manifests.js";
 import * as D from "./download-definitions.js";
 import { createGraphqlUsageState, fetchRepoReleaseIndexes, isSupportedReleaseTag, graphqlUsageSnapshot } from "./release-resolution.js";
-import { updateRepoLiveness } from "./repo-liveness.js";
+import {
+  livenessSourceKey,
+  parseLivenessSourceKey,
+  updateSourceLiveness,
+} from "./repo-liveness.js";
 import type {
   IntegrityCache,
   IntegrityCacheEntry,
@@ -344,6 +348,11 @@ async function resolveListingContexts(params: {
   repoActiveUse: Map<string, boolean>;
   // repo -> non-deprecated, non-test listing ids referencing it (liveness tracking).
   repoEligibleListings: Map<string, Set<string>>;
+  urlObservations: {
+    reachable: Set<string>;
+    transient: Set<string>;
+    unreachable: Set<string>;
+  };
   transientErrorListings: Set<string>;
 }): Promise<void> {
   const {
@@ -360,17 +369,21 @@ async function resolveListingContexts(params: {
     repoSet,
     repoActiveUse,
     repoEligibleListings,
+    urlObservations,
     transientErrorListings,
   } = params;
 
-  const markRepoUse = (repo: string, id: string, manifest: { is_test?: boolean; deprecation?: unknown }) => {
+  const markSourceUse = (key: string, id: string, manifest: { is_test?: boolean; deprecation?: unknown }) => {
     const isActive = !isManifestDeprecated(manifest) && manifest.is_test !== true;
-    repoActiveUse.set(repo, (repoActiveUse.get(repo) ?? false) || isActive);
+    const parsed = parseLivenessSourceKey(key);
+    if (parsed?.kind === "repo") {
+      repoActiveUse.set(parsed.value, (repoActiveUse.get(parsed.value) ?? false) || isActive);
+    }
     if (isActive) {
-      let listings = repoEligibleListings.get(repo);
+      let listings = repoEligibleListings.get(key);
       if (!listings) {
         listings = new Set();
-        repoEligibleListings.set(repo, listings);
+        repoEligibleListings.set(key, listings);
       }
       listings.add(id);
     }
@@ -401,7 +414,7 @@ async function resolveListingContexts(params: {
     if (manifest.update.type === "github") {
       const repo = manifest.update.repo.toLowerCase();
       repoSet.add(repo);
-      markRepoUse(repo, id, manifest);
+      markSourceUse(livenessSourceKey("repo", repo), id, manifest);
       listingContexts.set(id, {
         id,
         listingType,
@@ -415,17 +428,25 @@ async function resolveListingContexts(params: {
       await new Promise<void>((resolve) => setTimeout(resolve, CUSTOM_UPDATE_INTER_FETCH_DELAY_MS));
     }
     customFetchCount += 1;
-    const customFetch = await fetchCustomVersions(id, manifest.update.url, fetchImpl, warnings);
+    const updateUrl = manifest.update.url;
+    markSourceUse(livenessSourceKey("url", updateUrl), id, manifest);
+    const customFetch = await fetchCustomVersions(id, updateUrl, fetchImpl, warnings);
     if (customFetch.transientError) {
+      urlObservations.transient.add(updateUrl);
       downloadsByListing[id] = sortObjectByKeys(previousDownloads[id] ?? {});
       transientErrorListings.add(id);
       warnListing(warnings, id, "preserved previous custom-update downloads (transient fetch error)");
       continue;
     }
+    if (customFetch.sourceUnreachable) {
+      urlObservations.unreachable.add(updateUrl);
+    } else {
+      urlObservations.reachable.add(updateUrl);
+    }
     for (const version of customFetch.versions) {
       if (version.parsed) {
         repoSet.add(version.parsed.repo);
-        markRepoUse(version.parsed.repo, id, manifest);
+        markSourceUse(livenessSourceKey("repo", version.parsed.repo), id, manifest);
       }
     }
     listingContexts.set(id, {
@@ -1425,6 +1446,11 @@ export async function generateDownloadsDataFull(
   const repoSet = new Set<string>();
   const repoActiveUse = new Map<string, boolean>();
   const repoEligibleListings = new Map<string, Set<string>>();
+  const urlObservations = {
+    reachable: new Set<string>(),
+    transient: new Set<string>(),
+    unreachable: new Set<string>(),
+  };
   const transientErrorListings = new Set<string>();
 
   await resolveListingContexts({
@@ -1441,6 +1467,7 @@ export async function generateDownloadsDataFull(
     repoSet,
     repoActiveUse,
     repoEligibleListings,
+    urlObservations,
     transientErrorListings,
   });
 
@@ -1460,11 +1487,22 @@ export async function generateDownloadsDataFull(
     const notFound: Record<string, string[]> = {};
     for (const repo of repoSet) {
       if (repoIndexes.has(repo) || unavailableRepos.has(repo)) continue;
-      notFound[repo] = [...(repoEligibleListings.get(repo) ?? [])];
+      const key = livenessSourceKey("repo", repo);
+      notFound[key] = [...(repoEligibleListings.get(key) ?? [])];
     }
-    updateRepoLiveness(repoRoot, dir, {
-      reachable: repoIndexes.keys(),
-      transient: unavailableRepos,
+    for (const url of urlObservations.unreachable) {
+      const key = livenessSourceKey("url", url);
+      notFound[key] = [...(repoEligibleListings.get(key) ?? [])];
+    }
+    updateSourceLiveness(repoRoot, dir, {
+      reachable: [
+        ...[...repoIndexes.keys()].map((repo) => livenessSourceKey("repo", repo)),
+        ...[...urlObservations.reachable].map((url) => livenessSourceKey("url", url)),
+      ],
+      transient: [
+        ...[...unavailableRepos].map((repo) => livenessSourceKey("repo", repo)),
+        ...[...urlObservations.transient].map((url) => livenessSourceKey("url", url)),
+      ],
       notFound,
     }, nowIso);
   }

--- a/scripts/lib/downloads-support.ts
+++ b/scripts/lib/downloads-support.ts
@@ -433,7 +433,9 @@ export async function fetchZipBuffer(
 
 export type CustomVersionFetchResult =
   | { transientError: true; versions: [] }
-  | { transientError: false; versions: CustomVersionCandidate[] };
+  // sourceUnreachable marks the endpoint itself as definitively gone (a
+  // non-transient HTTP status), as opposed to reachable-but-unusable content.
+  | { transientError: false; versions: CustomVersionCandidate[]; sourceUnreachable?: boolean };
 
 function isTransientCustomFetchStatus(status: number): boolean {
   return status === 408 || status === 425 || status === 429 || status >= 500;
@@ -468,7 +470,8 @@ export async function fetchCustomVersions(
   if (!response.ok) {
     const transientError = isTransientCustomFetchStatus(response.status);
     warnListing(warnings, listingId, `custom update JSON returned HTTP ${response.status}${transientError ? " (transient; previous counts preserved)" : ""}`);
-    return { transientError, versions: [] };
+    if (transientError) return { transientError: true, versions: [] };
+    return { transientError: false, versions: [], sourceUnreachable: true };
   }
 
   let body: unknown;

--- a/scripts/lib/repo-liveness.ts
+++ b/scripts/lib/repo-liveness.ts
@@ -3,34 +3,54 @@ import { resolve } from "node:path";
 import type { ManifestDirectory } from "./manifests.js";
 import { isObject, writeJsonFile } from "./json-utils.js";
 
-// Tracks source repos that are currently unreachable in the permanent sense
-// (GitHub "Could not resolve to a Repository": deleted, renamed without
-// redirect, or made private). Transient failures (429/5xx) never touch this
-// file — an entry's first_unreachable_at only starts, and only clears, on a
-// definitive observation. Consumed by the repo-liveness review workflow,
-// which nags maintainers once a repo has been unreachable for multiple days.
+// Tracks update sources that are currently unreachable in the permanent sense:
+// a GitHub repo that returns "Could not resolve to a Repository" (deleted,
+// renamed without redirect, or made private), or a custom update JSON whose
+// endpoint returns a non-transient HTTP error. Transient failures (429/5xx,
+// network errors) never touch this file — an entry's first_unreachable_at only
+// starts, and only clears, on a definitive observation. Consumed by the
+// repo-liveness review workflow, which nags maintainers once a source has been
+// unreachable for multiple days.
+//
+// The file name predates custom-source support; entries are keyed by kind.
 
-export const REPO_LIVENESS_SCHEMA_VERSION = 1;
+export const REPO_LIVENESS_SCHEMA_VERSION = 2;
 
-export interface RepoLivenessEntry {
+export type LivenessSourceKind = "repo" | "url";
+
+/** Key space: "repo:owner/name" and "url:https://…" cannot collide. */
+export function livenessSourceKey(kind: LivenessSourceKind, value: string): string {
+  return `${kind}:${value}`;
+}
+
+export function parseLivenessSourceKey(
+  key: string,
+): { kind: LivenessSourceKind; value: string } | null {
+  if (key.startsWith("repo:")) return { kind: "repo", value: key.slice(5) };
+  if (key.startsWith("url:")) return { kind: "url", value: key.slice(4) };
+  return null;
+}
+
+export interface SourceLivenessEntry {
+  kind: LivenessSourceKind;
   first_unreachable_at: string;
   last_checked_at: string;
-  /** Non-deprecated, non-test listings that reference the repo. */
+  /** Non-deprecated, non-test listings that reference the source. */
   listings: string[];
 }
 
-export interface RepoLivenessFile {
+export interface SourceLivenessFile {
   schema_version: number;
   updated_at: string;
-  repos: Record<string, RepoLivenessEntry>;
+  sources: Record<string, SourceLivenessEntry>;
 }
 
-export interface RepoLivenessObservations {
-  /** Repos that resolved successfully this run. */
+export interface SourceLivenessObservations {
+  /** Source keys that resolved successfully this run. */
   reachable: Iterable<string>;
-  /** Repos that failed transiently this run (existing entries are kept as-is). */
+  /** Source keys that failed transiently (existing entries are kept as-is). */
   transient: Iterable<string>;
-  /** Definitively-unreachable repos, with the eligible listings referencing each. */
+  /** Definitively-unreachable source keys, with the eligible listings referencing each. */
   notFound: Record<string, string[]>;
 }
 
@@ -38,23 +58,32 @@ export function getRepoLivenessPath(repoRoot: string, dir: ManifestDirectory): s
   return resolve(repoRoot, dir, "repo-liveness.json");
 }
 
-export function loadRepoLiveness(repoRoot: string, dir: ManifestDirectory): RepoLivenessFile {
+export function loadSourceLiveness(repoRoot: string, dir: ManifestDirectory): SourceLivenessFile {
   const path = getRepoLivenessPath(repoRoot, dir);
-  const empty: RepoLivenessFile = {
+  const empty: SourceLivenessFile = {
     schema_version: REPO_LIVENESS_SCHEMA_VERSION,
     updated_at: "",
-    repos: {},
+    sources: {},
   };
   if (!existsSync(path)) return empty;
   try {
     const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
-    if (!isObject(raw) || !isObject(raw.repos)) return empty;
-    const repos: Record<string, RepoLivenessEntry> = {};
-    for (const [repo, value] of Object.entries(raw.repos)) {
+    if (!isObject(raw)) return empty;
+    // v1 stored bare repo names under `repos`; read them as repo-kind sources.
+    const legacy = isObject(raw.repos) ? raw.repos : null;
+    const current = isObject(raw.sources) ? raw.sources : null;
+    const sources: Record<string, SourceLivenessEntry> = {};
+    for (const [rawKey, value] of Object.entries(current ?? legacy ?? {})) {
       if (!isObject(value)) continue;
-      const entry = value as Partial<RepoLivenessEntry>;
-      if (typeof entry.first_unreachable_at !== "string" || typeof entry.last_checked_at !== "string") continue;
-      repos[repo] = {
+      const entry = value as Partial<SourceLivenessEntry>;
+      if (typeof entry.first_unreachable_at !== "string" || typeof entry.last_checked_at !== "string") {
+        continue;
+      }
+      const key = current ? rawKey : livenessSourceKey("repo", rawKey);
+      const parsed = parseLivenessSourceKey(key);
+      if (!parsed) continue;
+      sources[key] = {
+        kind: parsed.kind,
         first_unreachable_at: entry.first_unreachable_at,
         last_checked_at: entry.last_checked_at,
         listings: Array.isArray(entry.listings)
@@ -62,7 +91,7 @@ export function loadRepoLiveness(repoRoot: string, dir: ManifestDirectory): Repo
           : [],
       };
     }
-    return { ...empty, repos };
+    return { ...empty, sources };
   } catch {
     return empty;
   }
@@ -70,52 +99,59 @@ export function loadRepoLiveness(repoRoot: string, dir: ManifestDirectory): Repo
 
 /**
  * Pure state transition:
- * - reachable repo -> entry removed (repo recovered)
- * - not-found repo with eligible listings -> entry upserted; the original
+ * - reachable source -> entry removed (source recovered)
+ * - not-found source with eligible listings -> entry upserted; the original
  *   first_unreachable_at is preserved so the unreachable clock keeps running
- * - not-found repo whose listings are all deprecated/test -> never tracked
- * - transient repo -> existing entry carried over untouched (state unknown)
- * - repo absent from every observation (no longer referenced) -> entry removed
+ * - not-found source whose listings are all deprecated/test -> never tracked
+ * - transient source -> existing entry carried over untouched (state unknown)
+ * - source absent from every observation (no longer referenced) -> entry removed
  */
-export function applyRepoLivenessObservations(
-  previous: RepoLivenessFile,
-  observations: RepoLivenessObservations,
+export function applySourceLivenessObservations(
+  previous: SourceLivenessFile,
+  observations: SourceLivenessObservations,
   nowIso: string,
-): RepoLivenessFile {
+): SourceLivenessFile {
   const transient = new Set(observations.transient);
-  const repos: Record<string, RepoLivenessEntry> = {};
+  const sources: Record<string, SourceLivenessEntry> = {};
 
-  for (const repo of transient) {
-    const existing = previous.repos[repo];
-    if (existing) repos[repo] = existing;
+  for (const key of transient) {
+    const existing = previous.sources[key];
+    if (existing) sources[key] = existing;
   }
-  for (const [repo, listings] of Object.entries(observations.notFound)) {
+  for (const [key, listings] of Object.entries(observations.notFound)) {
     if (listings.length === 0) continue;
-    repos[repo] = {
-      first_unreachable_at: previous.repos[repo]?.first_unreachable_at ?? nowIso,
+    const parsed = parseLivenessSourceKey(key);
+    if (!parsed) continue;
+    sources[key] = {
+      kind: parsed.kind,
+      first_unreachable_at: previous.sources[key]?.first_unreachable_at ?? nowIso,
       last_checked_at: nowIso,
       listings: [...listings].sort(),
     };
   }
 
-  const sorted: Record<string, RepoLivenessEntry> = {};
-  for (const repo of Object.keys(repos).sort()) {
-    sorted[repo] = repos[repo]!;
+  const sorted: Record<string, SourceLivenessEntry> = {};
+  for (const key of Object.keys(sources).sort()) {
+    sorted[key] = sources[key]!;
   }
   return {
     schema_version: REPO_LIVENESS_SCHEMA_VERSION,
     updated_at: nowIso,
-    repos: sorted,
+    sources: sorted,
   };
 }
 
-export function updateRepoLiveness(
+export function updateSourceLiveness(
   repoRoot: string,
   dir: ManifestDirectory,
-  observations: RepoLivenessObservations,
+  observations: SourceLivenessObservations,
   nowIso: string,
-): RepoLivenessFile {
-  const next = applyRepoLivenessObservations(loadRepoLiveness(repoRoot, dir), observations, nowIso);
+): SourceLivenessFile {
+  const next = applySourceLivenessObservations(
+    loadSourceLiveness(repoRoot, dir),
+    observations,
+    nowIso,
+  );
   writeJsonFile(getRepoLivenessPath(repoRoot, dir), next);
   return next;
 }

--- a/scripts/ops/check-repo-liveness.ts
+++ b/scripts/ops/check-repo-liveness.ts
@@ -1,7 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { ManifestDirectory } from "../lib/manifests.js";
-import { loadRepoLiveness } from "../lib/repo-liveness.js";
+import {
+  loadSourceLiveness,
+  parseLivenessSourceKey,
+  type LivenessSourceKind,
+} from "../lib/repo-liveness.js";
 
 // Daily review pass over definitively-unreachable source repos (deleted,
 // renamed without redirect, or made private), as recorded in maps/mods
@@ -36,7 +40,9 @@ const apiHeaders: Record<string, string> = {
 };
 
 interface OverdueRepo {
+  /** Display form: "owner/name" for repos, the endpoint URL for custom sources. */
   repo: string;
+  kind: LivenessSourceKind;
   dir: ManifestDirectory;
   listings: string[];
   firstUnreachableAt: string;
@@ -51,11 +57,13 @@ interface IssueListItem {
 }
 
 function buildIssueTitle(repo: string): string {
-  return `Unreachable source repository: ${repo}`;
+  return `Unreachable source: ${repo}`;
 }
 
 function parseIssueTitle(title: string): string | null {
-  const match = /^Unreachable source repository: (\S+)$/.exec(title.trim());
+  // The legacy title form is still matched so issues opened before custom
+  // sources were tracked are recognised (and closed) rather than duplicated.
+  const match = /^Unreachable source(?: repository)?: (\S+)$/.exec(title.trim());
   return match ? match[1]! : null;
 }
 
@@ -65,9 +73,12 @@ function buildIssueBody(entry: OverdueRepo): string {
     const suffix = total !== undefined ? ` — ${total} preserved downloads` : "";
     return `- \`${entry.dir}/${id}\`${suffix}`;
   });
+  const subject =
+    entry.kind === "url"
+      ? `The custom update endpoint \`${entry.repo}\` has been returning a permanent error`
+      : `The source repository \`${entry.repo}\` has been definitively unreachable\n(deleted, renamed without redirect, or made private)`;
   return [
-    `The source repository \`${entry.repo}\` has been definitively unreachable`,
-    `(deleted, renamed without redirect, or made private) since`,
+    `${subject} since`,
     `**${entry.firstUnreachableAt}** — about **${Math.floor(entry.hoursUnreachable / 24)} day(s)** —`,
     `last confirmed at ${entry.lastCheckedAt}.`,
     "",
@@ -77,7 +88,9 @@ function buildIssueBody(entry: OverdueRepo): string {
     "Download counts and integrity state are preserved automatically while the",
     "repo is unreachable, so there is no data-loss urgency. Suggested review:",
     "",
-    "1. Check whether the repo moved (rename/transfer) — if so, update the listing manifests.",
+    entry.kind === "url"
+      ? "1. Check whether the JSON moved — if so, update the listing's custom update URL."
+      : "1. Check whether the repo moved (rename/transfer) — if so, update the listing manifests.",
     "2. If the author intends to keep it unavailable, deprecate the listing(s) via the",
     "   **Deprecate asset** issue form (download counts are frozen automatically on deprecation).",
     "3. If the outage was temporary, this issue closes itself once the repo is reachable again.",
@@ -101,9 +114,12 @@ function collectRepoState(nowMs: number): { overdue: OverdueRepo[]; tracked: Set
   const overdue: OverdueRepo[] = [];
   const tracked = new Set<string>();
   for (const dir of ["maps", "mods"] as const) {
-    const liveness = loadRepoLiveness(REPO_ROOT, dir);
+    const liveness = loadSourceLiveness(REPO_ROOT, dir);
     const downloads = loadListingTotals(dir);
-    for (const [repo, entry] of Object.entries(liveness.repos)) {
+    for (const [key, entry] of Object.entries(liveness.sources)) {
+      const parsed = parseLivenessSourceKey(key);
+      if (!parsed) continue;
+      const repo = parsed.value;
       tracked.add(repo);
       const firstMs = Date.parse(entry.first_unreachable_at);
       if (!Number.isFinite(firstMs)) continue;
@@ -118,6 +134,7 @@ function collectRepoState(nowMs: number): { overdue: OverdueRepo[]; tracked: Set
       }
       overdue.push({
         repo,
+        kind: parsed.kind,
         dir,
         listings: entry.listings,
         firstUnreachableAt: entry.first_unreachable_at,

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -487,8 +487,8 @@ test("download-only mode preserves previous downloads when a GitHub repo is temp
     );
     const liveness = JSON.parse(
       readFileSync(join(repoRoot, "mods", "repo-liveness.json"), "utf-8"),
-    ) as { repos: Record<string, unknown> };
-    assert.deepEqual(liveness.repos, {});
+    ) as { sources: Record<string, unknown> };
+    assert.deepEqual(liveness.sources, {});
   });
 });
 
@@ -643,8 +643,8 @@ test("download-only mode preserves previous downloads when a GitHub repo is priv
     );
     const liveness = JSON.parse(
       readFileSync(join(repoRoot, "mods", "repo-liveness.json"), "utf-8"),
-    ) as { repos: Record<string, { listings: string[] }> };
-    assert.deepEqual(liveness.repos["owner/gone"]?.listings, ["github-mod"]);
+    ) as { sources: Record<string, { listings: string[] }> };
+    assert.deepEqual(liveness.sources["repo:owner/gone"]?.listings, ["github-mod"]);
   });
 });
 

--- a/scripts/tests/repo-liveness.unit.test.ts
+++ b/scripts/tests/repo-liveness.unit.test.ts
@@ -1,29 +1,31 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  applyRepoLivenessObservations,
-  loadRepoLiveness,
-  updateRepoLiveness,
-  type RepoLivenessFile,
+  applySourceLivenessObservations,
+  livenessSourceKey,
+  loadSourceLiveness,
+  updateSourceLiveness,
+  type SourceLivenessFile,
 } from "../lib/repo-liveness.js";
 
 const T0 = "2026-08-01T00:00:00.000Z";
 const T1 = "2026-08-02T00:00:00.000Z";
 
-function fileWith(repos: RepoLivenessFile["repos"]): RepoLivenessFile {
-  return { schema_version: 1, updated_at: T0, repos };
+function fileWith(sources: SourceLivenessFile["sources"]): SourceLivenessFile {
+  return { schema_version: 2, updated_at: T0, sources };
 }
 
 test("a newly not-found repo starts its unreachable clock", () => {
-  const next = applyRepoLivenessObservations(fileWith({}), {
+  const next = applySourceLivenessObservations(fileWith({}), {
     reachable: [],
     transient: [],
-    notFound: { "owner/gone": ["mod-a", "mod-b"] },
+    notFound: { "repo:owner/gone": ["mod-a", "mod-b"] },
   }, T1);
-  assert.deepEqual(next.repos["owner/gone"], {
+  assert.deepEqual(next.sources["repo:owner/gone"], {
+    kind: "repo",
     first_unreachable_at: T1,
     last_checked_at: T1,
     listings: ["mod-a", "mod-b"],
@@ -32,83 +34,145 @@ test("a newly not-found repo starts its unreachable clock", () => {
 
 test("a repeatedly not-found repo keeps its original first_unreachable_at", () => {
   const previous = fileWith({
-    "owner/gone": { first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] },
+    "repo:owner/gone": { kind: "repo", first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] },
   });
-  const next = applyRepoLivenessObservations(previous, {
+  const next = applySourceLivenessObservations(previous, {
     reachable: [],
     transient: [],
-    notFound: { "owner/gone": ["mod-a"] },
+    notFound: { "repo:owner/gone": ["mod-a"] },
   }, T1);
-  assert.equal(next.repos["owner/gone"]?.first_unreachable_at, T0);
-  assert.equal(next.repos["owner/gone"]?.last_checked_at, T1);
+  assert.equal(next.sources["repo:owner/gone"]?.first_unreachable_at, T0);
+  assert.equal(next.sources["repo:owner/gone"]?.last_checked_at, T1);
 });
 
 test("a reachable repo clears its entry", () => {
   const previous = fileWith({
-    "owner/back": { first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] },
+    "repo:owner/back": { kind: "repo", first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] },
   });
-  const next = applyRepoLivenessObservations(previous, {
-    reachable: ["owner/back"],
+  const next = applySourceLivenessObservations(previous, {
+    reachable: ["repo:owner/back"],
     transient: [],
     notFound: {},
   }, T1);
-  assert.deepEqual(next.repos, {});
+  assert.deepEqual(next.sources, {});
 });
 
 test("a transient failure neither starts nor advances the clock", () => {
   const previous = fileWith({
-    "owner/flaky": { first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] },
+    "repo:owner/flaky": { kind: "repo", first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] },
   });
-  const next = applyRepoLivenessObservations(previous, {
+  const next = applySourceLivenessObservations(previous, {
     reachable: [],
-    transient: ["owner/flaky", "owner/new-flaky"],
+    transient: ["repo:owner/flaky", "repo:owner/new-flaky"],
     notFound: {},
   }, T1);
-  assert.deepEqual(next.repos["owner/flaky"], previous.repos["owner/flaky"]);
-  assert.equal("owner/new-flaky" in next.repos, false);
+  assert.deepEqual(next.sources["repo:owner/flaky"], previous.sources["repo:owner/flaky"]);
+  assert.equal("repo:owner/new-flaky" in next.sources, false);
 });
 
 test("repos referenced only by deprecated/test listings are never tracked", () => {
-  const next = applyRepoLivenessObservations(fileWith({}), {
+  const next = applySourceLivenessObservations(fileWith({}), {
     reachable: [],
     transient: [],
-    notFound: { "owner/gone": [] },
+    notFound: { "repo:owner/gone": [] },
   }, T1);
-  assert.deepEqual(next.repos, {});
+  assert.deepEqual(next.sources, {});
 });
 
 test("a repo no longer referenced by any listing is dropped", () => {
   const previous = fileWith({
-    "owner/delisted": { first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] },
+    "repo:owner/delisted": { kind: "repo", first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] },
   });
-  const next = applyRepoLivenessObservations(previous, {
+  const next = applySourceLivenessObservations(previous, {
     reachable: [],
     transient: [],
     notFound: {},
   }, T1);
-  assert.deepEqual(next.repos, {});
+  assert.deepEqual(next.sources, {});
 });
 
-test("updateRepoLiveness round-trips through the file", (t) => {
+test("updateSourceLiveness round-trips through the file", (t) => {
   const root = mkdtempSync(join(tmpdir(), "railyard-liveness-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   mkdirSync(join(root, "mods"), { recursive: true });
 
-  updateRepoLiveness(root, "mods", {
+  updateSourceLiveness(root, "mods", {
     reachable: [],
     transient: [],
-    notFound: { "owner/gone": ["mod-a"] },
+    notFound: { "repo:owner/gone": ["mod-a"] },
   }, T0);
-  const loaded = loadRepoLiveness(root, "mods");
-  assert.equal(loaded.repos["owner/gone"]?.first_unreachable_at, T0);
+  const loaded = loadSourceLiveness(root, "mods");
+  assert.equal(loaded.sources["repo:owner/gone"]?.first_unreachable_at, T0);
 
-  const written = JSON.parse(readFileSync(join(root, "mods", "repo-liveness.json"), "utf-8")) as RepoLivenessFile;
-  assert.equal(written.schema_version, 1);
+  const written = JSON.parse(readFileSync(join(root, "mods", "repo-liveness.json"), "utf-8")) as SourceLivenessFile;
+  assert.equal(written.schema_version, 2);
 
-  updateRepoLiveness(root, "mods", {
-    reachable: ["owner/gone"],
+  updateSourceLiveness(root, "mods", {
+    reachable: ["repo:owner/gone"],
     transient: [],
     notFound: {},
   }, T1);
-  assert.deepEqual(loadRepoLiveness(root, "mods").repos, {});
+  assert.deepEqual(loadSourceLiveness(root, "mods").sources, {});
+});
+
+test("a custom update endpoint is tracked like a repo", () => {
+  const url = "https://example.com/updates/map-a.json";
+  const key = livenessSourceKey("url", url);
+  const next = applySourceLivenessObservations(fileWith({}), {
+    reachable: [],
+    transient: [],
+    notFound: { [key]: ["map-a"] },
+  }, T1);
+  assert.deepEqual(next.sources[key], {
+    kind: "url",
+    first_unreachable_at: T1,
+    last_checked_at: T1,
+    listings: ["map-a"],
+  });
+
+  // Recovery clears it on the same rule as repos.
+  const recovered = applySourceLivenessObservations(next, {
+    reachable: [key],
+    transient: [],
+    notFound: {},
+  }, T1);
+  assert.deepEqual(recovered.sources, {});
+});
+
+test("a repo and a URL never collide in the key space", () => {
+  const shared = "owner/name";
+  const next = applySourceLivenessObservations(fileWith({}), {
+    reachable: [],
+    transient: [],
+    notFound: {
+      [livenessSourceKey("repo", shared)]: ["mod-a"],
+      [livenessSourceKey("url", shared)]: ["map-a"],
+    },
+  }, T1);
+  assert.equal(Object.keys(next.sources).length, 2);
+  assert.equal(next.sources[livenessSourceKey("repo", shared)]?.kind, "repo");
+  assert.equal(next.sources[livenessSourceKey("url", shared)]?.kind, "url");
+});
+
+test("a v1 file's bare repo names load as repo-kind sources", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "railyard-liveness-v1-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(join(root, "mods"), { recursive: true });
+  writeFileSync(
+    join(root, "mods", "repo-liveness.json"),
+    JSON.stringify({
+      schema_version: 1,
+      updated_at: T0,
+      repos: { "owner/gone": { first_unreachable_at: T0, last_checked_at: T0, listings: ["mod-a"] } },
+    }) + "\n",
+    "utf-8",
+  );
+
+  const loaded = loadSourceLiveness(root, "mods");
+  assert.deepEqual(loaded.sources["repo:owner/gone"], {
+    kind: "repo",
+    first_unreachable_at: T0,
+    last_checked_at: T0,
+    listings: ["mod-a"],
+  });
 });


### PR DESCRIPTION
First of the asymmetries surfaced by the docs audit, and the largest correctness gap of the set.

## The gap

Repo-liveness only ever keyed on `owner/repo`. For a `custom` listing, the repo is parsed out of GitHub release URLs found **inside** the fetched JSON — so when the host serving that JSON dies, the fetch fails *before* any repo can be extracted. The listing was never added to the observation set, never tracked, and never raised a review issue: one workflow-log line and nothing else.

That is the majority of the registry: **236 of 349 listings (68%) are `custom`** — 233 of 296 maps, 3 of 53 mods. The liveness system built after the private-repo wipe covered only the minority case, which went unnoticed because both incidents that motivated it happened to be GitHub-sourced.

## Changes

- `fetchCustomVersions` reports **`sourceUnreachable`** for a non-transient HTTP status, distinguishing "the endpoint is gone" from "the endpoint served something unusable". Malformed JSON stays untracked on purpose — the host is alive, that is a different failure.
- The liveness file is keyed **by source**: `repo:owner/name` or `url:https://…`, so the two kinds cannot collide (there is a test). `schema_version` 2; v1's bare repo names still load as repo-kind sources, so no migration is needed and an in-flight file cannot be misread.
- Both generators feed URL observations through the **same** reachable / transient / notFound classification as repos, so the 72-hour clock, auto-close on recovery, and the deprecated/test eligibility rule all apply unchanged. Network errors stay transient for URLs exactly as they do for repos — a dead domain and a blip are indistinguishable in one observation.
- The review issue names the right subject per kind and suggests the matching fix ("check whether the JSON moved — update the listing's custom update URL" vs. the repo rename). The title regex still matches the legacy form so pre-existing issues close rather than duplicate.

## Dry run (before opening this PR)

Ran the real fetch-and-classify path against **all 236 live custom endpoints**, read-only:

```
mods: 3 custom listings  | reachable=3   transient=0  unreachable=0
maps: 233 custom listings | reachable=233 transient=0  unreachable=0
would-track: {}
```

Every endpoint healthy, nothing tracked — **no false positives on rollout**, which was the main risk given this fires maintainer issues.

Positive control against a real 404 endpoint (`raw.githubusercontent.com/.../definitely-not-here.json`): classified `transientError=false, sourceUnreachable=true`, tracked as a `url` source with the correct listing attribution. So detection fires in the direction that matters.

449 tests pass (4 new: URL tracking + recovery, key-space collision, v1 migration); check-formatting clean.

## Note

The file name stays `repo-liveness.json` and the label stays `repo-unreachable` — renaming both would churn two workflows, the review script, and the README section documenting them (#7856, in flight). The file's header comment records that the name predates custom-source support. Happy to rename as a follow-up if you'd prefer accuracy over continuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)