### PR TITLE
undeprecate(mod): penguin-approved-rolling-stock

### DIFF
--- a/mods/penguin-approved-rolling-stock/manifest.json
+++ b/mods/penguin-approved-rolling-stock/manifest.json
@@ -20,9 +20,13 @@
     "repo": "prodigious-penguin/Penguin-Approved-Rolling-Stock"
   },
   "last_updated": 1785415916,
-  "deprecation": {
-    "since": "2026-08-14T15:39:45.878Z",
-    "by_github_id": 268817724,
-    "reason": "Maintainer-initiated: no version has ever passed integrity (both releases are missing a matching top-level manifest.json), the listing has never recorded a download, and it has been unavailable since 2026-07-26. Reversible — remove the deprecation once a release passes integrity."
-  }
+  "deprecation_history": [
+    {
+      "since": "2026-08-14T15:39:45.878Z",
+      "by_github_id": 268817724,
+      "reason": "Maintainer-initiated: no version has ever passed integrity (both releases are missing a matching top-level manifest.json), the listing has never recorded a download, and it has been unavailable since 2026-07-26. Reversible — remove the deprecation once a release passes integrity.",
+      "until": "2026-08-18T15:15:23.096Z",
+      "removed_by_github_id": 19807509
+    }
+  ]
 }


### PR DESCRIPTION
The author (prodigious-penguin) has returned and is fixing the integrity failure (both releases missing a matching top-level `manifest.json`). The 2026-08-14 deprecation was maintainer-initiated and marked reversible for exactly this case.

Applied via `scripts/intake/undeprecate-listing.ts` (acting maintainer: ahkimn): the `deprecation` field is removed and the window is closed into `deprecation_history` with `until` + `removed_by_github_id`, so the record of the deprecation is preserved. Search visibility, the published integrity view, and downloadability all self-heal on the next pipeline run — no other files need touching (the listing has never recorded a download, so there is no grandfathered-counts interplay).

Note: the listing will remain effectively uninstallable in the app until a release actually passes integrity (`has_complete_version` is still false) — undeprecating just reopens the path so the author's fixed release flows through normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)