### PR TITLE
feat(ops): flag listings left with no installable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ Download and release-integrity snapshots are generated into:
 - `mods/integrity.json`
 - `maps/grandfathered-downloads.json`, `mods/grandfathered-downloads.json` — counts frozen
   when a listing is retired or a version stops resolving, so totals never regress
-- `maps/repo-liveness.json`, `mods/repo-liveness.json` — source repos observed as
-  definitively unreachable (deleted, renamed, or made private), with the clock that drives
-  the daily `repo-liveness-review` workflow
+- `maps/repo-liveness.json`, `mods/repo-liveness.json` — listings observed as unavailable,
+  with the clock that drives the daily `repo-liveness-review` workflow. Entries are keyed by
+  cause: `repo:` (GitHub repo deleted, renamed, or made private), `url:` (custom update JSON
+  returning a permanent error), and `listing:` (source answers, but no installable version
+  remains). The file name predates the last two kinds.
 
 Local commands:
 
@@ -114,10 +116,12 @@ Automation:
 - `regenerate-downloads-hourly.yml` runs hourly in download-only mode (updates downloads only; no ZIP integrity pass).
 - `regenerate-registry-analytics.yml` runs every 3 hours in full mode (refreshes downloads + integrity + integrity cache, map demand stats, and syncs map manifest `file_sizes` from integrity).
 - Full mode posts two Discord summaries (downloads/integrity and map demand stats) to the same webhook secret: `DISCORD_WEBHOOK_URL`.
-- `repo-liveness-review.yml` runs daily: source repos that have been definitively
-  unreachable past the threshold (default 72h) get a maintainer review issue labelled
-  `repo-unreachable`, closed automatically once the repo returns. Counts and integrity are
-  preserved throughout, so this is hygiene rather than data-loss triage.
+- `repo-liveness-review.yml` runs daily: listings that have been unavailable past the
+  threshold (default 72h) — dead repo, dead custom endpoint, or no installable version left
+  — get a maintainer review issue labelled `repo-unreachable`, closed automatically once the
+  listing recovers. Counts and integrity are preserved throughout, so this is hygiene rather
+  than data-loss triage. Deprecated and test listings are never flagged; a listing whose
+  source is already reported is not reported twice.
 
 ## Security
 

--- a/mods/penguin-approved-rolling-stock/manifest.json
+++ b/mods/penguin-approved-rolling-stock/manifest.json
@@ -19,5 +19,10 @@
     "type": "github",
     "repo": "prodigious-penguin/Penguin-Approved-Rolling-Stock"
   },
-  "last_updated": 1785415916
+  "last_updated": 1785415916,
+  "deprecation": {
+    "since": "2026-08-14T15:39:45.878Z",
+    "by_github_id": 268817724,
+    "reason": "Maintainer-initiated: no version has ever passed integrity (both releases are missing a matching top-level manifest.json), the listing has never recorded a download, and it has been unavailable since 2026-07-26. Reversible — remove the deprecation once a release passes integrity."
+  }
 }

--- a/scripts/lib/downloads-download-only.ts
+++ b/scripts/lib/downloads-download-only.ts
@@ -10,7 +10,11 @@ import {
 } from "./download-attribution.js";
 import { toDownloadAssetBucketKey } from "./download-version-buckets.js";
 import { isManifestDeprecated } from "./downloads-full/deprecation.js";
-import { livenessSourceKey, updateSourceLiveness } from "./repo-liveness.js";
+import {
+  collectListingsWithoutInstallableVersion,
+  livenessSourceKey,
+  updateSourceLiveness,
+} from "./repo-liveness.js";
 import {
   type ListingContext,
   emptyIntegrity,
@@ -136,23 +140,53 @@ export async function generateDownloadsDataDownloadOnly(
 
   {
     const notFound: Record<string, string[]> = {};
+    const unreachableSourceKeys = new Set<string>();
     for (const repo of repoSet) {
       if (repoIndexes.has(repo) || unavailableRepos.has(repo)) continue;
-      const key = livenessSourceKey("repo", repo);
-      notFound[key] = [...(sourceEligibleListings.get(key) ?? [])];
+      unreachableSourceKeys.add(livenessSourceKey("repo", repo));
     }
     for (const url of unreachableUrls) {
-      const key = livenessSourceKey("url", url);
+      unreachableSourceKeys.add(livenessSourceKey("url", url));
+    }
+    for (const key of unreachableSourceKeys) {
       notFound[key] = [...(sourceEligibleListings.get(key) ?? [])];
     }
+
+    // Listing-level cause, evaluated against the published integrity snapshot
+    // this mode already loads. Both modes must apply it: the hourly
+    // download-only run would otherwise drop entries the full run recorded,
+    // resetting the clock every hour.
+    const eligibleForListingCheck = (id: string): boolean => {
+      try {
+        const manifest = getManifest(repoRoot, dir, id);
+        return !isManifestDeprecated(manifest) && manifest.is_test !== true;
+      } catch {
+        return false;
+      }
+    };
+    Object.assign(notFound, collectListingsWithoutInstallableVersion({
+      ids,
+      isEligible: (id) => hasIntegritySnapshot && eligibleForListingCheck(id),
+      hasCompleteVersion: (id) => integrity.listings[id]?.has_complete_version === true,
+      hasUnreachableSource: (id) =>
+        [...unreachableSourceKeys].some((key) => sourceEligibleListings.get(key)?.has(id) === true),
+    }));
+
     updateSourceLiveness(repoRoot, dir, {
       reachable: [
         ...[...repoIndexes.keys()].map((repo) => livenessSourceKey("repo", repo)),
         ...[...reachableUrls].map((url) => livenessSourceKey("url", url)),
+        ...(hasIntegritySnapshot
+          ? ids
+              .filter((id) => integrity.listings[id]?.has_complete_version === true)
+              .map((id) => livenessSourceKey("listing", id))
+          : []),
       ],
       transient: [
         ...[...unavailableRepos].map((repo) => livenessSourceKey("repo", repo)),
         ...[...transientUrls].map((url) => livenessSourceKey("url", url)),
+        // No integrity snapshot means no verdict on any listing this run.
+        ...(hasIntegritySnapshot ? [] : ids.map((id) => livenessSourceKey("listing", id))),
       ],
       notFound,
     }, nowIso);

--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -2,6 +2,7 @@ import type { ManifestDirectory, MapManifest } from "./manifests.js";
 import * as D from "./download-definitions.js";
 import { createGraphqlUsageState, fetchRepoReleaseIndexes, isSupportedReleaseTag, graphqlUsageSnapshot } from "./release-resolution.js";
 import {
+  collectListingsWithoutInstallableVersion,
   livenessSourceKey,
   parseLivenessSourceKey,
   updateSourceLiveness,
@@ -79,6 +80,7 @@ interface ListingMetaEntry {
   authorId: string;
   caretakerGithubId?: number;
   deprecated?: boolean;
+  isTest?: boolean;
 }
 
 interface AdjustedVersionCount {
@@ -409,6 +411,7 @@ async function resolveListingContexts(params: {
       authorId: manifest.author,
       caretakerGithubId: getActiveCaretaker(manifest)?.github_id,
       deprecated: isManifestDeprecated(manifest),
+      isTest: manifest.is_test === true,
     });
 
     if (manifest.update.type === "github") {
@@ -1483,30 +1486,6 @@ export async function generateDownloadsDataFull(
     suppressWarningRepos,
   });
 
-  {
-    const notFound: Record<string, string[]> = {};
-    for (const repo of repoSet) {
-      if (repoIndexes.has(repo) || unavailableRepos.has(repo)) continue;
-      const key = livenessSourceKey("repo", repo);
-      notFound[key] = [...(repoEligibleListings.get(key) ?? [])];
-    }
-    for (const url of urlObservations.unreachable) {
-      const key = livenessSourceKey("url", url);
-      notFound[key] = [...(repoEligibleListings.get(key) ?? [])];
-    }
-    updateSourceLiveness(repoRoot, dir, {
-      reachable: [
-        ...[...repoIndexes.keys()].map((repo) => livenessSourceKey("repo", repo)),
-        ...[...urlObservations.reachable].map((url) => livenessSourceKey("url", url)),
-      ],
-      transient: [
-        ...[...unavailableRepos].map((repo) => livenessSourceKey("repo", repo)),
-        ...[...urlObservations.transient].map((url) => livenessSourceKey("url", url)),
-      ],
-      notFound,
-    }, nowIso);
-  }
-
   const ctx: FullRunContext = {
     listingType,
     fetchImpl,
@@ -1551,6 +1530,57 @@ export async function generateDownloadsDataFull(
       continue;
     }
     await evaluateListing(ctx, id, context);
+  }
+
+  {
+    const notFound: Record<string, string[]> = {};
+    const unreachableSourceKeys = new Set<string>();
+    for (const repo of repoSet) {
+      if (repoIndexes.has(repo) || unavailableRepos.has(repo)) continue;
+      unreachableSourceKeys.add(livenessSourceKey("repo", repo));
+    }
+    for (const url of urlObservations.unreachable) {
+      unreachableSourceKeys.add(livenessSourceKey("url", url));
+    }
+    for (const key of unreachableSourceKeys) {
+      notFound[key] = [...(repoEligibleListings.get(key) ?? [])];
+    }
+
+    // Listing-level cause: the source answers, but nothing installable is
+    // left. Tombstoned versions carry no failed checks, so no per-version
+    // integrity alert can fire — this is the only signal for it. Skipped when
+    // the listing's own source is already reported above, so one dead upstream
+    // raises one issue rather than two.
+    const listingNotFound = collectListingsWithoutInstallableVersion({
+      ids,
+      isEligible: (id) => {
+        const meta = listingMeta.get(id);
+        return meta?.deprecated !== true && meta?.isTest !== true;
+      },
+      hasCompleteVersion: (id) => ctx.integrityListings[id]?.has_complete_version === true,
+      hasUnreachableSource: (id) =>
+        [...unreachableSourceKeys].some((key) => repoEligibleListings.get(key)?.has(id) === true),
+    });
+    Object.assign(notFound, listingNotFound);
+
+    updateSourceLiveness(repoRoot, dir, {
+      reachable: [
+        ...[...repoIndexes.keys()].map((repo) => livenessSourceKey("repo", repo)),
+        ...[...urlObservations.reachable].map((url) => livenessSourceKey("url", url)),
+        // Listings that still have an installable version clear any entry.
+        ...ids
+          .filter((id) => ctx.integrityListings[id]?.has_complete_version === true)
+          .map((id) => livenessSourceKey("listing", id)),
+      ],
+      transient: [
+        ...[...unavailableRepos].map((repo) => livenessSourceKey("repo", repo)),
+        ...[...urlObservations.transient].map((url) => livenessSourceKey("url", url)),
+        // A listing whose source failed transiently has an unknown version
+        // set this run; carry any existing entry rather than judging it.
+        ...[...transientErrorListings].map((id) => livenessSourceKey("listing", id)),
+      ],
+      notFound,
+    }, nowIso);
   }
 
   const sortedDownloads: D.DownloadsByListing = {};

--- a/scripts/lib/repo-liveness.ts
+++ b/scripts/lib/repo-liveness.ts
@@ -3,22 +3,26 @@ import { resolve } from "node:path";
 import type { ManifestDirectory } from "./manifests.js";
 import { isObject, writeJsonFile } from "./json-utils.js";
 
-// Tracks update sources that are currently unreachable in the permanent sense:
-// a GitHub repo that returns "Could not resolve to a Repository" (deleted,
-// renamed without redirect, or made private), or a custom update JSON whose
-// endpoint returns a non-transient HTTP error. Transient failures (429/5xx,
-// network errors) never touch this file — an entry's first_unreachable_at only
-// starts, and only clears, on a definitive observation. Consumed by the
-// repo-liveness review workflow, which nags maintainers once a source has been
-// unreachable for multiple days.
+// Tracks listings that are effectively unavailable, by cause:
+//   repo    — GitHub repo returning "Could not resolve to a Repository"
+//             (deleted, renamed without redirect, or made private)
+//   url     — custom update JSON whose endpoint returns a non-transient error
+//   listing — source reachable, but no installable version remains (every
+//             version removed upstream), which no per-version integrity alert
+//             can catch: tombstones carry no failed checks
+// Transient failures (429/5xx, network errors) never touch this file — an
+// entry's first_unreachable_at only starts, and only clears, on a definitive
+// observation. Consumed by the repo-liveness review workflow, which nags
+// maintainers once a cause has persisted for multiple days.
 //
-// The file name predates custom-source support; entries are keyed by kind.
+// The file name predates both custom sources and listing entries; the key kind
+// carries the distinction.
 
 export const REPO_LIVENESS_SCHEMA_VERSION = 2;
 
-export type LivenessSourceKind = "repo" | "url";
+export type LivenessSourceKind = "repo" | "url" | "listing";
 
-/** Key space: "repo:owner/name" and "url:https://…" cannot collide. */
+/** Key space: "repo:owner/name", "url:https://…" and "listing:<id>" cannot collide. */
 export function livenessSourceKey(kind: LivenessSourceKind, value: string): string {
   return `${kind}:${value}`;
 }
@@ -28,6 +32,7 @@ export function parseLivenessSourceKey(
 ): { kind: LivenessSourceKind; value: string } | null {
   if (key.startsWith("repo:")) return { kind: "repo", value: key.slice(5) };
   if (key.startsWith("url:")) return { kind: "url", value: key.slice(4) };
+  if (key.startsWith("listing:")) return { kind: "listing", value: key.slice(8) };
   return null;
 }
 
@@ -35,7 +40,7 @@ export interface SourceLivenessEntry {
   kind: LivenessSourceKind;
   first_unreachable_at: string;
   last_checked_at: string;
-  /** Non-deprecated, non-test listings that reference the source. */
+  /** Non-deprecated, non-test listings affected (the listing itself, for listing-kind). */
   listings: string[];
 }
 
@@ -154,4 +159,26 @@ export function updateSourceLiveness(
   );
   writeJsonFile(getRepoLivenessPath(repoRoot, dir), next);
   return next;
+}
+
+/**
+ * Listing-level observations: listings with no installable version left, keyed
+ * as listing-kind sources. Deprecated and test listings are excluded (their
+ * empty version set is intended), as are listings whose own source is already
+ * reported unreachable — one dead upstream should raise one issue.
+ */
+export function collectListingsWithoutInstallableVersion(params: {
+  ids: readonly string[];
+  isEligible: (id: string) => boolean;
+  hasCompleteVersion: (id: string) => boolean;
+  hasUnreachableSource: (id: string) => boolean;
+}): Record<string, string[]> {
+  const notFound: Record<string, string[]> = {};
+  for (const id of params.ids) {
+    if (!params.isEligible(id)) continue;
+    if (params.hasCompleteVersion(id)) continue;
+    if (params.hasUnreachableSource(id)) continue;
+    notFound[livenessSourceKey("listing", id)] = [id];
+  }
+  return notFound;
 }

--- a/scripts/ops/check-repo-liveness.ts
+++ b/scripts/ops/check-repo-liveness.ts
@@ -76,7 +76,9 @@ function buildIssueBody(entry: OverdueRepo): string {
   const subject =
     entry.kind === "url"
       ? `The custom update endpoint \`${entry.repo}\` has been returning a permanent error`
-      : `The source repository \`${entry.repo}\` has been definitively unreachable\n(deleted, renamed without redirect, or made private)`;
+      : entry.kind === "listing"
+        ? `The listing \`${entry.repo}\` has had no installable version — its source answers, but every version has been removed upstream —`
+        : `The source repository \`${entry.repo}\` has been definitively unreachable\n(deleted, renamed without redirect, or made private)`;
   return [
     `${subject} since`,
     `**${entry.firstUnreachableAt}** — about **${Math.floor(entry.hoursUnreachable / 24)} day(s)** —`,
@@ -85,15 +87,19 @@ function buildIssueBody(entry: OverdueRepo): string {
     "Affected listings:",
     ...listingLines,
     "",
-    "Download counts and integrity state are preserved automatically while the",
-    "repo is unreachable, so there is no data-loss urgency. Suggested review:",
+    "Download counts and integrity state are preserved automatically, so there is",
+    "no data-loss urgency. Suggested review:",
     "",
     entry.kind === "url"
       ? "1. Check whether the JSON moved — if so, update the listing's custom update URL."
-      : "1. Check whether the repo moved (rename/transfer) — if so, update the listing manifests.",
-    "2. If the author intends to keep it unavailable, deprecate the listing(s) via the",
-    "   **Deprecate asset** issue form (download counts are frozen automatically on deprecation).",
-    "3. If the outage was temporary, this issue closes itself once the repo is reachable again.",
+      : entry.kind === "listing"
+        ? "1. Check whether the releases were removed deliberately — if not, re-publishing one restores the listing."
+        : "1. Check whether the repo moved (rename/transfer) — if so, update the listing manifests.",
+    "2. If the author intends to keep it unavailable, retire the listing(s) via the",
+    "   **Deprecate an Asset** or **Delete an Asset** form (counts are frozen either way).",
+    entry.kind === "listing"
+      ? "3. This issue closes itself once any version is installable again."
+      : "3. This issue closes itself once the source is reachable again.",
     "",
     "_Opened automatically by the repo-liveness review workflow; see KNOWN_INCIDENTS.md_",
     "_(2026-08-04 private-repo wipe) for the incident that motivated this check._",
@@ -158,7 +164,7 @@ async function ensureLabelExists(): Promise<void> {
     body: JSON.stringify({
       name: REPO_UNREACHABLE_LABEL,
       color: "d93f0b",
-      description: "Source repo for one or more listings is unreachable; maintainer review needed",
+      description: "A listing is unavailable (dead source, or no installable version); maintainer review needed",
     }),
   });
   // 422 = already exists — the expected steady state.

--- a/scripts/tests/repo-liveness.unit.test.ts
+++ b/scripts/tests/repo-liveness.unit.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   applySourceLivenessObservations,
+  collectListingsWithoutInstallableVersion,
   livenessSourceKey,
   loadSourceLiveness,
   updateSourceLiveness,
@@ -175,4 +176,62 @@ test("a v1 file's bare repo names load as repo-kind sources", (t) => {
     last_checked_at: T0,
     listings: ["mod-a"],
   });
+});
+
+test("a listing with no installable version is tracked", () => {
+  const found = collectListingsWithoutInstallableVersion({
+    ids: ["live-mod", "dead-mod"],
+    isEligible: () => true,
+    hasCompleteVersion: (id) => id === "live-mod",
+    hasUnreachableSource: () => false,
+  });
+  assert.deepEqual(found, { "listing:dead-mod": ["dead-mod"] });
+});
+
+test("deprecated and test listings are never tracked as dead listings", () => {
+  // Their empty version set is the deprecation overlay working as intended.
+  const found = collectListingsWithoutInstallableVersion({
+    ids: ["retired-mod", "test-mod"],
+    isEligible: () => false,
+    hasCompleteVersion: () => false,
+    hasUnreachableSource: () => false,
+  });
+  assert.deepEqual(found, {});
+});
+
+test("a listing whose source is already reported is not double-reported", () => {
+  // One dead upstream should raise one issue, not two.
+  const found = collectListingsWithoutInstallableVersion({
+    ids: ["orphan-mod"],
+    isEligible: () => true,
+    hasCompleteVersion: () => false,
+    hasUnreachableSource: () => true,
+  });
+  assert.deepEqual(found, {});
+});
+
+test("listing entries share the clock and recovery rules of every other kind", () => {
+  const key = livenessSourceKey("listing", "dead-mod");
+  const first = applySourceLivenessObservations(fileWith({}), {
+    reachable: [],
+    transient: [],
+    notFound: { [key]: ["dead-mod"] },
+  }, T0);
+  assert.equal(first.sources[key]?.kind, "listing");
+
+  // A transient source failure must not advance or clear the clock.
+  const held = applySourceLivenessObservations(first, {
+    reachable: [],
+    transient: [key],
+    notFound: {},
+  }, T1);
+  assert.equal(held.sources[key]?.first_unreachable_at, T0);
+
+  // A version becoming installable again clears it.
+  const recovered = applySourceLivenessObservations(held, {
+    reachable: [key],
+    transient: [],
+    notFound: {},
+  }, T1);
+  assert.deepEqual(recovered.sources, {});
 });


### PR DESCRIPTION
Asymmetry 2 of the audit set, and the last silent path to an unavailable listing.

## The gap (narrower than the audit suggested)

I measured before building: **no listing is currently in the silent state.** The two live listings with zero installable versions (`penguin-approved-rolling-stock`, `test-mod-vulnscan`) both have *failed* `required_checks`, so they alert today as intended. And #7858 closed one of the two silent paths — a dead custom endpoint now raises a review issue.

The residual hole is exactly one case: **the source answers, but every version is gone.** Those versions become tombstones carrying `required_checks: {}`, so the alert condition (`some check === false`) never fires, and liveness sees a healthy source. Latent rather than active — worth closing before it bites.

## Why not integrity alerts

Emitting an alert for tombstoned versions fights that model in two ways: alerts are version-keyed, and the pruner treats `availability === "removed"` as **resolved** (`integrity-alert-pruning.ts:57`), so such an alert would be auto-closed on the next daily pass. Sidestepping is cleaner than bending it.

## Design

A third liveness kind, `listing:<id>`, reusing the clock, 72h threshold, auto-close on recovery, and deprecated/test eligibility that the `repo` and `url` kinds already prove.

- `collectListingsWithoutInstallableVersion` is **shared by both generators** so the rule cannot drift. Both must apply it: the hourly download-only run would otherwise drop entries the 4-hourly full run recorded, resetting the clock every hour. Download-only evaluates against the published integrity snapshot it already loads; with no snapshot it reports every listing *transient* rather than judging them.
- **No double-reporting**: a listing whose own source is already reported unreachable is skipped, so one dead upstream raises one issue, not two.
- **No flapping**: a listing whose source failed transiently is held, not judged.
- Review-issue copy gains a listing variant (re-publish a release, or retire via deprecate/delete), and the label description now covers all three causes.

## Dry run

Applied the rule to committed integrity across all 349 listings, read-only:

```
mods: 53 listings  | would-track=1 | correctly-skipped (retired/test) = 9
  WOULD TRACK: listing:penguin-approved-rolling-stock
maps: 296 listings | would-track=0 | correctly-skipped = 1
```

**Merging this will open exactly one issue**, for `penguin-approved-rolling-stock` — a genuinely dead listing: both versions (v1.0.0, v1.1.0, released 2026-07-20 and 07-25) fail integrity on a missing/mismatched `manifest.json`, it has never recorded a download, and it has sat that way since at least 2026-07-26. It is not deprecated and not a test listing, so flagging it is correct — this is precisely the "sitting unnoticed" case the review workflow exists for.

Worth noting it *does* also have per-version integrity alerts, since its versions carry failed checks. I kept the rule at "zero installable versions" rather than "zero installable versions **and** no failed checks": the 72h debounce means it only fires for listings that stay dead, and a listing dead for three weeks with an unactioned author alert is exactly what should escalate to a maintainer. Say the word if you'd rather narrow it to the strictly-silent case.

453 tests (4 new: the rule, the deprecated/test exclusion, the no-double-report guard, and clock/recovery parity with the other kinds); check-formatting clean. README updated for the third kind, now that #7856 has merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)