### PR TITLE
feat(intake): refuse metadata updates on deleted listings

### DIFF
--- a/scripts/intake/validate-update.ts
+++ b/scripts/intake/validate-update.ts
@@ -133,6 +133,18 @@ async function main() {
         ? manifest.collaborators.map((id) => String(id))
         : [];
 
+      // Deletion is permanent: the listing survives only as a record, so its
+      // metadata stops being the author's to edit. Plain deprecation is
+      // reversible, and tidying a listing before restoring it is legitimate.
+      if ((manifest.deprecation as { deleted?: boolean } | undefined)?.deleted === true
+        && !isMaintainer(authorId)) {
+        errors.push(
+          `**${manifestType}-id**: \`${id}\` was permanently deleted and its metadata can no `
+          + `longer be changed. Returning the content to the registry requires publishing a new `
+          + `listing; contact a maintainer if the record itself is wrong.`,
+        );
+      }
+
       // Code owners may act on any listing (see lib/maintainers.ts), matching
       // the retirement validators.
       if (!isMaintainer(authorId) && ownerId !== authorId && !collaboratorIds.includes(authorId)) {

--- a/scripts/tests/validation-rules.integration.test.ts
+++ b/scripts/tests/validation-rules.integration.test.ts
@@ -281,7 +281,7 @@ const UPDATE_OWNER_ID = 4100;
 const UPDATE_COLLABORATOR_ID = 4200;
 const UPDATE_CARETAKER_ID = 4300;
 
-function makeUpdateFixtureRepo(): string {
+function makeUpdateFixtureRepo(deprecation?: Record<string, unknown>): string {
   const root = mkdtempSync(join(tmpdir(), "railyard-update-auth-"));
   mkdirSync(join(root, "mods", "fixture-mod"), { recursive: true });
   mkdirSync(join(root, "scripts"), { recursive: true });
@@ -301,6 +301,7 @@ function makeUpdateFixtureRepo(): string {
       is_test: false,
       source: "https://example.com/fixture",
       update: { type: "github", repo: "fixture/fixture" },
+      ...(deprecation ? { deprecation } : {}),
     }, null, 2) + "\n",
     "utf-8",
   );
@@ -373,5 +374,42 @@ test("update validation lets a code owner change the update source", (t) => {
 
   // subway-builder-modded-admin — see lib/maintainers.ts.
   const result = runUpdateInFixture(root, 268817724, { "update-type": "GitHub Releases" });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+const DELETED_RECORD = {
+  since: "2026-08-01T00:00:00Z",
+  by_github_id: UPDATE_OWNER_ID,
+  deleted: true,
+};
+
+test("update validation refuses metadata edits on a deleted listing", (t) => {
+  const root = makeUpdateFixtureRepo(DELETED_RECORD);
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runUpdateInFixture(root, UPDATE_OWNER_ID, { description: "A new description." });
+  assert.notEqual(result.status, 0, "deletion is permanent for the publisher too");
+  assert.match(fixtureValidationError(root), /was permanently deleted and its metadata can no longer be changed/);
+});
+
+test("update validation lets a code owner correct a deleted listing's record", (t) => {
+  const root = makeUpdateFixtureRepo(DELETED_RECORD);
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // subway-builder-modded-admin — see lib/maintainers.ts.
+  const result = runUpdateInFixture(root, 268817724, { description: "A corrected description." });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("update validation still accepts edits on a listing that is merely deprecated", (t) => {
+  const root = makeUpdateFixtureRepo({
+    since: "2026-08-01T00:00:00Z",
+    by_github_id: UPDATE_OWNER_ID,
+    reason: "Superseded",
+  });
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // Tidying a listing before restoring it is legitimate; deprecation reverses.
+  const result = runUpdateInFixture(root, UPDATE_OWNER_ID, { description: "A new description." });
   assert.equal(result.status, 0, result.stderr);
 });


### PR DESCRIPTION
Asymmetry 5.2 — the last item from the retirement audit.

Rebased onto `main` now that #7872 has merged.

`validate-update.ts` never read `manifest.deprecation`, so a permanently deleted listing still accepted metadata edits — name, description, gallery, everything. Deletion is the one retirement state that is supposed to be final, and the update path was the hole in it.

Updates on a `deleted: true` listing are now rejected, with an error pointing at the actual remedy (publish a new listing) and at maintainers if the record itself is wrong.

Two deliberate scope choices:

- **Code owners are exempt.** Something has to be able to correct a bad record — a deletion filed against the wrong ID, or a reason that names the wrong person — and that is a maintainer action, not an author one.
- **Plain deprecation is untouched.** It reverses by design, and an author tidying a listing's description before asking for it back is legitimate. Blocking that would make un-deprecation harder while protecting nothing.

Tests: 471 pass. Three new cases — the publisher refused on a deleted listing, a code owner allowed through, and a merely-deprecated listing still accepting edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
