### PR TITLE
fix(ops): skip deprecated listings in vanilla city-code conflict detection

### DIFF
--- a/scripts/downloads/sync-vanilla-city-codes.ts
+++ b/scripts/downloads/sync-vanilla-city-codes.ts
@@ -88,7 +88,13 @@ export function findListingCollisions(repoRoot: string, codes: Set<string>): Van
       const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
         city_code?: unknown;
         author?: unknown;
+        deprecation?: unknown;
       };
+      // Deprecated listings are uninstallable regardless, so a code collision is
+      // not actionable — don't file (or keep open) conflict issues for them. If
+      // the listing is later undeprecated with the conflict intact, the next
+      // sync run files a fresh issue. Deleted listings drop out of the index.
+      if (manifest.deprecation !== undefined) continue;
       if (typeof manifest.city_code === "string" && codes.has(manifest.city_code)) {
         collisions.push({
           listing_id: listingId,

--- a/scripts/tests/vanilla-city-codes.unit.test.ts
+++ b/scripts/tests/vanilla-city-codes.unit.test.ts
@@ -77,6 +77,32 @@ test("findListingCollisions reports listing, code, and author for colliding mani
   ]);
 });
 
+test("findListingCollisions skips deprecated listings", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "vanilla-collisions-dep-"));
+  const write = (id: string, manifest: unknown): void => {
+    mkdirSync(join(repoRoot, "maps", id), { recursive: true });
+    writeFileSync(join(repoRoot, "maps", id, "manifest.json"), JSON.stringify(manifest), "utf-8");
+  };
+  // A deprecated listing is uninstallable regardless; its collision is not actionable.
+  write("deprecated-clash", {
+    id: "deprecated-clash",
+    city_code: "DUB",
+    author: "someone",
+    deprecation: { since: "2026-08-17T00:00:00.000Z", by_github_id: 1, reason: "test" },
+  });
+  write("live-clash", { id: "live-clash", city_code: "MAR", author: "other" });
+  writeFileSync(
+    join(repoRoot, "maps", "index.json"),
+    JSON.stringify({ maps: ["deprecated-clash", "live-clash"] }),
+    "utf-8",
+  );
+
+  const collisions = findListingCollisions(repoRoot, new Set(["DUB", "MAR"]));
+  assert.deepEqual(collisions, [
+    { listing_id: "live-clash", city_code: "MAR", author: "other" },
+  ]);
+});
+
 test("loadVanillaCityCodeSet degrades to the floor when the synced file is absent or malformed", () => {
   const missingRoot = mkdtempSync(join(tmpdir(), "vanilla-codes-missing-"));
   assert.deepEqual([...loadVanillaCityCodeSet(missingRoot)].sort(), [...VANILLA_CITY_CODE_SET].sort());


### PR DESCRIPTION
Dublin's conflict issue (#7680) was closed by hand after the map was deprecated — a deprecated map is uninstallable regardless, so the collision isn't actionable. Without this fix the closure actually backfires: the sync's dedup only checks **open** issues for the marker, so the next 4-hourly run would have re-filed a fresh dublin conflict issue.

`findListingCollisions` now skips any manifest carrying a `deprecation` field. Consequences:
- No new conflict issues for deprecated maps, and any still-open issue for a newly deprecated map auto-closes on the next run ("no longer detects this conflict").
- Undeprecation with the conflict intact re-files a fresh issue on the next sync — correct, since the listing is installable again.
- Deleted listings need no handling: they drop out of `maps/index.json`.

Unit test added (deprecated collision skipped, live collision still reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)