### PR TITLE
docs(registry): document version retirement, the availability field, and the update.json schema

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,6 +104,10 @@ Each file includes:
 - `versions.<version>` entries containing:
 - `is_complete`, `errors`
 - `required_checks`, `matched_files`
+- `availability` (absent on live versions): `retired` when the author withdrew the artifact
+  but kept the version listed, `removed` when the version stopped being enumerated upstream
+  and this entry is a frozen carry-forward. Clients render both as display-only history
+  rows; a version with neither flag and no complete check simply does not appear.
 - `file_sizes` (maps only, complete versions only; ZIP entry path => uncompressed MiB rounded to 2 decimals)
 - `source`, `fingerprint`, `checked_at`
 
@@ -250,6 +254,18 @@ Category tags from issue templates:
 ```
 
 Validation checks reachable/updateable endpoints at publish/update time.
+
+### Withdrawing a single version
+
+Version-level retirement is author-driven — no intake form, no manifest field. Each source
+type has one gesture, and both land as `availability: "retired"`:
+
+- `custom`: keep the `versions[]` entry, set `retired: true`, and null the `download`.
+  Pruning the entry instead makes the version `removed` and loses its changelog.
+- `github`: delete the release's ZIP asset, keeping the release itself. Only versions that
+  were previously complete are marked retired — a release still awaiting its first upload is
+  indistinguishable upstream, so it is left alone. Deleting the release or tag makes the
+  version `removed`.
 
 ## Map ZIP Format
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -255,6 +255,27 @@ Category tags from issue templates:
 
 Validation checks reachable/updateable endpoints at publish/update time.
 
+### Custom update.json format
+
+```json
+{ "schema_version": 1, "versions": [{ "version": "1.0.0", "download": "…", "sha256": "…" }] }
+```
+
+Only `versions` is read by the pipeline; entries missing `version` are skipped with a warning.
+Per entry:
+
+| Field          | Type              | Notes                                                                    |
+| -------------- | ----------------- | ------------------------------------------------------------------------ |
+| `version`      | string            | Required. Semver, `X.Y.Z` or `vX.Y.Z`; non-semver is recorded incomplete. |
+| `download`     | string            | Must be a `github.com/<owner>/<repo>/releases/download/<tag>/<asset>` URL — download counts are read from the release asset. |
+| `sha256`       | string            | Verified by clients on install.                                           |
+| `manifest`     | string            | Mods only: the release's `manifest.json` asset, parsed for compatibility. |
+| `date`         | string            | Publish date; becomes `released_at`.                                      |
+| `game_version` | string            | Range against `subway-builder`. Required on versions published on/after the cutoff in `integrity.ts`. |
+| `dependencies` | object            | Mod id => range. String values only; other types are dropped.             |
+| `retired`      | boolean           | See below. Read by the pipeline only.                                     |
+| `changelog`    | string            | Not read here — clients fetch it from `update.json` directly.             |
+
 ### Withdrawing a single version
 
 Version-level retirement is author-driven — no intake form, no manifest field. Each source

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Two forms, differing only in permanence:
   asset from profiles, uninstalling it for users who had it. A deprecated listing may later
   be escalated to deleted; the reverse is not possible.
 
+Retiring a single **version** is a separate, author-driven action that needs no form: withdraw
+the artifact and keep the version listed — `retired: true` with a null `download` for custom
+update sources, or delete the release's ZIP asset (not the release) for GitHub sources. The
+version stops being installable but keeps its date, changelog, and frozen download count in
+the version history. See [Retiring Versions](https://subwaybuildermodded.com/registry/docs/retiring-versions).
+
 ## How It Works
 
 `registry` stores metadata only - manifests, gallery images, and pointers to where your mod or map is actually hosted (GitHub Releases, CDNs, etc.). When you submit through an issue template, CI validates your submission and opens a PR automatically. Once merged, your listing goes live.

--- a/scripts/lib/github.ts
+++ b/scripts/lib/github.ts
@@ -135,7 +135,7 @@ export async function validateGitHubRepo(repo: string, sourceUrl?: string, listi
           `**GitHub Releases** update type only supports repositories with a single mod or map.\n\n` +
           `To fix this, switch your update type to **Custom URL** and create an \`update.json\` file. ` +
           `You can host it in the same repo — for example:\n\`${updateJsonExample}\`\n\n` +
-          `See [the update.json format](https://github.com/Subway-Builder-Modded/registry/blob/main/ARCHITECTURE.md#custom-updatejson-format) in the docs.`
+          `See [the update.json format](https://subwaybuildermodded.com/registry/docs/using-custom-url#schema-template) in the docs.`
         );
       } else if (!/^v?\d/.test(sourceTag)) {
         // Source tag matches latest but doesn't look like a version — proactive detection.
@@ -148,7 +148,7 @@ export async function validateGitHubRepo(repo: string, sourceUrl?: string, listi
           `to this repo, the mod manager will start serving the wrong file.\n\n` +
           `To fix this, switch your update type to **Custom URL** and create an \`update.json\` file. ` +
           `You can host it in the same repo — for example:\n\`${updateJsonExample}\`\n\n` +
-          `See [the update.json format](https://github.com/Subway-Builder-Modded/registry/blob/main/ARCHITECTURE.md#custom-updatejson-format) in the docs.`
+          `See [the update.json format](https://subwaybuildermodded.com/registry/docs/using-custom-url#schema-template) in the docs.`
         );
       }
     }


### PR DESCRIPTION
Companion to #7866, and the registry half of monorepo #629.

**Version-level retirement was undocumented here.** README covered listing deprecation and deletion but never mentioned that a single version can be withdrawn, and the integrity field list in ARCHITECTURE omitted `availability` — the field both the app and website key their display-only version history off.

- **README** — a short paragraph under the retirement forms: version retirement needs no form, both gestures, link to the docs site.
- **ARCHITECTURE** — `availability` added to the `versions.<version>` list, plus a *Withdrawing a single version* subsection covering both source types, the previously-complete gate from #7866, and the retired-vs-removed distinction.

**A dead link authors were being handed.** `lib/github.ts` tells anyone who points a GitHub-source listing at a monorepo release to switch to a custom URL, and links to `ARCHITECTURE.md#custom-updatejson-format` for the format. That anchor has never existed — the link lands at the top of an architecture document with no such section, at exactly the moment the author needs the schema.

Fixed on both ends: ARCHITECTURE gains a *Custom update.json format* section with the per-field reference (so the anchor resolves for internal readers), and the two author-facing links now point at the docs site page, which is where an author should land. That page gets the full field table in monorepo #629.

No behavior change beyond the two link targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)