### PR TITLE
docs: soften the absent-tier description

### DIFF
--- a/docs/data-quality-questions.md
+++ b/docs/data-quality-questions.md
@@ -10,15 +10,15 @@ Every question has plain-language options, and **"Not sure" is always a safe ans
 
 Your answers are used to produce a provisional data-quality score. A reviewer from the [Subway Builder Modded](https://github.com/Subway-Builder-Modded) organization will then confirm it, after which the map receives one of seven quality tiers:
 
-| Tier          | Meaning (approximate)                                                                        |
-| :------------ | :------------------------------------------------------------------------------------------- |
-| **Very High** | Measured, government data on both sides of the commute (residence/workplace), at fine detail |
-| **High**      | Strong official data with minor gaps in coverage or at somewhat coarse granularity           |
-| **Medium**    | Real official data, but potentially coarse or partial (e.g. residence side only)             |
-| **Low**       | Weak or indirect anchoring in official data                                                  |
-| **Very Low**  | Mostly estimated, loosely anchored to real statistics                                        |
-| **Absent**    | No census or official statistics at all                                                      |
-| **Unscored**  | Not yet reviewed — the default for every map                                                 |
+| Tier          | Meaning (approximate)                                                                                     |
+| :------------ | :-------------------------------------------------------------------------------------------------------- |
+| **Very High** | Measured, government data on both sides of the commute (residence/workplace), at fine detail              |
+| **High**      | Strong official data with minor gaps in coverage or at somewhat coarse granularity                        |
+| **Medium**    | Real official data, but potentially coarse or partial (e.g. residence side only)                          |
+| **Low**       | Weak or indirect anchoring in official data                                                               |
+| **Very Low**  | Mostly estimated, loosely anchored to real statistics                                                     |
+| **Absent**    | No effective anchoring in official statistics — none at all, or too coarse or indirect to shape the model |
+| **Unscored**  | Not yet reviewed — the default for every map                                                              |
 
 Until a reviewer confirms a score, your map will show as **Unscored**. Answering nothing or
 answering "Not sure" to everything is not penalized, so there is no downside to

--- a/docs/data-quality.md
+++ b/docs/data-quality.md
@@ -211,7 +211,7 @@ Every pipeline resolves to a single **weighted score** in [0, 1] and a named qua
 
 _Tiers apply to the **weighted** (player-facing) score, and refine the current three-level tag system: **very high** and **high** map to `high`, **medium** to `medium`, and **low** / **very low** / **absent** to `low`._
 
-_The **absent** tier (grade F) is reserved for pipelines with no usable census anchor — the granularity multiplier floors the score at ~0 by construction, categorically apart from a map that is weakly grounded in census data._
+_The **absent** tier (grade F) marks pipelines whose data does not effectively anchor the model. Most arrive with no usable census anchor at all — the granularity multiplier floors their score at ~0 by construction — but a pipeline with a real yet minimal anchor (a single region-wide total, an assumed employment ratio) can also fall below the very-low floor on score alone. Absent means the official data does not meaningfully constrain the model — not that none was consulted._
 
 _The **unknown** tier (grade U) is reserved for pipelines that have not been scored yet, to enable backwards compatibility for pipelines/maps that have yet to be scored._
 


### PR DESCRIPTION
Companion to [monorepo #638](https://github.com/Subway-Builder-Modded/monorepo/pull/638) — see that PR for the full rationale. The Middle-East data-quality triage lands anchored-but-minimal pipelines (riyadh, damascus, baghdad) below the 0.15 floor, and the current F-tier wording would tell players those maps used "no census or official statistics at all", which is false.

- `docs/data-quality-questions.md` tier table: **"No effective anchoring in official statistics — none at all, or too coarse or indirect to shape the model"**
- `docs/data-quality.md` §8: the "reserved for pipelines with no usable census anchor" paragraph now covers the real-but-minimal-anchor case explicitly and closes with *"Absent means the official data does not meaningfully constrain the model — not that none was consulted."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)