### PR TITLE
feat(intake): require the ToS attestation on mod metadata updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-mod.yml
+++ b/.github/ISSUE_TEMPLATE/update-mod.yml
@@ -113,3 +113,16 @@ body:
         Leave blank to keep the current caretaker. Enter `None` to end the current caretakership. Otherwise,
         enter a single GitHub user ID to hand over caretakership; the previous caretaker's window is closed and
         the new caretaker is added as a collaborator.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Authorization
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Terms
+      options:
+        - label: I attest that I have reviewed the Subway Builder Modded platform [Terms of Service](https://subwaybuildermodded.com/terms-of-service).
+          required: true


### PR DESCRIPTION
`update-map.yml` has required a Terms of Service attestation since it was generated; `update-mod.yml` never has. The same action — editing a listing's metadata — carried different terms depending on asset type.

Adds the attestation to the mod update form under an **Authorization** heading, matching how `update-map.yml` groups it.

Form-only: nothing in `scripts/` reads the `terms` field, so enforcement is GitHub's `required: true` at submission time. `update-map.yml` is auto-generated by `generate-map-templates.ts`; `update-mod.yml` is hand-maintained, so this is a direct edit.

Deliberately **not** matching `update-map.yml` exactly. That form also carries an authorship attestation ("I attest that I am the author of this map or have been granted permission…"), which makes sense at publish time for map data republished from external sources. On an update, authorship is already enforced in code — `validate-update.ts` rejects anyone who is not the publisher or a listed collaborator — so adding a second, unverified self-attestation would be friction without a check behind it. The ToS line is the one that has no code equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)