### PR TITLE
feat(intake): gate control fields on updates behind the retirement rule

### DIFF
--- a/scripts/intake/validate-update.ts
+++ b/scripts/intake/validate-update.ts
@@ -11,6 +11,7 @@ import {
 } from "../lib/manifests.js";
 import { resolveCollaboratorUpdate } from "../lib/collaborators.js";
 import { getActiveCaretaker, resolveCaretakerUpdate } from "../lib/caretakers.js";
+import { isMaintainer } from "../lib/maintainers.js";
 import { loadVanillaCityCodeSet } from "../lib/map-constants.js";
 import { isPresentIssueValue } from "../lib/map-field-utils.js";
 import { validateMapUpdateFields } from "../lib/map-update-logic.js";
@@ -19,6 +20,17 @@ import { checkCityCodeUniqueness } from "../lib/registry-uniqueness.js";
 const REPO_ROOT = process.env.RAILYARD_REPO_ROOT
   ? resolve(process.env.RAILYARD_REPO_ROOT)
   : resolve(import.meta.dirname, "..", "..");
+
+// Fields that decide who controls a listing, or where its artifacts are served
+// from. Editing any of them carries the same authorization as retiring the
+// listing; everything else on the update forms is presentation metadata.
+const PRIVILEGED_UPDATE_FIELDS = [
+  "update-type",
+  "github-repo",
+  "custom-update-url",
+  "collaborators",
+  "caretaker",
+] as const;
 
 function getString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
@@ -121,11 +133,32 @@ async function main() {
         ? manifest.collaborators.map((id) => String(id))
         : [];
 
-      if (ownerId !== authorId && !collaboratorIds.includes(authorId)) {
+      // Code owners may act on any listing (see lib/maintainers.ts), matching
+      // the retirement validators.
+      if (!isMaintainer(authorId) && ownerId !== authorId && !collaboratorIds.includes(authorId)) {
         errors.push(
           `**Ownership check failed**: Your GitHub account does not match the original publisher or any listed collaborator of \`${id}\`. `
           + `Only the original publisher or a listed collaborator can update this listing.`,
         );
+      }
+
+      // Without this, the weaker-authenticated path would grant strictly more
+      // than the stronger one: a collaborator cannot deprecate a listing, but
+      // could repoint its downloads or write themselves a caretakership.
+      const activeCaretaker = getActiveCaretaker(manifest);
+      const mayEditPrivileged = isMaintainer(authorId)
+        || ownerId === authorId
+        || (activeCaretaker !== undefined && String(activeCaretaker.github_id) === authorId);
+      if (!mayEditPrivileged) {
+        const attempted = PRIVILEGED_UPDATE_FIELDS.filter((field) => isPresentIssueValue(data[field]));
+        if (attempted.length > 0) {
+          errors.push(
+            `**Authorization check failed**: ${attempted.map((f) => `\`${f}\``).join(", ")} `
+            + `can only be changed by the original publisher or the active caretaker of \`${id}\`, `
+            + `the same rule that governs deprecation. Leave these fields blank to update the `
+            + `listing's other metadata.`,
+          );
+        }
       }
 
       if (manifestType === "map") {

--- a/scripts/tests/validation-rules.integration.test.ts
+++ b/scripts/tests/validation-rules.integration.test.ts
@@ -1,7 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import JSZip from "jszip";
 
@@ -272,4 +273,105 @@ test("update validation rejects malformed collaborators", () => {
   assert.notEqual(result.status, 0, "Validation should fail for malformed collaborators");
   const output = readValidationError();
   assert.match(output, /\*\*collaborators\*\*: Collaborators must be a comma-separated list of GitHub user IDs with no empty entries\./);
+});
+
+// --- privileged update fields (ownership parity with retirement) ---
+
+const UPDATE_OWNER_ID = 4100;
+const UPDATE_COLLABORATOR_ID = 4200;
+const UPDATE_CARETAKER_ID = 4300;
+
+function makeUpdateFixtureRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "railyard-update-auth-"));
+  mkdirSync(join(root, "mods", "fixture-mod"), { recursive: true });
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(
+    join(root, "mods", "fixture-mod", "manifest.json"),
+    JSON.stringify({
+      schema_version: 1,
+      id: "fixture-mod",
+      name: "Fixture Mod",
+      author: "fixture-author",
+      github_id: UPDATE_OWNER_ID,
+      collaborators: [UPDATE_COLLABORATOR_ID, UPDATE_CARETAKER_ID],
+      caretakers: [{ github_id: UPDATE_CARETAKER_ID, since: "2026-03-01T00:00:00Z" }],
+      description: "A fixture mod.",
+      tags: ["qol"],
+      gallery: [],
+      is_test: false,
+      source: "https://example.com/fixture",
+      update: { type: "github", repo: "fixture/fixture" },
+    }, null, 2) + "\n",
+    "utf-8",
+  );
+  return root;
+}
+
+function runUpdateInFixture(root: string, authorId: number, issue: Record<string, string>) {
+  return spawnSync(
+    process.execPath,
+    [resolve(scriptsRoot, ".test-dist", "intake", "validate-update.js")],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        RAILYARD_REPO_ROOT: root,
+        LISTING_TYPE: "mod",
+        ISSUE_AUTHOR_ID: String(authorId),
+        ISSUE_JSON: JSON.stringify({ "mod-id": "fixture-mod", ...issue }),
+      },
+      encoding: "utf-8" as const,
+    },
+  );
+}
+
+function fixtureValidationError(root: string): string {
+  const path = join(root, "scripts", "validation-error.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : "";
+}
+
+test("update validation blocks a collaborator from repointing the update source", (t) => {
+  const root = makeUpdateFixtureRepo();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runUpdateInFixture(root, UPDATE_COLLABORATOR_ID, { "update-type": "GitHub Releases" });
+  assert.notEqual(result.status, 0, "collaborators must not be able to repoint downloads");
+  assert.match(fixtureValidationError(root), /Authorization check failed.*update-type/s);
+});
+
+test("update validation blocks a collaborator from rewriting collaborators or caretaker", (t) => {
+  const root = makeUpdateFixtureRepo();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runUpdateInFixture(root, UPDATE_COLLABORATOR_ID, { caretaker: "not-an-id" });
+  assert.notEqual(result.status, 0);
+  assert.match(fixtureValidationError(root), /Authorization check failed.*caretaker/s);
+});
+
+test("update validation still lets a collaborator edit presentation metadata", (t) => {
+  const root = makeUpdateFixtureRepo();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runUpdateInFixture(root, UPDATE_COLLABORATOR_ID, {
+    name: "Renamed Fixture Mod",
+    description: "An updated description.",
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("update validation lets the active caretaker change the update source", (t) => {
+  const root = makeUpdateFixtureRepo();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runUpdateInFixture(root, UPDATE_CARETAKER_ID, { "update-type": "GitHub Releases" });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("update validation lets a code owner change the update source", (t) => {
+  const root = makeUpdateFixtureRepo();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // subway-builder-modded-admin — see lib/maintainers.ts.
+  const result = runUpdateInFixture(root, 268817724, { "update-type": "GitHub Releases" });
+  assert.equal(result.status, 0, result.stderr);
 });


### PR DESCRIPTION
Asymmetry 5.1 from the retirement audit.

Updates required owner-**or-collaborator** ([validate-update.ts:124](https://github.com/Subway-Builder-Modded/registry/blob/main/scripts/intake/validate-update.ts#L124)); retirement requires owner-or-active-**caretaker**. So a listed collaborator could not deprecate a listing, but could:

- change `update-type`, `github-repo`, `custom-update-url` — repointing where the artifact is downloaded from;
- rewrite `collaborators` and `caretaker`, neither of which was owner-gated.

The weaker-authenticated path granted strictly more than the stronger one.

Those five fields are now `PRIVILEGED_UPDATE_FIELDS`, editable only by the publisher, the active caretaker, or a code owner — the same rule as deprecation. Presentation metadata (name, description, tags, gallery, source, map fields) stays open to collaborators, and the error names the offending fields and says to leave them blank.

**One extra fix the tests forced.** Writing the code-owner case surfaced that the *base* ownership check never accepted code owners, so a code owner could deprecate or delete any listing after #7861 but could not update one. That inconsistency is fixed here too, with the same one-line `isMaintainer` bypass the three retirement validators use.

Tests: 467 pass. Five new cases — collaborator blocked from the update source, blocked from caretaker/collaborators, still able to edit presentation metadata, and the active caretaker and a code owner both allowed through. They use a temp fixture repo rather than the live registry, and avoid the network by relying on fields whose validation short-circuits before any GitHub lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)