### PR TITLE
fix(analytics): eliminate V8 argument-limit stack overflows on giant maps

### DIFF
--- a/scripts/lib/map-basemap.ts
+++ b/scripts/lib/map-basemap.ts
@@ -526,7 +526,8 @@ async function fetchRoadsFromOverpass(
     for (const quadrant of quadrants) {
       const result = await fetchRoadsFromOverpass(quadrant, options, depth + 1);
       selectedEndpoint = result.overpassUrl;
-      mergedRoads.push(...result.roads);
+      // Loop, not push(...roads): a metro quadrant's road list can exceed V8's argument limit.
+      for (const road of result.roads) mergedRoads.push(road);
     }
 
     const filteredRoads = dedupeRoads(mergedRoads).filter((road) => INCLUDED_ROAD_CLASSES.has(road.roadClass));

--- a/scripts/lib/map-playable-area.ts
+++ b/scripts/lib/map-playable-area.ts
@@ -103,11 +103,20 @@ function projectLocations(
     yKm: location.latitude * latScaleKm,
   }));
 
+  // Reduce, not Math.min(...spread): spreading exceeds V8's argument limit
+  // (~65k) on large maps — paris V2's ~144k demand points overflowed the stack.
+  let originXKm = Infinity;
+  let originYKm = Infinity;
+  for (const point of points) {
+    if (point.xKm < originXKm) originXKm = point.xKm;
+    if (point.yKm < originYKm) originYKm = point.yKm;
+  }
+
   return {
     points,
     projection: {
-      originXKm: Math.min(...points.map((point) => point.xKm)),
-      originYKm: Math.min(...points.map((point) => point.yKm)),
+      originXKm,
+      originYKm,
       lonScaleKm,
       latScaleKm,
     },

--- a/scripts/lib/map-polycentrism.ts
+++ b/scripts/lib/map-polycentrism.ts
@@ -291,7 +291,8 @@ function getNeighborIndexes(
     for (let dy = -cellRadius; dy <= cellRadius; dy += 1) {
       const bucket = index.get(`${cellX + dx}:${cellY + dy}`);
       if (!bucket) continue;
-      neighborIndexes.push(...bucket);
+      // Loop, not push(...bucket): a dense bucket can exceed V8's argument limit.
+      for (const bucketIndex of bucket) neighborIndexes.push(bucketIndex);
     }
   }
   return neighborIndexes;

--- a/scripts/tests/map-playable-area.unit.test.ts
+++ b/scripts/tests/map-playable-area.unit.test.ts
@@ -82,3 +82,15 @@ test("computePlayableAreaDebugGeoJson exposes the final playable raster cells as
     && feature.properties?.cellSizeKm === 1
   )));
 });
+
+test("computePlayableAreaMetrics survives point counts beyond V8's argument limit", () => {
+  // paris V2 (~144k demand points) overflowed the former Math.min(...spread)
+  // projection-origin computation; 150k synthetic points lock the regression.
+  const locations = Array.from({ length: 150_000 }, (_, i) => ({
+    longitude: kmToLongitudeDegrees((i % 400) * 0.1),
+    latitude: kmToLatitudeDegrees(Math.floor(i / 400) * 0.1),
+  }));
+  const metrics = computePlayableAreaMetrics(locations);
+  assert.ok(Number.isFinite(metrics.playableAreaKm2), "metrics computed without stack overflow");
+  assert.ok(metrics.playableAreaKm2 > 0, "non-degenerate area");
+});


### PR DESCRIPTION
The paris-ile-de-france V2 update run ([32600141271](https://github.com/Subway-Builder-Modded/registry/actions/runs/32600141271)) died with `Maximum call stack size exceeded` in `generateGrid` after fully processing all 35,416 grid cells — and this failure is the last thing keeping the French city-code loop incident open, since the stuck update is what leaves old clients looping on the retired-code v1.0.0 asset (~28/day still).

**Root cause**: `computePlayableAreaMetrics` computed projection origins with `Math.min(...points.map(...))` — spreading every demand point as a function argument. V8's argument limit is ~65k; paris V2 carries ~144k points (every previous map was smaller, so it never fired). Replaced with a reduce loop.

Same defensive fix applied to the only other data-sized spread sites in the pipeline: `map-polycentrism.ts` neighbor-bucket accumulation and `map-basemap.ts` road merging (a metro quadrant's road list can also exceed the limit). Bounded spreads (error lists, API pages) left as-is.

Regression test locks it with 150k synthetic points. 477/477 on a fresh `.test-dist`.

After merge: `revalidate` on #8770 re-runs the paris update with the fix; once it lands, the paris loop stops and the incident can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)