### PR TITLE
docs: multi-nation maps score at the floor across covered nations

### DIFF
--- a/docs/data-quality-questions.md
+++ b/docs/data-quality-questions.md
@@ -67,6 +67,16 @@ uses, with examples:
 - **Grid ("mesh") data** means the office publishes a value for every square in a uniform grid laid
   over the country, regardless of admin boundaries.
 
+### Rule 3 — Cross-border maps: answer for the weakest country
+
+If your map spans a national border, answer every question for the **country with the weakest
+data**, whatever its share of the map — reviewers score multi-nation maps at the floor across the
+covered nations (see the
+[rubric](https://github.com/Subway-Builder-Modded/registry/blob/main/docs/data-quality.md#multi-nation-maps)).
+Describe each country's sources separately in Methodology so the per-country quality is auditable.
+One exception worth claiming: real cross-border commute statistics count in the flows question
+even when one side's internal flows are estimated.
+
 ---
 
 ## Workplace data

--- a/docs/data-quality.md
+++ b/docs/data-quality.md
@@ -73,6 +73,17 @@ Granularity scores the grain at which a count's **magnitude** is measured — no
    - No independent finer signal (a coarse total spread by geometry alone) => score the **coarse** grain.
 3. **When it remains ambiguous, take the middle and record the bounds** so the call is auditable. _Example:_ Mexico's workplace magnitude is measurable at varying granularities: ~ADM2 (municipal) as a floor, with some industry counts available at ~ADM3/4 level. In addition, the establishment directory carries real employee-size bands at address level (ADM5). Within the rubric, it is thus scored at **~ADM4**, between the coarser ADM2 (total-only resolution floor) and the finer ADM5 (treat the establishments as measured units).
 
+### Multi-nation maps
+
+A map spanning national borders draws each pillar from more than one statistical system, and those systems rarely match in quality. **Each scored factor takes the floor across the nations covered** — the weakest count anchor, the coarsest measured grain, the weakest placement — regardless of each nation's population share. The tier is a single promise about the whole map: on its weaker side the map behaves like the weaker pipeline, and a blended or best-side score would overstate exactly the areas a player cannot distinguish.
+
+Two refinements:
+
+- **O/D is scored on what actually constrains the flows.** Real cross-border commuter series (e.g. the Swiss OFS frontalier statistics, by department/Landkreis of residence and canton of work) that bound a border map's defining flows can earn the structured-marginals rung even when one nation's internal flows are synthetic — the weak side's gravity model is why the pillar is not scored higher, not a reason to zero it.
+- **Record the per-nation bounds in the review notes** (same spirit as rule 3 above), so the discount is auditable and a data upgrade on the weak side can be re-scored without re-deriving the strong side.
+
+_Worked examples (2026-08): grand-geneve — the French MOBPRO commune-grain workplace side floors the Swiss 100 m STATENT side (medium); eurodistrict-bale — Germany's ratio-estimated employment totals floor two fully measured nations (low); pays-basque — the Spanish estimated-jobs side floors a full French Filosofi+MOBPRO pipeline (absent, floor exception recorded)._
+
 ## **3. Dasymetric**
 
 A **dasymetric** distributes a count in space _below_ the grain at which it is measured ([Granularity](#2-granularity)). It is shared by the Workplace and Resident pillars — scored identically for both — as the product of two independent factors:


### PR DESCRIPTION
Codifies the reviewer rule applied to the first three cross-border confirmations (grand-genève medium 0.48, eurodistrict-bâle low 0.35, pays-basque absent 0.15):

- **Rubric** (`docs/data-quality.md`, new "Multi-nation maps" subsection under §2): each scored factor takes the floor across the covered nations regardless of population share — the tier is a single promise about the whole map. Refinements: real cross-border commuter series can still earn the O/D structured-marginals rung even when one nation's internal flows are synthetic, and per-nation bounds are recorded in review notes so a weak-side data upgrade can be re-scored without re-deriving the strong side. The three worked examples are cited.
- **Authors' guide** (`docs/data-quality-questions.md`, new Grounding Rule 3): answer every question for the weakest country and describe each country's sources separately — with the cross-border-flows exception spelled out (pierreggt already did exactly this on pays-basque, unprompted).

Companion monorepo PR mirrors both onto the website docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)