### PR TITLE
fix(downloads): stop re-reporting versions that cannot carry an asset

### DIFF
--- a/scripts/lib/download-history-core.ts
+++ b/scripts/lib/download-history-core.ts
@@ -8,6 +8,7 @@ import {
   type DownloadAttributionLedger,
 } from "./download-attribution.js";
 import type { IntegritySource } from "./integrity.js";
+import { isSupportedReleaseTag } from "./release-resolution.js";
 import { isObject, toFiniteNumber, readJsonFile, writeJsonFile } from "./json-utils.js";
 import { toSnapshotDate, toCanonicalHistoryCutoffIso, getHistoryDir, CANONICAL_HISTORY_CUTOFF_HOUR_UTC } from "./history-utils.js";
 import type { DownloadHistorySnapshot } from "@subway-builder-modded/registry-schemas";
@@ -40,6 +41,7 @@ interface DownloadHistorySection {
 
 interface IntegrityVersionLike {
   source?: unknown;
+  availability?: unknown;
 }
 
 interface IntegrityListingLike {
@@ -179,8 +181,15 @@ function normalizeIntegritySourcesFromIntegrity(
         listingSources[version] = null;
         continue;
       }
-      const normalizedSource = normalizeIntegritySource((versionRaw as IntegrityVersionLike).source);
-      if ((versionRaw as IntegrityVersionLike).source && !normalizedSource) {
+      const versionEntry = versionRaw as IntegrityVersionLike;
+      const normalizedSource = normalizeIntegritySource(versionEntry.source);
+      // Two states can never carry an asset to match against, so warning about
+      // them reports a design decision back every run: a withdrawn version
+      // (availability set) and a non-semver tag, which is recorded incomplete
+      // deliberately.
+      const cannotCarryAsset = versionEntry.availability !== undefined
+        || !isSupportedReleaseTag(version);
+      if (versionEntry.source && !normalizedSource && !cannotCarryAsset) {
         warnings.push(
           `${listingKind}/integrity.json: listing='${listingId}' version='${version}' has invalid source metadata; strict attribution matching skipped for this version`,
         );

--- a/scripts/lib/downloads-download-only.ts
+++ b/scripts/lib/downloads-download-only.ts
@@ -278,12 +278,18 @@ export async function generateDownloadsDataDownloadOnly(
       versionsChecked += 1;
 
       if (!candidate.parsed) {
-        warnListing(
-          warnings,
-          id,
-          "skipped non-GitHub release download URL",
-          candidate.version,
-        );
+        // A retired entry has no download by design, so reporting it every run
+        // just echoes the author's own decision back at them.
+        if (!candidate.retired) {
+          warnListing(
+            warnings,
+            id,
+            candidate.downloadUrl
+              ? "skipped non-GitHub release download URL"
+              : "skipped version with no download URL",
+            candidate.version,
+          );
+        }
         continue;
       }
 

--- a/scripts/tests/download-history.unit.test.ts
+++ b/scripts/tests/download-history.unit.test.ts
@@ -316,3 +316,65 @@ test("backfillDownloadHistorySnapshots is idempotent after normalization", () =>
     rmSync(repoRoot, { recursive: true, force: true });
   }
 });
+
+// Versions that cannot carry an asset are a design outcome, not a data defect:
+// a withdrawn version has no artifact, and a non-semver tag is recorded
+// incomplete on purpose. Neither should be re-reported every run.
+test("generateDownloadHistorySnapshot does not warn about versions that cannot carry an asset", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "railyard-download-history-"));
+  try {
+    setupBaseRepo(repoRoot);
+    writeJson(join(repoRoot, "maps", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-03-30T00:00:00.000Z",
+      listings: {
+        "map-a": {
+          versions: {
+            "1.0.0": {
+              is_complete: false,
+              availability: "retired",
+              source: { update_type: "custom" },
+            },
+            "2.0.0": {
+              is_complete: false,
+              availability: "removed",
+              source: { update_type: "github", repo: "example/map", tag: "2.0.0" },
+            },
+            "railyard": {
+              is_complete: false,
+              source: { update_type: "github", repo: "example/map", tag: "railyard" },
+            },
+            "3.0.0": {
+              is_complete: false,
+              source: { update_type: "github", repo: "example/map", tag: "3.0.0" },
+            },
+          },
+        },
+      },
+    });
+    writeJson(join(repoRoot, "mods", "integrity.json"), {
+      schema_version: 1,
+      generated_at: "2026-03-30T00:00:00.000Z",
+      listings: {},
+    });
+    writeJson(join(repoRoot, "maps", "downloads.json"), { "map-a": { "1.0.0": 10 } });
+    writeJson(join(repoRoot, "mods", "downloads.json"), {});
+
+    const result = generateDownloadHistorySnapshot({
+      repoRoot,
+      now: new Date("2026-03-30T08:00:00.000Z"),
+    });
+
+    const invalidSourceWarnings = result.warnings.filter((warning) =>
+      warning.includes("has invalid source metadata")
+    );
+    // Only 3.0.0 qualifies: a live semver version whose source really is short
+    // an asset_name.
+    assert.deepEqual(
+      invalidSourceWarnings.map((warning) => warning.replace(/^.*version='([^']+)'.*$/, "$1")),
+      ["3.0.0"],
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/downloads.integration.test.ts
+++ b/scripts/tests/downloads.integration.test.ts
@@ -2648,3 +2648,59 @@ test("download-only mode does not warn about repos only deprecated listings use"
     );
   });
 });
+
+test("download-only mode does not warn about retired custom versions, and names the real cause otherwise", async () => {
+  await withTempRegistry(async ({ repoRoot, writeIndex, writeManifest }) => {
+    writeIndex("mods", ["custom-mod"]);
+    writeIndex("maps", []);
+    writeManifest("mods", "custom-mod", {
+      ...makeBaseModManifest("custom-mod"),
+      update: { type: "custom", url: "https://example.com/retire-update.json" },
+    });
+
+    const fetchMock = makeFetchRouter([
+      {
+        match: (url) => url === "https://example.com/retire-update.json",
+        handle: () => jsonResponse({
+          schema_version: 1,
+          versions: [
+            // Withdrawn by the author: no download by design.
+            { version: "1.0.0", date: "2026-01-01", download: null, sha256: null, retired: true },
+            // Live, but pointed somewhere the pipeline cannot read counts from.
+            { version: "1.1.0", date: "2026-02-01", download: "https://cdn.example.com/mod.zip", sha256: "abc" },
+            // Live, and simply missing its download.
+            { version: "1.2.0", date: "2026-03-01", sha256: "def" },
+          ],
+        }),
+      },
+    ]);
+
+    const { warnings } = await generateDownloadsData({
+      repoRoot,
+      listingType: "mod",
+      mode: "download-only",
+      fetchImpl: fetchMock,
+      token: "test-token",
+    });
+
+    assert.equal(
+      warnings.some((warning) => warning.includes("version=1.0.0")),
+      false,
+      `retired version warned: ${JSON.stringify(warnings)}`,
+    );
+    assert.ok(
+      warnings.some((warning) =>
+        warning.includes("version=1.1.0") && warning.includes("skipped non-GitHub release download URL")
+      ),
+      `non-GitHub URL should still warn: ${JSON.stringify(warnings)}`,
+    );
+    // Previously this said "non-GitHub release download URL" for a version that
+    // has no URL at all.
+    assert.ok(
+      warnings.some((warning) =>
+        warning.includes("version=1.2.0") && warning.includes("skipped version with no download URL")
+      ),
+      `missing URL should name its own cause: ${JSON.stringify(warnings)}`,
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #7885, same shape: warnings that report an expected consequence of retirement, once an hour, forever.

### `has invalid source metadata; strict attribution matching skipped`

`normalizeIntegritySource` requires `repo`, `tag`, **and** `asset_name`; without all three, attribution falls back from strict asset-keyed matching to the looser path. Nothing is lost, but the warning fires every run.

I classified the whole population rather than sampling:

| | maps | mods |
| --- | --- | --- |
| Retired/removed (`availability` set) | 213 | 0 |
| Non-semver tags | 4 | 5 |
| **Unexplained** | **0** | **0** |

Both states are permanent by construction. A withdrawn version has no artifact — that is what withdrawing means — and the README already documents that non-semver tags (`mfn-hong-kong@railyard`, `nashville@1.0`, `advanced-analytics@target-1.1.0`) are "recorded in `integrity.json` as incomplete". Neither can ever gain an `asset_name`, so the warning can never become actionable.

Both are now skipped. A live semver version whose source really is short an `asset_name` still warns.

### `skipped non-GitHub release download URL`

The hourly custom path branches on `!candidate.parsed`, which is true both when the URL is non-GitHub **and when there is no URL at all** — and a retired entry has `download: null`. So it reported a URL problem for versions that have no URL by design, and there was no `retired` check anywhere in that path.

Two changes, deliberately not one:

- **Retired entries no longer warn.** Same precedent as the eu/tw/jp map retirements.
- **Everything else names its actual cause** — `skipped version with no download URL` when there is none, the original message when the URL is genuinely non-GitHub.

That second case keeps warning on purpose. A permanently non-GitHub `download` leaves a version uninstallable forever, and it is exactly what the mods docs template taught people to write until #629 corrected it. Blanket-suppressing this class would have hidden that.

### Tests

473 pass, and I verified both new tests fail without the fixes (2 failures on revert). Coverage asserts the negative *and* the positive in both files: retired and non-semver stay quiet while a genuinely-broken live version still warns; retired custom entries stay quiet while a non-GitHub URL and a missing URL each produce their own distinct message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)