### PR TITLE
review: backfill data-quality for the six pack-migrated FR maps (reunion set)

### DIFF
--- a/maps/lille/data-quality.json
+++ b/maps/lille/data-quality.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "lille",
+  "answers": {
+    "workplace_count": "physical_measured",
+    "workplace_granularity": "adm3",
+    "workplace_resolution": "mesh_250",
+    "workplace_intensity": "size_only",
+    "resident_count": "total_population",
+    "resident_granularity": "mesh_250",
+    "resident_resolution": "mesh_250",
+    "resident_intensity": "measured_per_unit",
+    "od_metric": "full_matrix",
+    "od_granularity": "adm3"
+  },
+  "notes": "Backfilled by the maintainer from the reviewed reunion answer set: the author migrated this listing to the France pack repo (update merged 2026-08) and declared it runs the identical Filosofi+MOBPRO pipeline (MOBPRO 2021 place-of-work job totals per commune; Filosofi 2021 200m resident grid, nothing to place; full commune-to-commune O/D matrix; within-commune job placement resident-weighted onto 200m cells, scored mesh_250 x size_only per the reunion ruling). A map-update with revised answers supersedes this if the pipeline diverges.",
+  "sources": [
+    "INSEE Filosofi 2021 (200m population grid)",
+    "INSEE MOBPRO 2021 (commune-to-commune home-to-work flows, place of work)"
+  ],
+  "provenance": {
+    "method": "backfill",
+    "submitted_by": "ahkimn",
+    "reviewed_by": "ahkimn",
+    "date": "2026-08-23"
+  }
+}

--- a/maps/lille/manifest.json
+++ b/maps/lille/manifest.json
@@ -141,7 +141,10 @@
   },
   "last_updated": 1787356800,
   "data_quality": {
-    "tier": "unknown",
-    "rubric_version": 1
+    "tier": "medium",
+    "raw_score": 0.29,
+    "weighted_score": 0.52,
+    "rubric_version": 1,
+    "provenance": "backfill"
   }
 }

--- a/maps/lyon/data-quality.json
+++ b/maps/lyon/data-quality.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "lyon",
+  "answers": {
+    "workplace_count": "physical_measured",
+    "workplace_granularity": "adm3",
+    "workplace_resolution": "mesh_250",
+    "workplace_intensity": "size_only",
+    "resident_count": "total_population",
+    "resident_granularity": "mesh_250",
+    "resident_resolution": "mesh_250",
+    "resident_intensity": "measured_per_unit",
+    "od_metric": "full_matrix",
+    "od_granularity": "adm3"
+  },
+  "notes": "Backfilled by the maintainer from the reviewed reunion answer set: the author migrated this listing to the France pack repo (update merged 2026-08) and declared it runs the identical Filosofi+MOBPRO pipeline (MOBPRO 2021 place-of-work job totals per commune; Filosofi 2021 200m resident grid, nothing to place; full commune-to-commune O/D matrix; within-commune job placement resident-weighted onto 200m cells, scored mesh_250 x size_only per the reunion ruling). A map-update with revised answers supersedes this if the pipeline diverges.",
+  "sources": [
+    "INSEE Filosofi 2021 (200m population grid)",
+    "INSEE MOBPRO 2021 (commune-to-commune home-to-work flows, place of work)"
+  ],
+  "provenance": {
+    "method": "backfill",
+    "submitted_by": "ahkimn",
+    "reviewed_by": "ahkimn",
+    "date": "2026-08-23"
+  }
+}

--- a/maps/lyon/manifest.json
+++ b/maps/lyon/manifest.json
@@ -150,7 +150,10 @@
   },
   "last_updated": 1787356800,
   "data_quality": {
-    "tier": "unknown",
-    "rubric_version": 1
+    "tier": "medium",
+    "raw_score": 0.29,
+    "weighted_score": 0.52,
+    "rubric_version": 1,
+    "provenance": "backfill"
   }
 }

--- a/maps/marseille/data-quality.json
+++ b/maps/marseille/data-quality.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "marseille",
+  "answers": {
+    "workplace_count": "physical_measured",
+    "workplace_granularity": "adm3",
+    "workplace_resolution": "mesh_250",
+    "workplace_intensity": "size_only",
+    "resident_count": "total_population",
+    "resident_granularity": "mesh_250",
+    "resident_resolution": "mesh_250",
+    "resident_intensity": "measured_per_unit",
+    "od_metric": "full_matrix",
+    "od_granularity": "adm3"
+  },
+  "notes": "Backfilled by the maintainer from the reviewed reunion answer set: the author migrated this listing to the France pack repo (update merged 2026-08) and declared it runs the identical Filosofi+MOBPRO pipeline (MOBPRO 2021 place-of-work job totals per commune; Filosofi 2021 200m resident grid, nothing to place; full commune-to-commune O/D matrix; within-commune job placement resident-weighted onto 200m cells, scored mesh_250 x size_only per the reunion ruling). A map-update with revised answers supersedes this if the pipeline diverges.",
+  "sources": [
+    "INSEE Filosofi 2021 (200m population grid)",
+    "INSEE MOBPRO 2021 (commune-to-commune home-to-work flows, place of work)"
+  ],
+  "provenance": {
+    "method": "backfill",
+    "submitted_by": "ahkimn",
+    "reviewed_by": "ahkimn",
+    "date": "2026-08-23"
+  }
+}

--- a/maps/marseille/manifest.json
+++ b/maps/marseille/manifest.json
@@ -153,7 +153,10 @@
   },
   "last_updated": 1787356800,
   "data_quality": {
-    "tier": "unknown",
-    "rubric_version": 1
+    "tier": "medium",
+    "raw_score": 0.29,
+    "weighted_score": 0.52,
+    "rubric_version": 1,
+    "provenance": "backfill"
   }
 }

--- a/maps/nantes/data-quality.json
+++ b/maps/nantes/data-quality.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "nantes",
+  "answers": {
+    "workplace_count": "physical_measured",
+    "workplace_granularity": "adm3",
+    "workplace_resolution": "mesh_250",
+    "workplace_intensity": "size_only",
+    "resident_count": "total_population",
+    "resident_granularity": "mesh_250",
+    "resident_resolution": "mesh_250",
+    "resident_intensity": "measured_per_unit",
+    "od_metric": "full_matrix",
+    "od_granularity": "adm3"
+  },
+  "notes": "Backfilled by the maintainer from the reviewed reunion answer set: the author migrated this listing to the France pack repo (update merged 2026-08) and declared it runs the identical Filosofi+MOBPRO pipeline (MOBPRO 2021 place-of-work job totals per commune; Filosofi 2021 200m resident grid, nothing to place; full commune-to-commune O/D matrix; within-commune job placement resident-weighted onto 200m cells, scored mesh_250 x size_only per the reunion ruling). A map-update with revised answers supersedes this if the pipeline diverges.",
+  "sources": [
+    "INSEE Filosofi 2021 (200m population grid)",
+    "INSEE MOBPRO 2021 (commune-to-commune home-to-work flows, place of work)"
+  ],
+  "provenance": {
+    "method": "backfill",
+    "submitted_by": "ahkimn",
+    "reviewed_by": "ahkimn",
+    "date": "2026-08-23"
+  }
+}

--- a/maps/nantes/manifest.json
+++ b/maps/nantes/manifest.json
@@ -146,7 +146,10 @@
   },
   "last_updated": 1784576709,
   "data_quality": {
-    "tier": "unknown",
-    "rubric_version": 1
+    "tier": "medium",
+    "raw_score": 0.29,
+    "weighted_score": 0.52,
+    "rubric_version": 1,
+    "provenance": "backfill"
   }
 }

--- a/maps/rennes/data-quality.json
+++ b/maps/rennes/data-quality.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "rennes",
+  "answers": {
+    "workplace_count": "physical_measured",
+    "workplace_granularity": "adm3",
+    "workplace_resolution": "mesh_250",
+    "workplace_intensity": "size_only",
+    "resident_count": "total_population",
+    "resident_granularity": "mesh_250",
+    "resident_resolution": "mesh_250",
+    "resident_intensity": "measured_per_unit",
+    "od_metric": "full_matrix",
+    "od_granularity": "adm3"
+  },
+  "notes": "Backfilled by the maintainer from the reviewed reunion answer set: the author migrated this listing to the France pack repo (update merged 2026-08) and declared it runs the identical Filosofi+MOBPRO pipeline (MOBPRO 2021 place-of-work job totals per commune; Filosofi 2021 200m resident grid, nothing to place; full commune-to-commune O/D matrix; within-commune job placement resident-weighted onto 200m cells, scored mesh_250 x size_only per the reunion ruling). A map-update with revised answers supersedes this if the pipeline diverges.",
+  "sources": [
+    "INSEE Filosofi 2021 (200m population grid)",
+    "INSEE MOBPRO 2021 (commune-to-commune home-to-work flows, place of work)"
+  ],
+  "provenance": {
+    "method": "backfill",
+    "submitted_by": "ahkimn",
+    "reviewed_by": "ahkimn",
+    "date": "2026-08-23"
+  }
+}

--- a/maps/rennes/manifest.json
+++ b/maps/rennes/manifest.json
@@ -146,7 +146,10 @@
   },
   "last_updated": 1784576735,
   "data_quality": {
-    "tier": "unknown",
-    "rubric_version": 1
+    "tier": "medium",
+    "raw_score": 0.29,
+    "weighted_score": 0.52,
+    "rubric_version": 1,
+    "provenance": "backfill"
   }
 }

--- a/maps/toulouse/data-quality.json
+++ b/maps/toulouse/data-quality.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "toulouse",
+  "answers": {
+    "workplace_count": "physical_measured",
+    "workplace_granularity": "adm3",
+    "workplace_resolution": "mesh_250",
+    "workplace_intensity": "size_only",
+    "resident_count": "total_population",
+    "resident_granularity": "mesh_250",
+    "resident_resolution": "mesh_250",
+    "resident_intensity": "measured_per_unit",
+    "od_metric": "full_matrix",
+    "od_granularity": "adm3"
+  },
+  "notes": "Backfilled by the maintainer from the reviewed reunion answer set: the author migrated this listing to the France pack repo (update merged 2026-08) and declared it runs the identical Filosofi+MOBPRO pipeline (MOBPRO 2021 place-of-work job totals per commune; Filosofi 2021 200m resident grid, nothing to place; full commune-to-commune O/D matrix; within-commune job placement resident-weighted onto 200m cells, scored mesh_250 x size_only per the reunion ruling). A map-update with revised answers supersedes this if the pipeline diverges.",
+  "sources": [
+    "INSEE Filosofi 2021 (200m population grid)",
+    "INSEE MOBPRO 2021 (commune-to-commune home-to-work flows, place of work)"
+  ],
+  "provenance": {
+    "method": "backfill",
+    "submitted_by": "ahkimn",
+    "reviewed_by": "ahkimn",
+    "date": "2026-08-23"
+  }
+}

--- a/maps/toulouse/manifest.json
+++ b/maps/toulouse/manifest.json
@@ -154,7 +154,10 @@
   },
   "last_updated": 1784468332,
   "data_quality": {
-    "tier": "unknown",
-    "rubric_version": 1
+    "tier": "medium",
+    "raw_score": 0.29,
+    "weighted_score": 0.52,
+    "rubric_version": 1,
+    "provenance": "backfill"
   }
 }


### PR DESCRIPTION
lille, lyon, marseille, nantes, rennes, and toulouse were migrated to the France pack repo (update PRs merged this month) and per the author run the identical Filosofi+MOBPRO pipeline as the reviewed reunion listing. This backfills their previously-absent `data-quality.json` with the reunion answer set (mesh_250 × size_only workplace placement per the reunion ruling; full commune O/D; Filosofi 200 m residents). Expected: **medium (0.52)** each, matching reunion.

`rescore_data` to follow on this PR. paris-ile-de-france is deliberately excluded — its V2 update declares an upgraded SIRENE-based placement and gets its own triage. bordeaux/nice/strasbourg are also excluded (not yet migrated to the pack pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)