### PR TITLE
fix(intake): release MRS back to marseille; split reserved codes from vanilla

### DIFF
--- a/scripts/intake/validate-publish.ts
+++ b/scripts/intake/validate-publish.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_MAP_DATA_SOURCE,
   LEVEL_OF_DETAIL_VALUES,
   SOURCE_QUALITY_VALUES,
+  RESERVED_CITY_CODES,
   SPECIAL_DEMAND_TAG_SET,
   loadVanillaCityCodeSet,
   isOsmDataSource,
@@ -169,6 +170,11 @@ async function validateMap(data: Record<string, string>): Promise<ValidationResu
 
   if (loadVanillaCityCodeSet(REPO_ROOT).has(parsed.data["city-code"])) {
     errors.push(`**city-code**: \`${parsed.data["city-code"]}\` clashes with a vanilla city code.`);
+  } else if (RESERVED_CITY_CODES.includes(parsed.data["city-code"] as (typeof RESERVED_CITY_CODES)[number])) {
+    errors.push(
+      `**city-code**: \`${parsed.data["city-code"]}\` is reserved during a city-code migration ` +
+      "(stale installs still hold files under it) — contact a maintainer.",
+    );
   }
   errors.push(...checkCityCodeUniqueness({ repoRoot: REPO_ROOT, cityCode: parsed.data["city-code"], currentMapId: null }));
 

--- a/scripts/intake/validate-update.ts
+++ b/scripts/intake/validate-update.ts
@@ -12,7 +12,7 @@ import {
 import { resolveCollaboratorUpdate } from "../lib/collaborators.js";
 import { getActiveCaretaker, resolveCaretakerUpdate } from "../lib/caretakers.js";
 import { isMaintainer } from "../lib/maintainers.js";
-import { loadVanillaCityCodeSet } from "../lib/map-constants.js";
+import { RESERVED_CITY_CODES, loadVanillaCityCodeSet } from "../lib/map-constants.js";
 import { isPresentIssueValue } from "../lib/map-field-utils.js";
 import { validateMapUpdateFields } from "../lib/map-update-logic.js";
 import { checkCityCodeUniqueness } from "../lib/registry-uniqueness.js";
@@ -179,6 +179,11 @@ async function main() {
           const cityCode = data["city-code"] as string;
           if (loadVanillaCityCodeSet(REPO_ROOT).has(cityCode)) {
             errors.push(`**city-code**: \`${cityCode}\` clashes with a vanilla city code.`);
+          } else if (RESERVED_CITY_CODES.includes(cityCode as (typeof RESERVED_CITY_CODES)[number])) {
+            errors.push(
+              `**city-code**: \`${cityCode}\` is reserved during a city-code migration ` +
+              "(stale installs still hold files under it) — contact a maintainer.",
+            );
           }
           errors.push(...checkCityCodeUniqueness({ repoRoot: REPO_ROOT, cityCode, currentMapId: id }));
         }

--- a/scripts/lib/map-constants.ts
+++ b/scripts/lib/map-constants.ts
@@ -60,11 +60,17 @@ export const VANILLA_CITY_CODES = [
   "KC",
   "NAS",
   "DUB",
-  // Reserved (never vanilla): pierreggt's pre-rename French codes; stale installs
-  // on user disks still hold them during the migration.
-  "LYS",
-  "MRS",
 ] as const;
+
+// Reserved (never vanilla): codes held back during a city-code migration because
+// stale installs on user disks still hold files under them — a NEW listing
+// claiming one would extract into those folders. Distinct from vanilla codes so
+// validation can explain the rejection honestly.
+// - LYS: lyon's pre-2026-08 code (now LSY). Release once the French city-code
+//   incident closes (old-version traffic back at allowance, v0.2.10 saturated).
+// - MRS was reserved here too, released 2026-08-20 back to marseille — the
+//   original holder reclaiming its own code is self-healing (issue #8327).
+export const RESERVED_CITY_CODES = ["LYS"] as const;
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/scripts/tests/validation-rules.integration.test.ts
+++ b/scripts/tests/validation-rules.integration.test.ts
@@ -91,16 +91,30 @@ test("publish validation rejects city codes that clash with vanilla maps", () =>
   assert.match(output, /\*\*city-code\*\*: `NYC` clashes with a vanilla city code\./);
 });
 
-test("publish validation rejects the 2026-08 French vanilla city codes", () => {
+test("publish validation rejects migration-reserved city codes with a reserved message", () => {
   const issue = basePublishMapIssue({ "city-code": "LYS" });
   const result = runScript("validate-publish", {
     LISTING_TYPE: "map",
     ISSUE_JSON: JSON.stringify(issue),
   });
 
-  assert.notEqual(result.status, 0, "Validation should fail for a French vanilla city code");
+  assert.notEqual(result.status, 0, "Validation should fail for a migration-reserved city code");
   const output = readValidationError();
-  assert.match(output, /\*\*city-code\*\*: `LYS` clashes with a vanilla city code\./);
+  assert.match(output, /\*\*city-code\*\*: `LYS` is reserved during a city-code migration/);
+  assert.doesNotMatch(output, /`LYS` clashes with a vanilla city code/);
+});
+
+test("publish validation no longer blocks MRS (released back to marseille, 2026-08-20)", () => {
+  const issue = basePublishMapIssue({ "city-code": "MRS" });
+  const result = runScript("validate-publish", {
+    LISTING_TYPE: "map",
+    ISSUE_JSON: JSON.stringify(issue),
+  });
+
+  // MRS may fail other rules in this fixture, but never the city-code rules.
+  const output = result.status === 0 ? "" : readValidationError();
+  assert.doesNotMatch(output, /`MRS` clashes with a vanilla city code/);
+  assert.doesNotMatch(output, /`MRS` is reserved/);
 });
 
 test("publish validation enforces ISO country code format (2 uppercase letters)", () => {


### PR DESCRIPTION
Unblocks #8327 (marseille reverting `MAR` → `MRS`).

**What happened** (reconciling the conflicting reports): pierreggt's original French codes were `PAR`/`LYS`/`MRS`. The incident was first written up against the wrong vanilla codes, so all three were renamed Aug 7–9 — and the game update then actually shipped `PAR`/`LYO`/`MAR`: only paris ever collided, lyon's rename was unnecessary-but-harmless, and marseille renamed **from a safe code onto the actual vanilla one**. `MRS` was never vanilla; it was only in our hardcoded floor as stale-install protection, and the validator's "clashes with a vanilla city code" message was wrong on both counts for his revert.

**Changes:**
- `MRS` removed from the blocklist — the original holder reclaiming its own code is self-healing: the pre-Aug-7 install base re-aligns, v1.0.3 becomes installable on updated clients, the marseille churn feeding the French loop incident stops, and conflict issue #7681 auto-closes on the next sync (the collision scanner uses the live list, verified).
- `LYS` moved to a new `RESERVED_CITY_CODES` list, kept until the French incident closes — freeing it would let a *different* listing extract into stale lyon folders, which is the actual hazard the reservation exists for.
- Reserved codes now reject with an honest message ("reserved during a city-code migration — contact a maintainer") in both publish and update validation, instead of falsely claiming a vanilla clash.

Tests: LYS expectation updated to the reserved message, new MRS-unblocked test; 475/475 on a fresh `.test-dist`.

After merge: pierreggt comments `revalidate` on #8327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)