### PR TITLE
feat(intake): let the two code owners retire any listing

### DIFF
--- a/scripts/intake/validate-delete.ts
+++ b/scripts/intake/validate-delete.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { getActiveCaretaker, type ManifestWithCaretakers } from "../lib/caretakers.js";
+import { isMaintainer } from "../lib/maintainers.js";
 import { resolveListingById } from "../lib/manifests.js";
 
 const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
@@ -55,7 +56,10 @@ function main() {
       const activeCaretaker = getActiveCaretaker(manifest as unknown as ManifestWithCaretakers);
       const caretakerId = activeCaretaker ? String(activeCaretaker.github_id) : null;
 
-      if (requesterId !== ownerId && requesterId !== caretakerId) {
+      // Code owners may act on any listing (see lib/maintainers.ts); the
+      // stamped by_github_id records who did, so the manifest still shows it
+      // was a maintainer action rather than the author's.
+      if (!isMaintainer(requesterId) && requesterId !== ownerId && requesterId !== caretakerId) {
         errors.push(
           `**Ownership check failed**: Only the original publisher or the active caretaker of `
           + `\`${id}\` can delete it. Collaborators cannot delete a listing.`,

--- a/scripts/intake/validate-deprecate.ts
+++ b/scripts/intake/validate-deprecate.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { getActiveCaretaker, type ManifestWithCaretakers } from "../lib/caretakers.js";
+import { isMaintainer } from "../lib/maintainers.js";
 import { resolveListingById } from "../lib/manifests.js";
 
 const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
@@ -51,7 +52,10 @@ function main() {
       const activeCaretaker = getActiveCaretaker(manifest as unknown as ManifestWithCaretakers);
       const caretakerId = activeCaretaker ? String(activeCaretaker.github_id) : null;
 
-      if (requesterId !== ownerId && requesterId !== caretakerId) {
+      // Code owners may act on any listing (see lib/maintainers.ts); the
+      // stamped by_github_id records who did, so the manifest still shows it
+      // was a maintainer action rather than the author's.
+      if (!isMaintainer(requesterId) && requesterId !== ownerId && requesterId !== caretakerId) {
         errors.push(
           `**Ownership check failed**: Only the original publisher or the active caretaker of `
           + `\`${id}\` can deprecate it. Collaborators cannot deprecate a listing.`,

--- a/scripts/intake/validate-undeprecate.ts
+++ b/scripts/intake/validate-undeprecate.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { getActiveCaretaker, type ManifestWithCaretakers } from "../lib/caretakers.js";
+import { isMaintainer } from "../lib/maintainers.js";
 import { resolveListingById } from "../lib/manifests.js";
 
 const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
@@ -47,7 +48,10 @@ function main() {
       const activeCaretaker = getActiveCaretaker(manifest as unknown as ManifestWithCaretakers);
       const caretakerId = activeCaretaker ? String(activeCaretaker.github_id) : null;
 
-      if (requesterId !== ownerId && requesterId !== caretakerId) {
+      // Code owners may act on any listing (see lib/maintainers.ts); the
+      // stamped by_github_id records who did, so the manifest still shows it
+      // was a maintainer action rather than the author's.
+      if (!isMaintainer(requesterId) && requesterId !== ownerId && requesterId !== caretakerId) {
         errors.push(
           `**Ownership check failed**: Only the original publisher or the active caretaker of `
           + `\`${id}\` can remove its deprecation. Collaborators cannot.`,

--- a/scripts/lib/maintainers.ts
+++ b/scripts/lib/maintainers.ts
@@ -1,0 +1,21 @@
+// The repository's code owners (.github/CODEOWNERS), by GitHub numeric ID.
+//
+// These accounts may retire a listing they do not own. The Terms of Service
+// reserve that authority — §2(a) for content left broken, §3(a) for takedowns
+// — but the retirement forms otherwise accept only the publisher or active
+// caretaker, so acting on an abandoned listing meant bypassing the flow and
+// hand-editing the manifest.
+//
+// Deliberately a versioned constant rather than a repo variable: changing who
+// can retire someone else's listing should require a reviewed PR, and the
+// CODEOWNERS rule above means these two must approve it.
+const MAINTAINER_GITHUB_IDS: readonly number[] = [
+  268817724, // subway-builder-modded-admin
+  19807509, // ahkimn
+];
+
+export function isMaintainer(githubId: string | number | undefined): boolean {
+  if (githubId === undefined) return false;
+  const id = typeof githubId === "number" ? githubId : Number.parseInt(githubId, 10);
+  return Number.isFinite(id) && MAINTAINER_GITHUB_IDS.includes(id);
+}

--- a/scripts/tests/delete-intake.integration.test.ts
+++ b/scripts/tests/delete-intake.integration.test.ts
@@ -250,3 +250,27 @@ test("un-deprecation refuses permanently deleted assets", (t) => {
   );
   assert.equal(existsSync(join(root, "mods", "fixture-mod", "grandfathered-downloads.json")), false);
 });
+
+test("a code owner may delete a listing they do not own", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // ahkimn — see lib/maintainers.ts.
+  const result = runScript("validate-delete", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: "19807509",
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("a code owner still has to acknowledge permanence", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // The override covers ownership only; every other guard still applies.
+  const result = runScript("validate-delete", root, {
+    ISSUE_JSON: issueJson("fixture-mod", { confirmed: false }),
+    ISSUE_AUTHOR_ID: "19807509",
+  });
+  assert.notEqual(result.status, 0);
+});

--- a/scripts/tests/deprecate-intake.integration.test.ts
+++ b/scripts/tests/deprecate-intake.integration.test.ts
@@ -276,3 +276,26 @@ test("deprecate-listing succeeds without freezing when the listing has no counts
   assert.ok(result.stdout.includes("No download counts to freeze"));
   assert.equal(existsSync(join(root, "mods", "grandfathered-downloads.json")), false);
 });
+
+test("a code owner may deprecate a listing they do not own", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // subway-builder-modded-admin — see lib/maintainers.ts.
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: "268817724",
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("a non-owner who is not a code owner is still rejected", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": baseModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScript("validate-deprecate", root, {
+    ISSUE_JSON: issueJson("fixture-mod"),
+    ISSUE_AUTHOR_ID: String(STRANGER_ID),
+  });
+  assert.notEqual(result.status, 0);
+});

--- a/scripts/tests/undeprecate-intake.integration.test.ts
+++ b/scripts/tests/undeprecate-intake.integration.test.ts
@@ -172,3 +172,29 @@ test("undeprecate-listing refuses a listing that is not deprecated", (t) => {
   const result = runScript("undeprecate-listing", root, { ISSUE_JSON });
   assert.notEqual(result.status, 0);
 });
+
+test("a code owner may remove a deprecation they did not create", (t) => {
+  const root = makeFixtureRepo({ "fixture-mod": deprecatedModManifest("fixture-mod") });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // subway-builder-modded-admin — see lib/maintainers.ts.
+  const result = runScript("validate-undeprecate", root, {
+    ISSUE_JSON,
+    ISSUE_AUTHOR_ID: "268817724",
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("a code owner still cannot restore a deleted listing", (t) => {
+  const manifest = deprecatedModManifest("fixture-mod");
+  (manifest.deprecation as Record<string, unknown>).deleted = true;
+  const root = makeFixtureRepo({ "fixture-mod": manifest });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // Deletion is permanent for everyone; the override covers ownership only.
+  const result = runScript("validate-undeprecate", root, {
+    ISSUE_JSON,
+    ISSUE_AUTHOR_ID: "268817724",
+  });
+  assert.notEqual(result.status, 0);
+});


### PR DESCRIPTION
The three retirement validators (`validate-deprecate`, `validate-delete`, `validate-undeprecate`) all require the requester to be the listing's publisher or active caretaker. Retiring an abandoned listing — e.g. `penguin-approved-rolling-stock` in #7859 — meant hand-editing the manifest and bypassing the intake path entirely.

`scripts/lib/maintainers.ts` holds the `.github/CODEOWNERS` accounts by numeric GitHub ID, and the three validators now bypass **only** the ownership check for them.

Scoped deliberately narrowly:

- Not "any org owner" and not a repo variable — a versioned constant, so changing who can retire someone else's listing needs a reviewed PR.
- Only the ownership check moves. Deletion is still permanent for code owners, the permanence acknowledgement is still required, and a deleted listing still cannot be un-deprecated.
- `by_github_id` is stamped as usual, so the manifest records that a maintainer acted rather than the author.

Tests: 459 pass. New cases cover a code owner deprecating/deleting a listing they do not own, a code owner still needing the acknowledgement, a code owner un-deprecating someone else's listing, a code owner failing to restore a deleted one, and strangers still being rejected throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)