### PR TITLE
feat(integrity): mark pruned github releases retired, not merely incomplete

### DIFF
--- a/scripts/lib/downloads-full.ts
+++ b/scripts/lib/downloads-full.ts
@@ -841,6 +841,19 @@ async function evaluateGithubListing(
         ctx.nowIso,
         ["release has no .zip asset"],
       );
+      // Pruning the ZIP off a published release is the github analog of a
+      // custom source's `retired: true`: the artifact is withdrawn, the version
+      // stays listed. Gated on the version having been installable before, so a
+      // release still awaiting its first upload is never labelled retired, and
+      // accepting a previously-retired entry keeps the label across cache
+      // invalidation. Compatibility metadata is carried over for the same
+      // reason the custom path keeps it — there is no release ZIP left to parse.
+      const previous = ctx.previousIntegrity?.listings[id]?.versions?.[tag];
+      if (previous?.is_complete === true || previous?.availability === "retired") {
+        result.availability = "retired";
+        if (previous.game_version) result.game_version = previous.game_version;
+        if (previous.dependencies) result.dependencies = previous.dependencies;
+      }
       state.versionEntries[tag] = result;
       state.nextListingCacheEntries[tag] = {
         fingerprint,

--- a/scripts/lib/integrity.ts
+++ b/scripts/lib/integrity.ts
@@ -36,8 +36,9 @@ export interface IntegrityVersionEntry {
   // date). Rules-bump-proof; backfilled onto reused cache entries at no cost.
   released_at?: string;
   // Present only when the version is no longer downloadable by design:
-  // "retired" = the author's update.json still lists the version but marks it
-  // retired (download stripped); "removed" = the version stopped being
+  // "retired" = the author withdrew the artifact but kept the version listed —
+  // update.json marks it `retired: true`, or a github release lost the ZIP it
+  // was published with; "removed" = the version stopped being
   // enumerated upstream entirely and this entry is carried forward frozen from
   // the previous committed integrity output. Absent on live versions.
   availability?: "retired" | "removed";

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -2388,3 +2388,211 @@ test("repo-level fetch warnings are suppressed for repos referenced only by depr
     );
   });
 });
+
+// Author-declared version retirement, github flavor: the release survives, its
+// ZIP does not. Mirrors the custom-source `retired: true` outcome.
+test("github release whose ZIP was pruned after publishing is marked retired", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["pruned-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "pruned-mod", {
+      ...makeBaseModManifest("pruned-mod"),
+      update: { type: "github", repo: "owner/pruned" },
+    });
+    writeJson(join(repoRoot, "mods", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-03-14T00:00:00Z",
+      listings: {
+        "pruned-mod": {
+          has_complete_version: true,
+          latest_semver_version: "v1.0.0",
+          latest_semver_complete: true,
+          complete_versions: ["v1.0.0"],
+          incomplete_versions: [],
+          versions: {
+            "v1.0.0": {
+              is_complete: true,
+              errors: [],
+              required_checks: { release_manifest_asset: true, zip_manifest_json: true },
+              matched_files: { release_manifest_asset: "manifest.json", zip_manifest_json: "manifest.json" },
+              game_version: ">=0.2.0",
+              dependencies: { "subway-builder": ">=0.2.0" },
+              source: {
+                update_type: "github",
+                repo: "owner/pruned",
+                tag: "v1.0.0",
+                asset_name: "pruned-v1.zip",
+                download_url: "https://downloads.example.com/pruned-v1.zip",
+              },
+              fingerprint: "github:owner/pruned:v1.0.0:pruned-v1.zip",
+              checked_at: "2026-03-14T00:00:00Z",
+            },
+          },
+        },
+      },
+    });
+
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: () => jsonResponse({
+          data: {
+            repository: {
+              releases: {
+                nodes: [
+                  {
+                    tagName: "v1.0.0",
+                    releaseAssets: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+            rateLimit: { remaining: 120, cost: 1, resetAt: "2026-03-14T00:00:00Z" },
+          },
+        }),
+      },
+    ]);
+
+    const result = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    const version = result.integrity.listings["pruned-mod"].versions["v1.0.0"];
+    assert.equal(version.availability, "retired");
+    assert.equal(version.is_complete, false);
+    assert.deepEqual(version.errors, ["release has no .zip asset"]);
+    // Compatibility metadata survives the withdrawal; the ZIP that declared it
+    // is gone, so it cannot be re-derived.
+    assert.equal(version.game_version, ">=0.2.0");
+    assert.deepEqual(version.dependencies, { "subway-builder": ">=0.2.0" });
+    // The version stays listed (not a "removed" tombstone) but stops being
+    // installable, and a deliberate withdrawal must not nag the author.
+    assert.deepEqual(result.integrity.listings["pruned-mod"].complete_versions, []);
+    assert.deepEqual(result.integrity.listings["pruned-mod"].incomplete_versions, ["v1.0.0"]);
+    assert.equal(result.integrity.listings["pruned-mod"].latest_semver_version, "v1.0.0");
+    assert.deepEqual(result.integrityAlerts, []);
+  });
+});
+
+test("a retired github version keeps its label when the integrity cache is bypassed", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["still-pruned-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "still-pruned-mod", {
+      ...makeBaseModManifest("still-pruned-mod"),
+      update: { type: "github", repo: "owner/still-pruned" },
+    });
+    writeJson(join(repoRoot, "mods", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-03-14T00:00:00Z",
+      listings: {
+        "still-pruned-mod": {
+          has_complete_version: false,
+          latest_semver_version: "v1.0.0",
+          latest_semver_complete: false,
+          complete_versions: [],
+          incomplete_versions: ["v1.0.0"],
+          versions: {
+            "v1.0.0": {
+              is_complete: false,
+              availability: "retired",
+              errors: ["release has no .zip asset"],
+              required_checks: {},
+              matched_files: {},
+              source: { update_type: "github", repo: "owner/still-pruned", tag: "v1.0.0" },
+              fingerprint: "github:owner/still-pruned:v1.0.0:no-zip",
+              checked_at: "2026-03-14T00:00:00Z",
+            },
+          },
+        },
+      },
+    });
+
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: () => jsonResponse({
+          data: {
+            repository: {
+              releases: {
+                nodes: [
+                  {
+                    tagName: "v1.0.0",
+                    releaseAssets: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+            rateLimit: { remaining: 120, cost: 1, resetAt: "2026-03-14T00:00:00Z" },
+          },
+        }),
+      },
+    ]);
+
+    const result = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    // Nothing upstream distinguishes this from a never-published release once
+    // the previously-complete entry has aged out of the committed snapshot.
+    assert.equal(
+      result.integrity.listings["still-pruned-mod"].versions["v1.0.0"].availability,
+      "retired",
+    );
+  });
+});
+
+test("github release that never carried a ZIP is not marked retired", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["fresh-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "fresh-mod", {
+      ...makeBaseModManifest("fresh-mod"),
+      update: { type: "github", repo: "owner/fresh" },
+    });
+
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: () => jsonResponse({
+          data: {
+            repository: {
+              releases: {
+                nodes: [
+                  {
+                    tagName: "v1.0.0",
+                    releaseAssets: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+            rateLimit: { remaining: 120, cost: 1, resetAt: "2026-03-14T00:00:00Z" },
+          },
+        }),
+      },
+    ]);
+
+    const result = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    // A release awaiting its first upload looks identical upstream; only the
+    // absence of a previously-installable entry separates the two.
+    assert.equal(
+      result.integrity.listings["fresh-mod"].versions["v1.0.0"].availability,
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
Closes the version-retirement half of the custom-vs-github asymmetry.

A custom source retires a version by keeping the `update.json` entry and dropping the download; the pipeline stamps `availability: "retired"` ([downloads-full.ts:1234-1239](https://github.com/Subway-Builder-Modded/registry/blob/main/scripts/lib/downloads-full.ts#L1234-L1239)). 56 map listings use this across 213 versions.

The github equivalent is pruning the ZIP off a published release, and it turns out to already work: every release tag is evaluated regardless of assets (there is an explicit `no-zip` fingerprint branch), the version stays enumerated rather than becoming a `removed` tombstone, it drops out of `complete_versions` so it stops being installable, and **no integrity alert fires** — the raise condition needs a required check to be explicitly `false`, and an assetless release has no checks at all.

What was missing is user-visible, not just cosmetic. The app builds a listing's version history in `GetDisplayableVersions` (`railyard/internal/registry/installable_versions.go`), which appends a version to the display list only when `status.Availability != "" && !status.IsComplete`. A pruned github release satisfied neither list: not installable (integrity-filtered out), and not display-only (no `availability`). **It vanished from the version history entirely** — no "No longer available" row, no frozen download count, no release date.

That also means `retiring-versions.mdx` on the docs site has been describing behavior the pipeline did not implement: it tells github-source authors to "delete the release's assets, not the release itself" and promises the version "keeps its identity, date, and release notes". This PR makes that true.

This stamps `retired` when the version was installable before. That gate is what separates a withdrawal from a release still awaiting its first upload — the two are indistinguishable upstream. Accepting a previously-retired entry keeps the label across cache invalidation, where the prior entry is no longer complete. Compatibility metadata (`game_version`, `dependencies`) carries over for the same reason the custom path preserves it: the ZIP that declared it is gone.

No new manifest field, intake form, or author-facing file — the author's existing gesture is the signal.

Tests: 462 pass (3 new — retirement on a pruned release, no false positive on a never-published one, and label stickiness when the cache is bypassed).

Dry run against the committed snapshot: **zero** versions in `mods/integrity.json` or `maps/integrity.json` currently carry `release has no .zip asset`, so this is a no-op on today's registry and changes only how future withdrawals are recorded.

Follow-up (not in this PR): document pruning as the supported way to pull a version, and publish the `update.json` schema so custom-source authors can discover `retired` in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

