### PR TITLE
fix(ci): never fail issue workflows on the cosmetic comment reaction

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -66,12 +66,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Parse issue body
         id: parser
@@ -239,12 +244,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Parse issue body
         id: parser
@@ -412,12 +422,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Parse issue body
         id: parser

--- a/.github/workflows/process-data-quality.yml
+++ b/.github/workflows/process-data-quality.yml
@@ -80,12 +80,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Parse issue body
         id: parser
@@ -105,7 +110,7 @@ jobs:
         # checking out the whole branch broke on "Missing script".
         id: target
         env:
-          MAP_ID: ${{ fromJson(steps.parser.outputs.jsonString).map-id }}
+          MAP_ID: ${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }}
         run: |
           set -euo pipefail
           if [ ! -f "maps/${MAP_ID}/manifest.json" ] \
@@ -126,7 +131,7 @@ jobs:
       - name: Commit and push to publish branch
         if: steps.target.outputs.mode == 'publish'
         env:
-          MAP_ID: ${{ fromJson(steps.parser.outputs.jsonString).map-id }}
+          MAP_ID: ${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -155,7 +160,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const branch = 'publish/map/${{ fromJson(steps.parser.outputs.jsonString).map-id }}';
+            const branch = 'publish/map/${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }}';
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -199,10 +204,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "dq/${{ fromJson(steps.parser.outputs.jsonString).map-id }}"
+          git checkout -B "dq/${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }}"
           git add maps/
-          git commit -m "chore(data-quality): answers for ${{ fromJson(steps.parser.outputs.jsonString).map-id }} (self-reported)"
-          git push --force origin "dq/${{ fromJson(steps.parser.outputs.jsonString).map-id }}"
+          git commit -m "chore(data-quality): answers for ${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }} (self-reported)"
+          git push --force origin "dq/${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }}"
 
       - name: Create or update pull request
         if: steps.target.outputs.mode != 'publish'
@@ -210,7 +215,7 @@ jobs:
         with:
           github-token: ${{ steps.bot-token.outputs.token || github.token }}
           script: |
-            const branch = 'dq/${{ fromJson(steps.parser.outputs.jsonString).map-id }}';
+            const branch = 'dq/${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }}';
             const { data: existing } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -224,11 +229,11 @@ jobs:
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'chore(data-quality): answers for `${{ fromJson(steps.parser.outputs.jsonString).map-id }}`',
+              title: 'chore(data-quality): answers for `${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }}`',
               body: [
                 'Fixes #${{ github.event.issue.number }}',
                 '',
-                'Automated PR carrying self-reported data-quality answers for `${{ fromJson(steps.parser.outputs.jsonString).map-id }}`.',
+                'Automated PR carrying self-reported data-quality answers for `${{ fromJson(steps.parser.outputs.jsonString || '{}').map-id }}`.',
                 '',
                 'Submitted by @${{ github.event.issue.user.login }}',
                 '',

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,12 +80,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Detect maintainer overrides
         id: overrides
@@ -331,12 +336,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Detect maintainer overrides
         id: overrides

--- a/.github/workflows/rescore-data.yml
+++ b/.github/workflows/rescore-data.yml
@@ -36,12 +36,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: "eyes",
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: "eyes",
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Mint bot token
         id: bot-token

--- a/.github/workflows/update-author.yml
+++ b/.github/workflows/update-author.yml
@@ -46,12 +46,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Parse issue body
         id: parser

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -57,12 +57,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Parse issue body
         id: parser
@@ -230,12 +235,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+            // Cosmetic ack; a deleted or edited trigger comment must never fail the run.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } catch (error) {
+              core.warning(`Could not react to the trigger comment: ${error.message}`);
+            }
 
       - name: Parse issue body
         id: parser


### PR DESCRIPTION
Fixes the failure pierreggt reported on the reunion data-quality submission ([run 32285872368](https://github.com/Subway-Builder-Modded/registry/actions/runs/32285872368)): the "Acknowledge revalidation" 👀 reaction 404'd — the triggering comment was deleted or edited between trigger and run — and the unhandled error failed the whole job. The skipped downstream steps then surfaced the confusing secondary errors he quoted (`fromJson` on the never-populated parser output: "Error reading JToken from JsonReader"). His diagnosis of the cascade was exactly right; the reunion submission itself recovered via subsequent issue-edit runs and its answers are on PR #8388.

Two hardenings:
- **All 10 `reactions.createForIssueComment` sites across 6 issue workflows** (deprecate, process-data-quality, publish, rescore-data, update-author, update-metadata) wrapped in try/catch — the ack is cosmetic and must never fail a run.
- **All 9 `fromJson(steps.parser.outputs.jsonString)` templates** in process-data-quality.yml default to `'{}'` so a failed-before-parse job skips cleanly instead of erroring on template evaluation.

All six YAMLs re-validated with the `yaml` parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)