### PR TITLE
fix(downloads): stop hourly runs re-reporting retired listings' dead repos

### DIFF
--- a/scripts/lib/downloads-download-only.ts
+++ b/scripts/lib/downloads-download-only.ts
@@ -131,11 +131,18 @@ export async function generateDownloadsDataDownloadOnly(
   }
 
   const usageState = createGraphqlUsageState();
+  // A repo referenced only by deprecated/test listings is expected to stop
+  // resolving, so its fetch failure is not news. Full mode has always
+  // suppressed these; hourly runs did not, and re-reported them every hour.
+  const suppressWarningRepos = new Set(
+    [...repoSet].filter((repo) => !sourceEligibleListings.has(livenessSourceKey("repo", repo))),
+  );
   const { repoIndexes, unavailableRepos } = await fetchRepoReleaseIndexes(repoSet, {
     fetchImpl,
     token,
     warnings,
     usageState,
+    suppressWarningRepos,
   });
 
   {

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -2596,3 +2596,55 @@ test("github release that never carried a ZIP is not marked retired", async () =
     );
   });
 });
+
+// Retired listings are expected to lose their upstream, so hourly runs must not
+// re-report the failure every hour. Full mode has always suppressed these.
+test("download-only mode does not warn about repos only deprecated listings use", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["retired-mod", "live-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "retired-mod", {
+      ...makeBaseModManifest("retired-mod"),
+      update: { type: "github", repo: "owner/retired" },
+      deprecation: { since: "2026-08-01T00:00:00Z", by_github_id: 1, deleted: true },
+    });
+    writeManifest("mods", "live-mod", {
+      ...makeBaseModManifest("live-mod"),
+      update: { type: "github", repo: "owner/live" },
+    });
+
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://api.github.com/graphql",
+        handle: (_input, init) => {
+          const body = JSON.parse(String(init?.body)) as { variables: { name: string } };
+          return Response.json({
+            data: { repository: null },
+            errors: [{
+              message: `Could not resolve to a Repository with the name 'owner/${body.variables.name}'.`,
+            }],
+          });
+        },
+      },
+    ]);
+
+    const { warnings } = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      mode: "download-only",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    assert.equal(
+      warnings.some((warning) => warning.includes("repo=owner/retired")),
+      false,
+      `deprecated-only repo warning leaked: ${JSON.stringify(warnings)}`,
+    );
+    // The suppression must be scoped to retired repos, not blanket.
+    assert.ok(
+      warnings.some((warning) => warning.includes("repo=owner/live")),
+      `live repo warning was suppressed too: ${JSON.stringify(warnings)}`,
+    );
+  });
+});


### PR DESCRIPTION
The hourly job has been firing this every run:

```
mod: repo=danield1909/dantrains: GraphQL errors: Could not resolve to a Repository...
mod: repo=imb11/move-it: ...
mod: repo=imb11/subwaycine: ...
mod: repo=matematysek/prospector: ...
mod: repo=subway-builder-modded/zz-deletion-fixture: ...
mod: repo=subway-builder-modded/zz-deprecation-fixture: ...
```

All six belong to listings that are **already deprecated or deleted** — including our own two deletion/deprecation fixtures. Their upstreams are gone precisely because the listings were retired, so the alert reports an expected state, hourly, forever.

**Cause.** Full mode already handles this: `downloads-full.ts` builds `suppressWarningRepos` from repos with no active (non-deprecated, non-test) use and passes it to `fetchRepoReleaseIndexes`, which routes those messages to a log line instead of the warnings channel. `downloads-download-only.ts` — the hourly path — calls the same function and never passes the option. Full mode runs every 3 hours and stayed quiet; hourly ran and did not.

The fix reuses the data the hourly path already tracks: `sourceEligibleListings` maps a source key to the non-deprecated, non-test listings referencing it, so a repo absent from it has no live consumer.

Two things I checked and ruled out on the way, worth recording since they look plausible:

- **Not a casing bug.** Four of the six manifests store mixed-case repos (`DanielD1909/danTrains`, `IMB11/move-it`, `IMB11/SubwayCine`, `matematysek/Prospector`), but both pipelines lowercase before adding to `repoSet`, and `fetchRepoReleaseIndexes` lowercases again.
- **Not the suppression matcher.** The `message.includes(\`repo=${repo}\`)` check in `release-resolution.ts` matches these messages correctly; it was simply never reached.

**Tests: 472 pass.** The new case asserts both halves — a deprecated-only repo produces no warning, and a live listing's repo still does, so the suppression cannot silently go blanket. Verified it fails without the fix, with the leaked warning naming `owner/retired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)